### PR TITLE
Tharga.MongoDB.Mcp — MCP provider for MongoDB monitoring and admin

### DIFF
--- a/.claude/features-planned/27-mcp-action-parity.md
+++ b/.claude/features-planned/27-mcp-action-parity.md
@@ -1,0 +1,36 @@
+# Feature: MCP action parity with Blazor components
+
+## Source
+Follow-up from MCP Phase 2 (Tharga.MongoDB.Mcp) — the first release shipped 2 tools (touch, rebuild_index). Blazor components expose more collection-level actions that AI agents should also be able to trigger via MCP.
+
+## Goal
+Add MCP tools for the remaining collection and call-level actions so an AI agent can do everything the Blazor admin UI can do — except streaming (Ongoing calls, Queue live gauge) and interactive multi-step dialogs.
+
+## Scope
+
+### New tools
+| Tool | Maps to | Args |
+|---|---|---|
+| `mongodb.drop_index` | `IDatabaseMonitor.DropIndexAsync` | configurationName?, databaseName, collectionName |
+| `mongodb.clean` | `IDatabaseMonitor.CleanAsync` | configurationName?, databaseName, collectionName, cleanGuids |
+| `mongodb.find_duplicates` | `IDatabaseMonitor.GetIndexBlockersAsync` | configurationName?, databaseName, collectionName, indexName |
+| `mongodb.explain` | `IDatabaseMonitor.GetExplainAsync` | callKey |
+| `mongodb.reset_cache` | `IDatabaseMonitor.ResetAsync` | (none) |
+| `mongodb.clear_call_history` | `IDatabaseMonitor.ResetCalls` | (none) |
+
+### New resource (optional)
+- `mongodb://calls/{callKey}` — per-call detail with filter JSON and steps
+
+## Out of scope (explicitly deferred)
+- Live streaming (Ongoing calls, Queue live metrics) — MCP `resources/subscribe` support and polling semantics are better suited to non-MCP channels
+- Interactive multi-step dialogs (confirm clean, view duplicates inline before deciding to drop) — MCP tools return once; multi-step UX is an agent-scripting concern
+
+## Acceptance Criteria
+- [ ] All 6 new tools implemented in `MongoDbToolProvider`
+- [ ] All tools delegate to `IDatabaseMonitor` (so remote collections route through existing `IRemoteActionDispatcher`)
+- [ ] Error responses (`IsError = true`) when a collection or call is missing, or when no agent is connected for a remote collection
+- [ ] Tests cover each new tool
+- [ ] README MCP section updated
+
+## Done Condition
+An AI agent can inspect and manage MongoDB collections end-to-end via MCP with the same capabilities as the Blazor admin UI (excluding live streaming).

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
   "permissions": {
     "allow": [
       "Bash(cd *)",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,7 @@ jobs:
           dotnet pack Tharga.MongoDB.Blazor/Tharga.MongoDB.Blazor.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.version.outputs.version }}
           dotnet pack Tharga.MongoDB.Monitor.Client/Tharga.MongoDB.Monitor.Client.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.version.outputs.version }}
           dotnet pack Tharga.MongoDB.Monitor.Server/Tharga.MongoDB.Monitor.Server.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.version.outputs.version }}
+          dotnet pack Tharga.MongoDB.Mcp/Tharga.MongoDB.Mcp.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.version.outputs.version }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -615,6 +615,34 @@ app.MapGet("/api/monitor/pool", (IDatabaseMonitor m) => m.GetConnectionPoolState
 
 ---
 
+## MCP (Model Context Protocol)
+
+The `Tharga.MongoDB.Mcp` package exposes MongoDB monitoring data and admin actions via MCP, so AI agents can query collections, inspect monitoring data, and trigger actions.
+
+Install `Tharga.MongoDB.Mcp` and register inside the `AddThargaMcp` callback:
+
+```csharp
+services.AddThargaMcp(mcp =>
+{
+    mcp.AddMongoDB();
+});
+
+app.MapMcp();
+```
+
+### Resources (System scope)
+- `mongodb://collections` — list of collections with stats, index info, and clean status
+- `mongodb://monitoring` — recent and slow calls, summaries, error summary, connection pool state
+- `mongodb://clients` — connected remote monitoring agents
+
+### Tools (System scope)
+- `mongodb.touch` — refresh collection stats (args: `databaseName`, `collectionName`, optional `configurationName`)
+- `mongodb.rebuild_index` — restore/rebuild indexes (args: `databaseName`, `collectionName`, optional `configurationName`, `force`)
+
+Provides are registered with `McpScope.System`, so they are only exposed on the system-level MCP endpoint.
+
+---
+
 ## Aggregation Queries
 
 Server-side aggregation methods let you compute values without loading documents into memory.

--- a/Sample/Tharga.TemplateBlazor.Web/Program.cs
+++ b/Sample/Tharga.TemplateBlazor.Web/Program.cs
@@ -3,6 +3,8 @@ using Radzen;
 using Tharga.Blazor.Framework;
 using Tharga.MongoDB;
 using Tharga.MongoDB.Configuration;
+using Tharga.Mcp;
+using Tharga.MongoDB.Mcp;
 using Tharga.MongoDB.Monitor.Server;
 using Tharga.TemplateBlazor.Web.Components;
 using Tharga.TemplateBlazor.Web.Framework;
@@ -35,6 +37,12 @@ builder.AddMongoDB(o =>
 });
 
 builder.AddMongoDbMonitorServer();
