### PR TITLE
NuGet READMEs for all 5 publishable packages

### DIFF
--- a/Tharga.MongoDB.Blazor/README.md
+++ b/Tharga.MongoDB.Blazor/README.md
@@ -1,4 +1,56 @@
-﻿# Tharga MongoDB Blazor
-Manage Tharga.MongoDB features on a Blazor web.
+# Tharga.MongoDB.Blazor
+
+Drop-in Blazor admin UI for [`Tharga.MongoDB`](https://www.nuget.org/packages/Tharga.MongoDB). Renders the live monitoring data already captured by the core package — collections, calls, indexes, queue metrics, connected clients — as Razor components you can host on any admin page in your app.
+
+## Install
+
+```
+dotnet add package Tharga.MongoDB.Blazor
+```
+
+The components depend on the data flowing through `Tharga.MongoDB`'s `IDatabaseMonitor`, so you need that package registered as well:
+
+```csharp
+builder.AddMongoDB();
+```
+
+Then drop the components onto a Blazor page — they auto-discover the monitor via DI:
+
+```razor
+@page "/database"
+
+<RadzenCard Style="margin-bottom: 6px;">
+    <Tharga.MongoDB.Blazor.MonitorToolbar />
+</RadzenCard>
+
+<RadzenTabs>
+    <Tabs>
+        <RadzenTabsItem Text="Collections">
+            <Tharga.MongoDB.Blazor.CollectionView />
+        </RadzenTabsItem>
+        <RadzenTabsItem Text="Calls">
+            <Tharga.MongoDB.Blazor.CallView />
+        </RadzenTabsItem>
+        <RadzenTabsItem Text="Clients">
+            <Tharga.MongoDB.Blazor.ClientsView />
+        </RadzenTabsItem>
+    </Tabs>
+</RadzenTabs>
+```
+
+## Components
+
+- **`<MonitorToolbar />`** — top-bar controls: configuration switcher, reset calls, reset cache.
+- **`<CollectionView />`** — table of every registered collection with status, document count, indexes, and per-collection drill-down dialog.
+- **`<CallView />`** — every database call captured by the monitor, with filter, sort, explain plan, and timing.
+- **`<ClientsView />`** — connected MongoDB clients (driver-side). Useful with `Tharga.MongoDB.Monitor.Server` when aggregating multiple agents.
+- **`<QueueView />`** — execute-limiter queue depth and throughput.
+- **`<ConfigurationsSelector />`** — switch between configured `ConnectionStrings` entries when an app talks to multiple clusters.
+
+The package is built on Radzen.Blazor — the same components and theming as the rest of your Radzen app.
+
+## Documentation
+
+Full docs and configuration reference: [github.com/Tharga/MongoDB](https://github.com/Tharga/MongoDB).
 
 [![GitHub repo](https://img.shields.io/github/repo-size/Tharga/MongoDB?style=flat&logo=github&logoColor=red&label=Repo)](https://github.com/Tharga/MongoDB)

--- a/Tharga.MongoDB.Blazor/Tharga.MongoDB.Blazor.csproj
+++ b/Tharga.MongoDB.Blazor/Tharga.MongoDB.Blazor.csproj
@@ -6,7 +6,7 @@
     <Authors>Daniel Bohlin</Authors>
     <Company>Thargelion AB</Company>
     <Product>Tharga MongoDB Blazor</Product>
-    <Description>Component for manageing the Tharga MongoDB features in blazor.</Description>
+    <Description>Drop-in Blazor admin UI for Tharga.MongoDB — Razor components that render the live monitoring data (collections, calls, indexes, queue metrics, connected clients) on any admin page.</Description>
     <PackageIconUrl>https://thargelion.se/wp-content/uploads/2025/11/Thargelion-DB-Icon-150.png</PackageIconUrl>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Tharga.MongoDB.Mcp/README.md
+++ b/Tharga.MongoDB.Mcp/README.md
@@ -1,0 +1,52 @@
+# Tharga.MongoDB.Mcp
+
+Exposes [`Tharga.MongoDB`](https://www.nuget.org/packages/Tharga.MongoDB) monitoring data and admin actions over [MCP (Model Context Protocol)](https://modelcontextprotocol.io). Plugs into [`Tharga.Mcp`](https://www.nuget.org/packages/Tharga.Mcp) so that Claude, Cursor, and other MCP clients can inspect collections, diagnose slow queries, rebuild indexes, and (optionally) read or modify documents — without SSH'ing to a prod box for `mongosh`.
+
+## Install
+
+```
+dotnet add package Tharga.MongoDB.Mcp
+```
+
+```csharp
+builder.Services.AddThargaMcp(mcp => mcp.AddMongoDB());
+app.UseThargaMcp();
+```
+
+By default only **metadata** is exposed. Opt in to data tools explicitly:
+
+```csharp
+builder.Services.AddThargaMcp(mcp => mcp.AddMongoDB(o =>
+{
+    o.DataAccess = DataAccessLevel.DataRead;       // adds get_document, list_documents, find_duplicates, explain
+    // o.DataAccess = DataAccessLevel.DataReadWrite; // also adds clean
+}));
+```
+
+The provider is registered on the `System` MCP scope, so it only surfaces to system-level callers (e.g. an admin API key) — not to per-team users.
+
+## What's exposed
+
+**Resources**
+- `mongodb://collections` — every registered collection with status, indexes, document count
+- `mongodb://monitoring` — recent calls, slow queries, latency
+- `mongodb://clients` — connected MongoDB driver clients
+
+**Tools (Metadata level — default)**
+- `mongodb.touch` — initialise a collection (assure indexes, etc.)
+- `mongodb.rebuild_index` — drop & recreate a named index
+- `mongodb.drop_index`, `mongodb.reset_cache`, `mongodb.clear_call_history`, `mongodb.compare_schema`
+
+**Tools (DataRead)**
+- `mongodb.get_document` — raw BSON-as-JSON for a single document by id (auto-detects ObjectId / Guid / string)
+- `mongodb.list_documents` — paged listing with optional filter and sort
+- `mongodb.find_duplicates`, `mongodb.explain`
+
+**Tools (DataReadWrite)**
+- `mongodb.clean` — apply collection cleaners
+
+## Documentation
+
+Full docs and configuration reference: [github.com/Tharga/MongoDB](https://github.com/Tharga/MongoDB).
+
+[![GitHub repo](https://img.shields.io/github/repo-size/Tharga/MongoDB?style=flat&logo=github&logoColor=red&label=Repo)](https://github.com/Tharga/MongoDB)

--- a/Tharga.MongoDB.Mcp/Tharga.MongoDB.Mcp.csproj
+++ b/Tharga.MongoDB.Mcp/Tharga.MongoDB.Mcp.csproj
@@ -9,6 +9,7 @@
     <Description>Exposes Tharga.MongoDB monitoring data (collections, calls, clients) and actions (touch, rebuild index) via MCP (Model Context Protocol). Plugs into Tharga.Mcp.</Description>
     <PackageIconUrl>https://thargelion.se/wp-content/uploads/2025/11/Thargelion-DB-Icon-150.png</PackageIconUrl>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/Tharga/MongoDB</PackageProjectUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <IncludeSource>true</IncludeSource>
@@ -22,6 +23,13 @@
   <PropertyGroup>
     <NoWarn>1701;1702;CS1591;CS0809</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Tharga.Mcp" Version="0.1.3" />

--- a/Tharga.MongoDB.Monitor.Client/README.md
+++ b/Tharga.MongoDB.Monitor.Client/README.md
@@ -1,0 +1,32 @@
+# Tharga.MongoDB.Monitor.Client
+
+Forwards [`Tharga.MongoDB`](https://www.nuget.org/packages/Tharga.MongoDB) monitoring data — calls, collection info, queue metrics — from a running app (the *agent*) to a central [`Tharga.MongoDB.Monitor.Server`](https://www.nuget.org/packages/Tharga.MongoDB.Monitor.Server) over [Tharga.Communication](https://www.nuget.org/packages/Tharga.Communication) (SignalR-backed). Use this when you want a single dashboard pane covering many MongoDB-talking services without each one shipping its own admin UI.
+
+## Install
+
+```
+dotnet add package Tharga.MongoDB.Monitor.Client
+```
+
+```csharp
+builder.AddMongoDB();                                          // the agent's normal MongoDB usage
+builder.AddMongoDbMonitorClient(
+    sendTo: "https://monitor.example.com/",                    // monitor server URL
+    apiKey: builder.Configuration["MongoMonitor:ApiKey"]);     // optional, must match one of the server's primary/secondary keys
+```
+
+If `sendTo` is null/empty the client is a no-op — convenient for local dev.
+
+## What it sends
+
+- **Calls** — every database operation captured by `IDatabaseMonitor` (filter, sort, latency, exception, explain plan).
+- **Collection info** — registered collections, document counts, index status.
+- **Queue metrics** — execute-limiter depth and throughput.
+
+The agent appears as a connected client on the server side and can be inspected, addressed, and acted upon from there (e.g. "rebuild index on agent X" via remote action delegation).
+
+## Documentation
+
+Full docs, the matching server package, and the centralised-monitoring topology overview: [github.com/Tharga/MongoDB](https://github.com/Tharga/MongoDB).
+
+[![GitHub repo](https://img.shields.io/github/repo-size/Tharga/MongoDB?style=flat&logo=github&logoColor=red&label=Repo)](https://github.com/Tharga/MongoDB)

--- a/Tharga.MongoDB.Monitor.Client/Tharga.MongoDB.Monitor.Client.csproj
+++ b/Tharga.MongoDB.Monitor.Client/Tharga.MongoDB.Monitor.Client.csproj
@@ -9,6 +9,7 @@
     <Description>Forwards MongoDB monitoring data to a central server via Tharga.Communication.</Description>
     <PackageIconUrl>https://thargelion.se/wp-content/uploads/2025/11/Thargelion-DB-Icon-150.png</PackageIconUrl>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/Tharga/MongoDB</PackageProjectUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <IncludeSource>true</IncludeSource>
@@ -24,7 +25,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Tharga.Communication" Version="0.1.4" />
+    <None Include="README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Tharga.Communication" Version="0.1.5" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tharga.MongoDB.Monitor.Server/README.md
+++ b/Tharga.MongoDB.Monitor.Server/README.md
@@ -1,0 +1,35 @@
+# Tharga.MongoDB.Monitor.Server
+
+Receives MongoDB monitoring data from one or more remote agents running [`Tharga.MongoDB.Monitor.Client`](https://www.nuget.org/packages/Tharga.MongoDB.Monitor.Client) and aggregates it into the local `IDatabaseMonitor` — so the host app's [`Tharga.MongoDB.Blazor`](https://www.nuget.org/packages/Tharga.MongoDB.Blazor) admin UI can show calls, collections, and clients across every connected service from a single pane. Built on [Tharga.Communication](https://www.nuget.org/packages/Tharga.Communication) (SignalR-backed).
+
+## Install
+
+```
+dotnet add package Tharga.MongoDB.Monitor.Server
+```
+
+```csharp
+builder.AddMongoDB();                              // local MongoDB usage (and the IDatabaseMonitor everything aggregates into)
+builder.AddMongoDbMonitorServer(
+    primaryApiKey: cfg["MongoMonitor:PrimaryApiKey"],     // optional — when set, agents must match
+    secondaryApiKey: cfg["MongoMonitor:SecondaryApiKey"]); // optional — for zero-downtime key rotation
+
+var app = builder.Build();
+app.UseMongoDbMonitorServer();    // maps the SignalR hub at "/hub" by default
+```
+
+Drop the Blazor admin components onto a page (see [`Tharga.MongoDB.Blazor`](https://www.nuget.org/packages/Tharga.MongoDB.Blazor)) and remote agents show up alongside the local app's own data.
+
+## What it does
+
+- **Receives** call, collection-info, and queue-metric messages from connected agents.
+- **Tracks** each agent's connection state via `MonitorClientStateService` and `MonitorClientRepository` — the admin UI's `<ClientsView />` lists them.
+- **Bridges** agent connections into `IDatabaseMonitor` via `MonitorClientBridge`, so the calls/collections views render remote data alongside local data.
+- **Delegates remote actions** — admin tools can target a specific agent (e.g. *touch this collection on agent X*, *rebuild this index on agent Y*) through `IRemoteActionDispatcher`.
+- **Live monitoring subscriptions** — push live updates to subscribed clients via `ILiveMonitoringSubscription`.
+
+## Documentation
+
+Full docs, the matching client package, and the centralised-monitoring topology overview: [github.com/Tharga/MongoDB](https://github.com/Tharga/MongoDB).
+
+[![GitHub repo](https://img.shields.io/github/repo-size/Tharga/MongoDB?style=flat&logo=github&logoColor=red&label=Repo)](https://github.com/Tharga/MongoDB)

--- a/Tharga.MongoDB.Monitor.Server/Tharga.MongoDB.Monitor.Server.csproj
+++ b/Tharga.MongoDB.Monitor.Server/Tharga.MongoDB.Monitor.Server.csproj
@@ -9,6 +9,7 @@
     <Description>Receives MongoDB monitoring data from remote agents via Tharga.Communication and aggregates it into the local IDatabaseMonitor.</Description>
     <PackageIconUrl>https://thargelion.se/wp-content/uploads/2025/11/Thargelion-DB-Icon-150.png</PackageIconUrl>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/Tharga/MongoDB</PackageProjectUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <IncludeSource>true</IncludeSource>
@@ -24,8 +25,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Tharga.Communication" Version="0.1.4" />
+    <PackageReference Include="Tharga.Communication" Version="0.1.5" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tharga.MongoDB/README.md
+++ b/Tharga.MongoDB/README.md
@@ -1,6 +1,57 @@
-# Tharga MongoDB
-This package is extracted from a product that needs the possibility of dynamic naming of databases and collections.
+# Tharga.MongoDB
 
-It also have some aditional features for Atlas MongoDB like limiting the size of the responses and opening the firewall.
+A MongoDB repository toolkit for .NET 8 / 9 / 10. Adds dynamic database/collection naming, automatic index assurance, document-level locking with commit-on-success semantics, multi-document transactions, keyset pagination, and built-in monitoring of every call (latency, slow queries, cache stats) on top of the official `MongoDB.Driver`.
+
+## Install
+
+```
+dotnet add package Tharga.MongoDB
+```
+
+```csharp
+builder.AddMongoDB();
+```
+
+Configure connection strings in `appsettings.json`:
+
+```json
+"ConnectionStrings": {
+  "Default": "mongodb://localhost:27017/MyApp{Environment}{Part}"
+}
+```
+
+Define an entity and a repository collection — both get auto-registered into DI:
+
+```csharp
+public record Order : EntityBase<ObjectId>
+{
+    public string CustomerName { get; init; }
+    public DateTime CreatedAt { get; init; }
+}
+
+public class OrderCollection : DiskRepositoryCollectionBase<Order, ObjectId>
+{
+    public OrderCollection(IMongoDbServiceFactory factory) : base(factory) { }
+    public override string CollectionName => "orders";
+}
+```
+
+Inject `IRepositoryCollection<Order, ObjectId>` (or your concrete collection) wherever you need it.
+
+## What's in the box
+
+- **Repository pattern** with `Disk` and `Lockable` collection bases. Lockable adds per-document optimistic locks with commit/release/error workflows so you can hand a document to a worker, let it crash, and have the lock auto-recover.
+- **Dynamic database & collection naming** via `DatabaseContext` — multi-tenant URLs like `mongodb://.../{Environment}{Part}` resolve at call time, not at startup.
+- **Automatic index assurance** with rename-safe modes (`ByName`, `BySchema`, `DropCreate`).
+- **Multi-document transactions** via `WithTransactionAsync` — session-aware writes on both Disk and Lockable; lockable leases support transactional commit so the document update and your business writes land atomically.
+- **Keyset pagination** — `GetPageAsync` / `GetPageProjectionAsync` with opaque `CursorToken`. O(log N) per page regardless of depth, no skip penalty. `CursorPager<TEntity, TKey>` adapter for grids that emit `(skip, pageSize)`.
+- **Monitoring** — every call (with filter, sort, explain plan) is captured and exposed via `IDatabaseMonitor` for live dashboards. Slow-query detection, queue metrics, cache stats, and per-collection status.
+- **Result limiter** — hard cap on returned document counts via `ResultLimit` config.
+- **Execute limiter** — auto-sized per connection pool to keep long-running streams from oversubscribing the driver.
+- **Companion packages**: [`Tharga.MongoDB.Blazor`](https://www.nuget.org/packages/Tharga.MongoDB.Blazor) for the admin UI, [`Tharga.MongoDB.Mcp`](https://www.nuget.org/packages/Tharga.MongoDB.Mcp) for MCP/AI integration, [`Tharga.MongoDB.Monitor.Client`](https://www.nuget.org/packages/Tharga.MongoDB.Monitor.Client) + [`.Server`](https://www.nuget.org/packages/Tharga.MongoDB.Monitor.Server) for centralised monitoring across multiple agents.
+
+## Documentation
+
+Full docs, configuration reference, and worked examples for each feature: [github.com/Tharga/MongoDB](https://github.com/Tharga/MongoDB).
 
 [![GitHub repo](https://img.shields.io/github/repo-size/Tharga/MongoDB?style=flat&logo=github&logoColor=red&label=Repo)](https://github.com/Tharga/MongoDB)

--- a/Tharga.MongoDB/Tharga.MongoDB.csproj
+++ b/Tharga.MongoDB/Tharga.MongoDB.csproj
@@ -7,7 +7,7 @@
     <Authors>Daniel Bohlin</Authors>
     <Company>Thargelion AB</Company>
     <Product>Tharga MongoDB</Product>
-    <Description>Dynamic names for databases and collections.</Description>
+    <Description>MongoDB repository toolkit for .NET — dynamic database/collection naming, automatic index assurance, document-level locking, multi-document transactions, keyset pagination, and built-in call monitoring on top of MongoDB.Driver.</Description>
     <PackageIconUrl>https://thargelion.se/wp-content/uploads/2025/11/Thargelion-DB-Icon-150.png</PackageIconUrl>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
## Summary

- Replaces stub READMEs with focused ~30-50 line content on `Tharga.MongoDB` and `Tharga.MongoDB.Blazor`. The old stubs (4 lines and 1 line) shipped to nuget.org and didn't mention any of the package's actual features (lockable docs, transactions, paging, MCP, monitoring UI).
- Adds new READMEs + wires `PackageReadmeFile` for `Tharga.MongoDB.Mcp`, `Tharga.MongoDB.Monitor.Client`, and `Tharga.MongoDB.Monitor.Server`. Their nuget.org pages previously showed only the csproj `<Description>` line.
- Tightens the two weak `<Description>` lines (`Tharga.MongoDB`: "Dynamic names for databases and collections." and `Tharga.MongoDB.Blazor`: typo + vague). The other three already had reasonable descriptions and are unchanged.

Each README has the same shape: tagline, install snippet, registration code, "what's in the box" feature list, link to the GitHub repo for full docs.

## Test plan

- [x] `dotnet pack Tharga.MongoDB.sln -c Release` succeeds for all 5 packages
- [x] `unzip -l <pkg>.nupkg` shows `README.md` at the package root for all 5 packages
- [x] `dotnet build -c Debug` clean across net8/9/10