+
+builder.Services.AddThargaMcp(mcp =>
+{
+    mcp.Options.RequireAuth = false;
+    mcp.AddMongoDB();
+});
 
 builder.Services.AddCors(options =>
 {
@@ -72,6 +80,8 @@ app.MapRazorComponents<App>()
 
 app.UseMongoDB();
 app.UseMongoDbMonitorServer();
+
+app.MapMcp();
 
 app.MapGet("/api/monitor/clients", async (MonitorClientStateService svc) =>
 {

--- a/Sample/Tharga.TemplateBlazor.Web/Tharga.TemplateBlazor.Web.csproj
+++ b/Sample/Tharga.TemplateBlazor.Web/Tharga.TemplateBlazor.Web.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Tharga.TemplateBlazor.Web.Client\Tharga.TemplateBlazor.Web.Client.csproj" />
     <ProjectReference Include="..\..\Tharga.MongoDB.Monitor.Server\Tharga.MongoDB.Monitor.Server.csproj" />
+    <ProjectReference Include="..\..\Tharga.MongoDB.Mcp\Tharga.MongoDB.Mcp.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.6" />
   </ItemGroup>
 

--- a/Tharga.MongoDB.Mcp/MongoDbResourceProvider.cs
+++ b/Tharga.MongoDB.Mcp/MongoDbResourceProvider.cs
@@ -1,0 +1,158 @@
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using Tharga.Mcp;
+
+namespace Tharga.MongoDB.Mcp;
+
+/// <summary>
+/// Exposes Tharga.MongoDB monitoring data as MCP resources on the System scope.
+/// </summary>
+public sealed class MongoDbResourceProvider : IMcpResourceProvider
+{
+    private const string CollectionsUri = "mongodb://collections";
+    private const string MonitoringUri = "mongodb://monitoring";
+    private const string ClientsUri = "mongodb://clients";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+    };
+
+    private readonly IDatabaseMonitor _monitor;
+
+    public MongoDbResourceProvider(IDatabaseMonitor monitor)
+    {
+        _monitor = monitor;
+    }
+
+    public McpScope Scope => McpScope.System;
+
+    public Task<IReadOnlyList<McpResourceDescriptor>> ListResourcesAsync(IMcpContext context, CancellationToken cancellationToken)
+    {
+        IReadOnlyList<McpResourceDescriptor> resources =
+        [
+            new McpResourceDescriptor
+            {
+                Uri = CollectionsUri,
+                Name = "MongoDB Collections",
+                Description = "List of monitored collections with stats, index info, and clean status.",
+                MimeType = "application/json",
+            },
+            new McpResourceDescriptor
+            {
+                Uri = MonitoringUri,
+                Name = "MongoDB Monitoring",
+                Description = "Recent calls, call summary (by collection+function), error summary, and slow-call index coverage.",
+                MimeType = "application/json",
+            },
+            new McpResourceDescriptor
+            {
+                Uri = ClientsUri,
+                Name = "MongoDB Monitor Clients",
+                Description = "Connected remote monitoring agents and their connection state.",
+                MimeType = "application/json",
+            },
+        ];
+        return Task.FromResult(resources);
+    }
+
+    public async Task<McpResourceContent> ReadResourceAsync(string uri, IMcpContext context, CancellationToken cancellationToken)
+    {
+        return uri switch
+        {
+            CollectionsUri => await BuildCollectionsAsync(cancellationToken),
+            MonitoringUri => await BuildMonitoringAsync(cancellationToken),
+            ClientsUri => BuildClients(),
+            _ => new McpResourceContent { Uri = uri, Text = $"Unknown resource: {uri}" },
+        };
+    }
+
+    private async Task<McpResourceContent> BuildCollectionsAsync(CancellationToken cancellationToken)
+    {
+        var items = new List<object>();
+        await foreach (var info in _monitor.GetInstancesAsync().WithCancellation(cancellationToken))
+        {
+            items.Add(new
+            {
+                configurationName = info.ConfigurationName.Value,
+                databaseName = info.DatabaseName,
+                collectionName = info.CollectionName,
+                server = info.Server,
+                registration = info.Registration.ToString(),
+                discovery = info.Discovery.ToString(),
+                entityTypes = info.EntityTypes,
+                isLocal = info.CollectionType != null,
+                stats = info.Stats == null ? null : new
+                {
+                    documentCount = info.Stats.DocumentCount,
+                    size = info.Stats.Size,
+                    updatedAt = info.Stats.UpdatedAt,
+                },
+                index = info.Index == null ? null : new
+                {
+                    current = info.Index.Current?.Length ?? 0,
+                    defined = info.Index.Defined?.Length ?? 0,
+                    updatedAt = info.Index.UpdatedAt,
+                },
+                clean = info.Clean == null ? null : new
+                {
+                    documentsCleaned = info.Clean.DocumentsCleaned,
+                    cleanedAt = info.Clean.CleanedAt,
+                },
+            });
+        }
+
+        return new McpResourceContent
+        {
+            Uri = CollectionsUri,
+            MimeType = "application/json",
+            Text = JsonSerializer.Serialize(new { collections = items }, JsonOptions),
+        };
+    }
+
+    private async Task<McpResourceContent> BuildMonitoringAsync(CancellationToken cancellationToken)
+    {
+        var recentCalls = _monitor.GetCallDtos(CallType.Last).Take(50).ToArray();
+        var slowCalls = _monitor.GetCallDtos(CallType.Slow).Take(50).ToArray();
+        var callSummary = _monitor.GetCallSummary().ToArray();
+        var errorSummary = _monitor.GetErrorSummary().ToArray();
+
+        var slowWithIndex = new List<SlowCallWithIndexInfoDto>();
+        await foreach (var item in _monitor.GetSlowCallsWithIndexInfoAsync().WithCancellation(cancellationToken))
+        {
+            slowWithIndex.Add(item);
+            if (slowWithIndex.Count >= 50) break;
+        }
+
+        var payload = new
+        {
+            recentCalls,
+            slowCalls,
+            callSummary,
+            errorSummary,
+            slowCallsWithIndex = slowWithIndex,
+            connectionPool = _monitor.GetConnectionPoolState(),
+        };
+
+        return new McpResourceContent
+        {
+            Uri = MonitoringUri,
+            MimeType = "application/json",
+            Text = JsonSerializer.Serialize(payload, JsonOptions),
+        };
+    }
+
+    private McpResourceContent BuildClients()
+    {
+        var clients = _monitor.GetMonitorClients().ToArray();
+        return new McpResourceContent
+        {
+            Uri = ClientsUri,
+            MimeType = "application/json",
+            Text = JsonSerializer.Serialize(new { clients }, JsonOptions),
+        };
+    }
+}

--- a/Tharga.MongoDB.Mcp/MongoDbToolProvider.cs
+++ b/Tharga.MongoDB.Mcp/MongoDbToolProvider.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Tharga.Mcp;
+
+namespace Tharga.MongoDB.Mcp;
+
+/// <summary>
+/// Exposes Tharga.MongoDB actions as MCP tools on the System scope.
+/// </summary>
+public sealed class MongoDbToolProvider : IMcpToolProvider
+{
+    private const string TouchToolName = "mongodb.touch";
+    private const string RebuildIndexToolName = "mongodb.rebuild_index";
+
+    private static readonly JsonElement CollectionArgSchema = JsonSerializer.Deserialize<JsonElement>("""
+        {
+          "type": "object",
+          "properties": {
+            "configurationName": { "type": "string" },
+            "databaseName": { "type": "string" },
+            "collectionName": { "type": "string" }
+          },
+          "required": ["databaseName", "collectionName"]
+        }
+        """);
+
+    private static readonly JsonElement RebuildIndexArgSchema = JsonSerializer.Deserialize<JsonElement>("""
+        {
+          "type": "object",
+          "properties": {
+            "configurationName": { "type": "string" },
+            "databaseName": { "type": "string" },
+            "collectionName": { "type": "string" },
+            "force": { "type": "boolean" }
+          },
+          "required": ["databaseName", "collectionName"]
+        }
+        """);
+
+    private readonly IDatabaseMonitor _monitor;
+
+    public MongoDbToolProvider(IDatabaseMonitor monitor)
+    {
+        _monitor = monitor;
+    }
+
+    public McpScope Scope => McpScope.System;
+
+    public Task<IReadOnlyList<McpToolDescriptor>> ListToolsAsync(IMcpContext context, CancellationToken cancellationToken)
+    {
+        IReadOnlyList<McpToolDescriptor> tools =
+        [
+            new McpToolDescriptor
+            {
+                Name = TouchToolName,
+                Description = "Refresh collection stats (document count, size, indexes) from MongoDB.",
+                InputSchema = CollectionArgSchema,
+            },
+            new McpToolDescriptor
+            {
+                Name = RebuildIndexToolName,
+                Description = "Restore or rebuild indexes for a collection according to its defined index model.",
+                InputSchema = RebuildIndexArgSchema,
+            },
+        ];
+        return Task.FromResult(tools);
+    }
+
+    public async Task<McpToolResult> CallToolAsync(string toolName, JsonElement arguments, IMcpContext context, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return toolName switch
+            {
+                TouchToolName => await TouchAsync(arguments, cancellationToken),
+                RebuildIndexToolName => await RebuildIndexAsync(arguments, cancellationToken),
+                _ => Error($"Unknown tool: {toolName}"),
+            };
+        }
+        catch (Exception e)
+        {
+            return Error(e.Message);
+        }
+    }
+
+    private async Task<McpToolResult> TouchAsync(JsonElement arguments, CancellationToken cancellationToken)
+    {
+        var collection = await FindCollectionAsync(arguments, cancellationToken);
+        if (collection == null) return Error("Collection not found.");
+
+        await _monitor.TouchAsync(collection);
+
+        var refreshed = await _monitor.GetInstanceAsync(collection);
+        return Ok(new
+        {
+            touched = true,
+            collection = collection.CollectionName,
+            stats = refreshed?.Stats,
+        });
+    }
+
+    private async Task<McpToolResult> RebuildIndexAsync(JsonElement arguments, CancellationToken cancellationToken)
+    {
+        var collection = await FindCollectionAsync(arguments, cancellationToken);
+        if (collection == null) return Error("Collection not found.");
+
+        var force = arguments.TryGetProperty("force", out var f) && f.ValueKind == JsonValueKind.True;
+        await _monitor.RestoreIndexAsync(collection, force);
+
+        return Ok(new
+        {
+            rebuilt = true,
+            collection = collection.CollectionName,
+            force,
+        });
+    }
+
+    private async Task<CollectionInfo> FindCollectionAsync(JsonElement arguments, CancellationToken cancellationToken)
+    {
+        var configurationName = arguments.TryGetProperty("configurationName", out var c) ? c.GetString() : null;
+        var databaseName = arguments.GetProperty("databaseName").GetString();
+        var collectionName = arguments.GetProperty("collectionName").GetString();
+
+        return await _monitor.GetInstancesAsync()
+            .FirstOrDefaultAsync(
+                x => (configurationName == null || x.ConfigurationName.Value == configurationName)
+                    && x.DatabaseName == databaseName
+                    && x.CollectionName == collectionName,
+                cancellationToken);
+    }
+
+    private static McpToolResult Ok(object payload)
+    {
+        return new McpToolResult
+        {
+            Content = [new McpContent { Type = "text", Text = JsonSerializer.Serialize(payload) }],
+        };
+    }
+
+    private static McpToolResult Error(string message)
+    {
+        return new McpToolResult
+        {
+            IsError = true,
+            Content = [new McpContent { Type = "text", Text = message }],
+        };
+    }
+}

--- a/Tharga.MongoDB.Mcp/Tharga.MongoDB.Mcp.csproj
+++ b/Tharga.MongoDB.Mcp/Tharga.MongoDB.Mcp.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <Version>1.0.0</Version>
+    <Authors>Daniel Bohlin</Authors>
+    <Company>Thargelion AB</Company>
+    <Product>Tharga MongoDB MCP</Product>
+    <Description>Exposes Tharga.MongoDB monitoring data (collections, calls, clients) and actions (touch, rebuild index) via MCP (Model Context Protocol). Plugs into Tharga.Mcp.</Description>
+    <PackageIconUrl>https://thargelion.se/wp-content/uploads/2025/11/Thargelion-DB-Icon-150.png</PackageIconUrl>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <PackageProjectUrl>https://github.com/Tharga/MongoDB</PackageProjectUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <IncludeSource>true</IncludeSource>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+    <EnableSourceLink>true</EnableSourceLink>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <NoWarn>1701;1702;CS1591;CS0809</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Tharga.Mcp" Version="0.1.*" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.202">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Tharga.MongoDB\Tharga.MongoDB.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Tharga.MongoDB.Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+  </ItemGroup>
+
+</Project>

--- a/Tharga.MongoDB.Mcp/Tharga.MongoDB.Mcp.csproj
+++ b/Tharga.MongoDB.Mcp/Tharga.MongoDB.Mcp.csproj
@@ -24,7 +24,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Tharga.Mcp" Version="0.1.*" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.202">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -33,6 +32,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Tharga.MongoDB\Tharga.MongoDB.csproj" />
+    <ProjectReference Include="..\..\Mcp\Tharga.Mcp\Tharga.Mcp.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tharga.MongoDB.Mcp/Tharga.MongoDB.Mcp.csproj
+++ b/Tharga.MongoDB.Mcp/Tharga.MongoDB.Mcp.csproj
@@ -24,6 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Tharga.Mcp" Version="0.1.*" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.202">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -32,7 +33,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Tharga.MongoDB\Tharga.MongoDB.csproj" />
-    <ProjectReference Include="..\..\Mcp\Tharga.Mcp\Tharga.Mcp.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tharga.MongoDB.Mcp/ThargaMcpBuilderExtensions.cs
+++ b/Tharga.MongoDB.Mcp/ThargaMcpBuilderExtensions.cs
@@ -1,0 +1,20 @@
+using Tharga.Mcp;
+
+namespace Tharga.MongoDB.Mcp;
+
+/// <summary>
+/// Extension methods for <see cref="IThargaMcpBuilder"/> that register Tharga.MongoDB MCP providers.
+/// </summary>
+public static class ThargaMcpBuilderExtensions
+{
+    /// <summary>
+    /// Registers <see cref="MongoDbResourceProvider"/> and <see cref="MongoDbToolProvider"/>, exposing
+    /// MongoDB collection data, monitoring data, and admin tools on the System scope.
+    /// </summary>
+    public static IThargaMcpBuilder AddMongoDB(this IThargaMcpBuilder builder)
+    {
+        builder.AddResourceProvider<MongoDbResourceProvider>();
+        builder.AddToolProvider<MongoDbToolProvider>();
+        return builder;
+    }
+}

--- a/Tharga.MongoDB.Tests/McpProviderTests.cs
+++ b/Tharga.MongoDB.Tests/McpProviderTests.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using Tharga.Mcp;
+using Tharga.MongoDB.Configuration;
+using Tharga.MongoDB.Mcp;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests;
+
+public class McpProviderTests
+{
+    private readonly Mock<IDatabaseMonitor> _monitorMock;
+    private readonly Mock<IMcpContext> _contextMock;
+
+    public McpProviderTests()
+    {
+        _monitorMock = new Mock<IDatabaseMonitor>();
+        _contextMock = new Mock<IMcpContext>();
+        _contextMock.Setup(c => c.Scope).Returns(McpScope.System);
+        _contextMock.Setup(c => c.IsDeveloper).Returns(true);
+    }
+
+    // ---------- Resource provider ----------
+
+    [Fact]
+    public void ResourceProvider_Scope_IsSystem()
+    {
+        var provider = new MongoDbResourceProvider(_monitorMock.Object);
+        provider.Scope.Should().Be(McpScope.System);
+    }
+
+    [Fact]
+    public async Task ResourceProvider_ListResources_ReturnsExpected()
+    {
+        var provider = new MongoDbResourceProvider(_monitorMock.Object);
+
+        var resources = await provider.ListResourcesAsync(_contextMock.Object, CancellationToken.None);
+
+        resources.Should().HaveCount(3);
+        resources.Select(r => r.Uri).Should().Contain([
+            "mongodb://collections",
+            "mongodb://monitoring",
+            "mongodb://clients",
+        ]);
+    }
+
+    [Fact]
+    public async Task ResourceProvider_ReadCollections_ReturnsJson()
+    {
+        _monitorMock.Setup(m => m.GetInstancesAsync(false, null))
+            .Returns(EmptyAsyncEnumerable<CollectionInfo>());
+
+        var provider = new MongoDbResourceProvider(_monitorMock.Object);
+        var content = await provider.ReadResourceAsync("mongodb://collections", _contextMock.Object, CancellationToken.None);
+
+        content.Uri.Should().Be("mongodb://collections");
+        content.MimeType.Should().Be("application/json");
+        var doc = JsonDocument.Parse(content.Text);
+        doc.RootElement.GetProperty("collections").GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ResourceProvider_ReadMonitoring_ReturnsJson()
+    {
+        _monitorMock.Setup(m => m.GetCallDtos(It.IsAny<CallType>())).Returns(Array.Empty<CallDto>());
+        _monitorMock.Setup(m => m.GetCallSummary()).Returns(Array.Empty<CallSummaryDto>());
+        _monitorMock.Setup(m => m.GetErrorSummary()).Returns(Array.Empty<ErrorSummaryDto>());
+        _monitorMock.Setup(m => m.GetSlowCallsWithIndexInfoAsync()).Returns(EmptyAsyncEnumerable<SlowCallWithIndexInfoDto>());
+        _monitorMock.Setup(m => m.GetConnectionPoolState()).Returns(new ConnectionPoolStateDto
+        {
+            QueueCount = 0,
+            ExecutingCount = 0,
+            LastWaitTimeMs = 0,
+            RecentMetrics = [],
+        });
+
+        var provider = new MongoDbResourceProvider(_monitorMock.Object);
+        var content = await provider.ReadResourceAsync("mongodb://monitoring", _contextMock.Object, CancellationToken.None);
+
+        content.Uri.Should().Be("mongodb://monitoring");
+        var doc = JsonDocument.Parse(content.Text);
+        doc.RootElement.TryGetProperty("recentCalls", out _).Should().BeTrue();
+        doc.RootElement.TryGetProperty("slowCalls", out _).Should().BeTrue();
+        doc.RootElement.TryGetProperty("callSummary", out _).Should().BeTrue();
+        doc.RootElement.TryGetProperty("errorSummary", out _).Should().BeTrue();
+        doc.RootElement.TryGetProperty("connectionPool", out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ResourceProvider_ReadClients_ReturnsJson()
+    {
+        _monitorMock.Setup(m => m.GetMonitorClients()).Returns(Array.Empty<MonitorClientDto>());
+
+        var provider = new MongoDbResourceProvider(_monitorMock.Object);
+        var content = await provider.ReadResourceAsync("mongodb://clients", _contextMock.Object, CancellationToken.None);
+
+        content.Uri.Should().Be("mongodb://clients");
+        var doc = JsonDocument.Parse(content.Text);
+        doc.RootElement.GetProperty("clients").GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ResourceProvider_ReadUnknownUri_ReturnsText()
+    {
+        var provider = new MongoDbResourceProvider(_monitorMock.Object);
+        var content = await provider.ReadResourceAsync("mongodb://does-not-exist", _contextMock.Object, CancellationToken.None);
+
+        content.Text.Should().Contain("Unknown resource");
+    }
+
+    // ---------- Tool provider ----------
+
+    [Fact]
+    public void ToolProvider_Scope_IsSystem()
+    {
+        var provider = new MongoDbToolProvider(_monitorMock.Object);
+        provider.Scope.Should().Be(McpScope.System);
+    }
+
+    [Fact]
+    public async Task ToolProvider_ListTools_ReturnsExpected()
+    {
+        var provider = new MongoDbToolProvider(_monitorMock.Object);
+        var tools = await provider.ListToolsAsync(_contextMock.Object, CancellationToken.None);
+
+        tools.Should().HaveCount(2);
+        tools.Select(t => t.Name).Should().Contain(["mongodb.touch", "mongodb.rebuild_index"]);
+        tools.Should().AllSatisfy(t => t.InputSchema.Should().NotBeNull());
+    }
+
+    [Fact]
+    public async Task ToolProvider_Touch_CollectionNotFound_ReturnsError()
+    {
+        _monitorMock.Setup(m => m.GetInstancesAsync(false, null))
+            .Returns(EmptyAsyncEnumerable<CollectionInfo>());
+
+        var provider = new MongoDbToolProvider(_monitorMock.Object);
+        var args = JsonDocument.Parse("""{"databaseName":"test","collectionName":"missing"}""").RootElement;
+
+        var result = await provider.CallToolAsync("mongodb.touch", args, _contextMock.Object, CancellationToken.None);
+
+        result.IsError.Should().BeTrue();
+        result.Content.Should().HaveCount(1);
+        result.Content[0].Text.Should().Contain("not found");
+    }
+
+    [Fact]
+    public async Task ToolProvider_Touch_CallsMonitorTouchAsync()
+    {
+        var collection = CreateCollectionInfo("test", "users");
+        _monitorMock.Setup(m => m.GetInstancesAsync(false, null))
+            .Returns(AsyncEnumerable(collection));
+        _monitorMock.Setup(m => m.TouchAsync(It.IsAny<CollectionInfo>()))
+            .Returns(Task.CompletedTask);
+        _monitorMock.Setup(m => m.GetInstanceAsync(It.IsAny<CollectionFingerprint>()))
+            .ReturnsAsync(collection);
+
+        var provider = new MongoDbToolProvider(_monitorMock.Object);
+        var args = JsonDocument.Parse("""{"databaseName":"test","collectionName":"users"}""").RootElement;
+
+        var result = await provider.CallToolAsync("mongodb.touch", args, _contextMock.Object, CancellationToken.None);
+
+        result.IsError.Should().BeFalse();
+        _monitorMock.Verify(m => m.TouchAsync(It.Is<CollectionInfo>(c => c.CollectionName == "users")), Times.Once);
+    }
+
+    [Fact]
+    public async Task ToolProvider_RebuildIndex_CallsRestoreIndexAsync_WithForceFalse()
+    {
+        var collection = CreateCollectionInfo("test", "users");
+        _monitorMock.Setup(m => m.GetInstancesAsync(false, null))
+            .Returns(AsyncEnumerable(collection));
+        _monitorMock.Setup(m => m.RestoreIndexAsync(It.IsAny<CollectionInfo>(), It.IsAny<bool>()))
+            .Returns(Task.CompletedTask);
+
+        var provider = new MongoDbToolProvider(_monitorMock.Object);
+        var args = JsonDocument.Parse("""{"databaseName":"test","collectionName":"users"}""").RootElement;
+
+        var result = await provider.CallToolAsync("mongodb.rebuild_index", args, _contextMock.Object, CancellationToken.None);
+
+        result.IsError.Should().BeFalse();
+        _monitorMock.Verify(m => m.RestoreIndexAsync(It.IsAny<CollectionInfo>(), false), Times.Once);
+    }
+
+    [Fact]
+    public async Task ToolProvider_RebuildIndex_WithForceTrue_ForwardsFlag()
+    {
+        var collection = CreateCollectionInfo("test", "users");
+        _monitorMock.Setup(m => m.GetInstancesAsync(false, null))
+            .Returns(AsyncEnumerable(collection));
+        _monitorMock.Setup(m => m.RestoreIndexAsync(It.IsAny<CollectionInfo>(), It.IsAny<bool>()))
+            .Returns(Task.CompletedTask);
+
+        var provider = new MongoDbToolProvider(_monitorMock.Object);
+        var args = JsonDocument.Parse("""{"databaseName":"test","collectionName":"users","force":true}""").RootElement;
+
+        await provider.CallToolAsync("mongodb.rebuild_index", args, _contextMock.Object, CancellationToken.None);
+
+        _monitorMock.Verify(m => m.RestoreIndexAsync(It.IsAny<CollectionInfo>(), true), Times.Once);
+    }
+
+    [Fact]
+    public async Task ToolProvider_UnknownTool_ReturnsError()
+    {
+        var provider = new MongoDbToolProvider(_monitorMock.Object);
+        var args = JsonDocument.Parse("""{}""").RootElement;
+
+        var result = await provider.CallToolAsync("mongodb.nope", args, _contextMock.Object, CancellationToken.None);
+
+        result.IsError.Should().BeTrue();
+        result.Content[0].Text.Should().Contain("Unknown tool");
+    }
+
+    // ---------- Helpers ----------
+
+    private static CollectionInfo CreateCollectionInfo(string databaseName, string collectionName)
+    {
+        return new CollectionInfo
+        {
+            ConfigurationName = "Default",
+            DatabaseName = databaseName,
+            CollectionName = collectionName,
+            Server = "localhost:27017",
+            Discovery = Discovery.Database,
+            Registration = Registration.Static,
+            EntityTypes = [],
+            CollectionType = typeof(McpProviderTests),
+        };
+    }
+
+    private static async IAsyncEnumerable<T> EmptyAsyncEnumerable<T>()
+    {
+        await Task.CompletedTask;
+        yield break;
+    }
+
+    private static async IAsyncEnumerable<T> AsyncEnumerable<T>(params T[] items)
+    {
+        await Task.CompletedTask;
+        foreach (var item in items) yield return item;
+    }
+}

--- a/Tharga.MongoDB.Tests/Tharga.MongoDB.Tests.csproj
+++ b/Tharga.MongoDB.Tests/Tharga.MongoDB.Tests.csproj
@@ -34,6 +34,7 @@
 	  <ProjectReference Include="..\Tharga.MongoDB\Tharga.MongoDB.csproj" />
 	  <ProjectReference Include="..\Tharga.MongoDB.Monitor.Client\Tharga.MongoDB.Monitor.Client.csproj" />
 	  <ProjectReference Include="..\Tharga.MongoDB.Monitor.Server\Tharga.MongoDB.Monitor.Server.csproj" />
+	  <ProjectReference Include="..\Tharga.MongoDB.Mcp\Tharga.MongoDB.Mcp.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/Tharga.MongoDB.sln
+++ b/Tharga.MongoDB.sln
@@ -33,6 +33,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tharga.MongoDB.Monitor.Clie
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tharga.MongoDB.Monitor.Server", "Tharga.MongoDB.Monitor.Server\Tharga.MongoDB.Monitor.Server.csproj", "{50948D00-6127-4372-AB6D-DE2BDF188F73}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tharga.MongoDB.Mcp", "Tharga.MongoDB.Mcp\Tharga.MongoDB.Mcp.csproj", "{A8771451-C2A1-4497-AF29-D9459ECD155C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -163,6 +165,18 @@ Global
 		{50948D00-6127-4372-AB6D-DE2BDF188F73}.Release|x64.Build.0 = Release|Any CPU
 		{50948D00-6127-4372-AB6D-DE2BDF188F73}.Release|x86.ActiveCfg = Release|Any CPU
 		{50948D00-6127-4372-AB6D-DE2BDF188F73}.Release|x86.Build.0 = Release|Any CPU
+		{A8771451-C2A1-4497-AF29-D9459ECD155C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A8771451-C2A1-4497-AF29-D9459ECD155C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A8771451-C2A1-4497-AF29-D9459ECD155C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A8771451-C2A1-4497-AF29-D9459ECD155C}.Debug|x64.Build.0 = Debug|Any CPU
+		{A8771451-C2A1-4497-AF29-D9459ECD155C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A8771451-C2A1-4497-AF29-D9459ECD155C}.Debug|x86.Build.0 = Debug|Any CPU
+		{A8771451-C2A1-4497-AF29-D9459ECD155C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A8771451-C2A1-4497-AF29-D9459ECD155C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A8771451-C2A1-4497-AF29-D9459ECD155C}.Release|x64.ActiveCfg = Release|Any CPU
+		{A8771451-C2A1-4497-AF29-D9459ECD155C}.Release|x64.Build.0 = Release|Any CPU
+		{A8771451-C2A1-4497-AF29-D9459ECD155C}.Release|x86.ActiveCfg = Release|Any CPU
+		{A8771451-C2A1-4497-AF29-D9459ECD155C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/plan/feature.md
+++ b/plan/feature.md
@@ -1,0 +1,39 @@
+# Feature: Tharga.MongoDB.Mcp
+
+## Originating Branch
+develop
+
+## Goal
+Expose MongoDB monitoring data via MCP (Model Context Protocol) so AI agents can query collections, monitoring, and connected clients, plus trigger touch/rebuild actions.
+
+## Source
+- MCP master plan Phase 2 (`c:\Users\danie\SynologyDrive\Documents\Notes\Tharga\plans\Mcp\plan.md`)
+- Pending request in `Requests.md` from all products
+
+## Scope
+- New project `Tharga.MongoDB.Mcp` (new NuGet package)
+- References `Tharga.Mcp` (foundation) and `Tharga.MongoDB` (monitoring data source)
+- Provides `AddMcpMongoDB()` extension on `IThargaMcpBuilder`
+- All data/actions scoped to `McpScope.System` (infrastructure, not team-specific)
+
+## Resources to expose
+- `mongodb.collections` — list of collections with status, index info, document count
+- `mongodb.monitoring` — recent calls, latency, slow queries
+- `mongodb.clients` — connected monitor agents (for distributed monitoring)
+
+## Tools to expose
+- `mongodb.touch` — refresh collection stats
+- `mongodb.rebuild_index` — restore/rebuild indexes
+
+## Acceptance Criteria
+- [ ] `Tharga.MongoDB.Mcp` package builds
+- [ ] `AddMcpMongoDB()` extension registers provider(s)
+- [ ] Resources return current data from `IDatabaseMonitor`
+- [ ] Tools execute via `IDatabaseMonitor.TouchAsync` / `RestoreIndexAsync`
+- [ ] All exposed on System scope
+- [ ] CI/CD pipeline packs the new package
+- [ ] Tests cover providers
+- [ ] README documents usage
+
+## Done Condition
+An AI agent can list collections, see slow queries, and trigger rebuilds via MCP — with full audit trail (when Platform.Mcp is registered).

--- a/plan/plan.md
+++ b/plan/plan.md
@@ -1,0 +1,37 @@
+# Plan: Tharga.MongoDB.Mcp
+
+## Steps
+
+### Step 1: Create Tharga.MongoDB.Mcp project
+- [x] Create `Tharga.MongoDB.Mcp` project with net8/9/10 targets
+- [x] Reference `Tharga.Mcp` and `Tharga.MongoDB`
+- [x] Add to solution
+- [x] Build and verify
+
+### Step 2: Implement resource provider
+- [x] Create `MongoDbResourceProvider` implementing `IMcpResourceProvider`
+- [x] Scope: `McpScope.System`
+- [x] Resources: `mongodb://collections`, `mongodb://monitoring`, `mongodb://clients`
+- [x] Each resource reads from `IDatabaseMonitor`
+- [x] Build and verify
+
+### Step 3: Implement tool provider
+- [x] Create `MongoDbToolProvider` implementing `IMcpToolProvider`
+- [x] Scope: `McpScope.System`
+- [x] Tools: `mongodb.touch`, `mongodb.rebuild_index`
+- [x] Build and verify
+
+### Step 4: Add registration extension
+- [x] `AddMongoDB()` extension on `IThargaMcpBuilder`
+- [x] Registers resource and tool providers
+- [x] Build and verify
+
+### Step 5: Update CI/CD and tests
+- [x] Add `Tharga.MongoDB.Mcp` to pack step in GitHub Actions workflow
+- [x] Write tests (13 tests — resource list, resource read, tool list, tool execution)
+- [x] Build and run tests (274 passed total)
+
+### Step 6: README and commit
+- [x] Update README with MCP section
+- [x] Final build and test
+- [ ] Commit all changes


### PR DESCRIPTION
## Summary

Implements **Phase 2 of the MCP master plan**: a new `Tharga.MongoDB.Mcp` NuGet package that exposes Tharga.MongoDB monitoring data and admin actions via MCP (Model Context Protocol).

## What's new

**New package `Tharga.MongoDB.Mcp`** (depends on `Tharga.Mcp 0.1.1`):

- **Resources** (System scope):
  - `mongodb://collections` — list of collections with stats, indexes, clean status
  - `mongodb://monitoring` — recent/slow calls, summaries, error summary, connection pool state
  - `mongodb://clients` — connected remote monitoring agents

- **Tools** (System scope):
  - `mongodb.touch` — refresh collection stats
  - `mongodb.rebuild_index` — restore/rebuild indexes

- **Registration**: `services.AddThargaMcp(mcp => mcp.AddMongoDB())`

**Sample wiring** in `Tharga.TemplateBlazor.Web` — MCP endpoint at `/mcp` with `AddMongoDB()` registered.

**CI/CD** updated to pack the new package alongside the existing 4.

## Verified end-to-end

Ran the sample locally, connected via MCP Streamable HTTP, and confirmed:
- All 3 resources list correctly
- `mongodb://collections` returned 4 local collections + 1 remote collection (`SampleEntity` from a ConsoleSample agent) with document counts, sizes, index info, clean status
- `mongodb://clients` returned the connected agent (`NEPTUNUS/ConsoleSample`) with source name

## Tests

13 new unit tests (274 total passing), covering resource listing, resource reads, tool listing, tool execution, and error paths.

## Follow-up

Feature `#27 — MCP action parity with Blazor components` is already planned to add the remaining tools (drop_index, clean, find_duplicates, explain, reset_cache, clear_call_history).

## Test plan
- [ ] CI build passes (4 packages + new `Tharga.MongoDB.Mcp`)
- [ ] Package installs cleanly in a consumer app
- [ ] MCP client (Inspector or Claude Code) can list and read resources
- [ ] MCP client can invoke touch and rebuild_index tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)