### PR TITLE
DocFX site for mongodb.tharga.net

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,64 @@
+name: Docs
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'docs/**'
+      - 'Tharga.MongoDB/**.cs'
+      - 'Tharga.MongoDB.Blazor/**.cs'
+      - 'Tharga.MongoDB.Mcp/**.cs'
+      - 'Tharga.MongoDB.Monitor.Client/**.cs'
+      - 'Tharga.MongoDB.Monitor.Server/**.cs'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: Install DocFX
+        run: dotnet tool install -g docfx
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build site
+        run: docfx docs/docfx.json
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,4 @@
+_site/
+api/.manifest
+api/*.yml
+obj/

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+mongodb.tharga.net

--- a/docs/articles/getting-started.md
+++ b/docs/articles/getting-started.md
@@ -1,0 +1,87 @@
+# Getting started
+
+## Install
+
+```
+dotnet add package Tharga.MongoDB
+```
+
+## Register
+
+```csharp
+builder.AddMongoDB();
+```
+
+Or, if you only have access to `IServiceCollection`:
+
+```csharp
+builder.Services.AddMongoDB();
+```
+
+## Configure connection
+
+In `appsettings.json`:
+
+```json
+"ConnectionStrings": {
+  "Default": "mongodb://localhost:27017/MyApp{Environment}{Part}"
+}
+```
+
+The `{Environment}` and `{Part}` placeholders are resolved per call from a `DatabaseContext`, so the same code can talk to multiple tenant databases without re-registering anything in DI.
+
+## Define an entity
+
+```csharp
+public record WeatherForecast : EntityBase
+{
+    public DateOnly Date { get; set; }
+    public int TemperatureC { get; set; }
+    public string Summary { get; set; }
+}
+```
+
+`EntityBase` defaults the key type to `ObjectId`. Use `EntityBase<TKey>` for `Guid`, `string`, `int`, etc.
+
+## Define a collection
+
+```csharp
+public interface IWeatherForecastRepositoryCollection : IDiskRepositoryCollection<WeatherForecast> { }
+
+internal class WeatherForecastRepositoryCollection
+    : DiskRepositoryCollectionBase<WeatherForecast>, IWeatherForecastRepositoryCollection
+{
+    public WeatherForecastRepositoryCollection(IMongoDbServiceFactory factory)
+        : base(factory) { }
+}
+```
+
+The collection is registered in DI automatically — by default `AddMongoDB()` scans assemblies whose name starts with the entry-point assembly's prefix. Add external assemblies via `o.AddAutoRegistrationAssembly(...)`.
+
+## Inject and use it
+
+```csharp
+public class WeatherForecastService
+{
+    private readonly IWeatherForecastRepositoryCollection _collection;
+
+    public WeatherForecastService(IWeatherForecastRepositoryCollection collection)
+    {
+        _collection = collection;
+    }
+
+    public IAsyncEnumerable<WeatherForecast> GetAsync()
+        => _collection.GetAsync();
+
+    public Task AddAsync(WeatherForecast forecast)
+        => _collection.AddAsync(forecast);
+}
+```
+
+## Where next
+
+- **[Lockable collections](lockable-collections.md)** — when you need optimistic per-document locks
+- **[Transactions](transactions.md)** — multi-document atomicity
+- **[Keyset pagination](keyset-pagination.md)** — for grids and large result sets
+- **[Monitoring](monitoring.md)** — see every database call live
+- Full configuration reference, customisation hooks, and Atlas-specific guidance: [README on GitHub](https://github.com/Tharga/MongoDB#readme)

--- a/docs/articles/index.md
+++ b/docs/articles/index.md
@@ -1,0 +1,12 @@
+# Articles
+
+Feature guides for `Tharga.MongoDB`. Skim the [Getting started](getting-started.md) page first if you're new — it gives you a runnable end-to-end example. Otherwise jump to whichever topic matches what you're solving:
+
+- **[Getting started](getting-started.md)** — install, configure, register a collection, the first read/write
+- **[Lockable collections](lockable-collections.md)** — per-document optimistic locking with commit/release/error workflows
+- **[Transactions](transactions.md)** — multi-document atomicity with `WithTransactionAsync` and lockable lease commits
+- **[Keyset pagination](keyset-pagination.md)** — `GetPageAsync` / `CursorPager` for grids that need O(log N) per page
+- **[Monitoring](monitoring.md)** — the `IDatabaseMonitor` surface, slow-query detection, and centralised topologies via `Monitor.Client` / `Monitor.Server`
+- **[MCP integration](mcp-integration.md)** — exposing collections, monitoring, and admin actions to AI clients via `Tharga.MongoDB.Mcp`
+
+Each guide is short — the full reference is in the [API](xref:Tharga.MongoDB) tab.

--- a/docs/articles/keyset-pagination.md
+++ b/docs/articles/keyset-pagination.md
@@ -1,0 +1,121 @@
+# Keyset pagination
+
+`GetPageAsync` and `GetPageProjectionAsync` page through a collection by *cursor*, not by `skip`/`limit`. Cost is O(log N) per page regardless of how deep the page sits — there is no skip penalty when paging into the millions of documents and no spike when a user clicks "jump to last." Single-column sort with a `_id` tiebreaker; total count is intentionally not part of the result and should be fetched separately via `CountAsync(predicate)` (cache it client-side; it changes far less often than the page).
+
+## Basic usage
+
+```csharp
+var first = await collection.GetPageAsync(
+    pageSize: 25,
+    position: PagePosition.First,
+    sortBy: e => e.CreatedAt,
+    ascending: false);
+
+// "Next page" — feed the previous page's LastCursor back in
+var next = await collection.GetPageAsync(
+    pageSize: 25,
+    position: PagePosition.After(first.LastCursor),
+    sortBy: e => e.CreatedAt,
+    ascending: false);
+
+// "Previous page" — feed the current page's FirstCursor in via Before
+var prev = await collection.GetPageAsync(
+    pageSize: 25,
+    position: PagePosition.Before(next.FirstCursor),
+    sortBy: e => e.CreatedAt,
+    ascending: false);
+```
+
+`PagePosition` has four factories:
+
+| Position | Use |
+|---|---|
+| `PagePosition.First` | First page in sort order |
+| `PagePosition.Last` | Final `pageSize` items in sort order (the trailing `pageSize` items, slid to align with the page boundary) |
+| `PagePosition.After(cursor, pageStep = 0)` | Page after the cursor; `pageStep` skips that many extra pages forward |
+| `PagePosition.Before(cursor, pageStep = 0)` | Page before the cursor; `pageStep` skips that many extra pages backward |
+
+`CursorPage<T>` exposes `Items`, `FirstCursor`, `LastCursor`, `HasNext`, `HasPrevious`. The cursors are opaque, URL-safe strings (Base64URL of a small BSON doc) — store them in query strings, hidden form fields, or component state.
+
+## Sort + filter
+
+```csharp
+var page = await collection.GetPageAsync(
+    pageSize: 50,
+    position: PagePosition.After(cursor),
+    predicate: e => e.Status == "active",
+    sortBy: e => e.Name,
+    ascending: true);
+```
+
+Predicates compose with the keyset filter — the page is the items matching `predicate` strictly past `cursor` in the sort order.
+
+## Index guidance
+
+For each `(sortBy, ascending)` you page on, create the compound index `{ sortField: ±1, _id: ±1 }`:
+
+```csharp
+public override IEnumerable<CreateIndexModel<MyEntity>> Indices =>
+[
+    new(Builders<MyEntity>.IndexKeys.Ascending(e => e.CreatedAt).Ascending(e => e.Id),
+        new CreateIndexOptions { Name = "createdAt_id" }),
+];
+```
+
+Without the compound index the query still works but degrades to a sort + scan. With it, the planner uses an `IXSCAN` that walks straight to the cursor boundary and reads only the page-size's worth of documents.
+
+## Total count
+
+```csharp
+var total = await collection.CountAsync(e => e.Status == "active");
+```
+
+`CountAsync` is a separate query because counts are typically far cheaper to cache than pages — once per filter-change, not once per page-flip. Don't bake it into the paging hot path.
+
+## `CursorPager<TEntity, TKey>` — easy path for grids
+
+Most grid components (Radzen `RadzenDataGrid`, MudBlazor `MudDataGrid`, etc.) emit a `(skip, pageSize)` request on user navigation. `CursorPager` adapts that shape to the keyset API: it tracks the previous page's cursors, decodes the skip-delta into the appropriate `PagePosition`, falls back to skip-based `GetManyAsync` when the user does an arbitrary jump (e.g. clicking "page 17 of 200"), and re-issues cursors from the fallback's boundary documents so the next prev/next call resumes the keyset path.
+
+```csharp
+private CursorPager<Order, ObjectId> _pager;
+
+protected override void OnInitialized()
+{
+    _pager = new CursorPager<Order, ObjectId>(_orders);
+}
+
+private async Task LoadDataAsync(LoadDataArgs args)
+{
+    var (items, total) = await _pager.LoadAsync(
+        skip: args.Skip ?? 0,
+        pageSize: args.Top ?? 25,
+        predicate: BuildPredicate(args.Filter),
+        sortBy: o => o.CreatedAt,
+        ascending: false);
+
+    _orders = items;
+    _totalCount = (int)total;
+}
+
+private void OnFilterChanged() => _pager.Reset();
+```
+
+`CursorPager` caches the total count per `(predicate, sortBy, ascending)` cache key — when any of those change it re-runs `CountAsync` and clears the cursors. `Reset()` clears all state (use it when the underlying data is known to have changed underfoot).
+
+## Manual path
+
+When you need full control — e.g. cursor links shared between users, or persistence across sessions — work with `GetPageAsync` directly and stash `FirstCursor`/`LastCursor` wherever fits your application. `CursorToken` round-trips through `ToString()` and `CursorToken.Parse(string)` so it's safe to put in URLs, cookies, or hidden form fields. `CursorToken.From(entity, sortBy, ascending)` lets you mint a cursor pointing at any specific document — useful when restoring grid state from a deep link.
+
+```csharp
+var anchorToken = CursorToken.From<Order, ObjectId>(anchor, o => o.CreatedAt, ascending: false);
+var page = await collection.GetPageAsync(25, PagePosition.After(anchorToken),
+    sortBy: o => o.CreatedAt, ascending: false);
+```
+
+Cursors are sort-bound: passing one issued for `sortBy: x => x.Name` to a call sorting by `x => x.CreatedAt` throws `InvalidOperationException`. This is intentional — silently re-sorting would return wrong results.
+
+## See also
+
+- [API: IRepositoryCollection&lt;TEntity, TKey&gt;](xref:Tharga.MongoDB.IRepositoryCollection`2)
+- [API: CursorToken](xref:Tharga.MongoDB.Paging.CursorToken)
+- [API: CursorPager&lt;TEntity, TKey&gt;](xref:Tharga.MongoDB.Paging.CursorPager`2)

--- a/docs/articles/lockable-collections.md
+++ b/docs/articles/lockable-collections.md
@@ -1,0 +1,78 @@
+# Lockable collections
+
+`ILockableRepositoryCollection<TEntity, TKey>` is a write-protected collection — you can only update or delete documents by first taking an exclusive lock. Useful for queue-like workloads, long-running per-document workflows, and any case where two workers might race on the same record.
+
+The lock is stored on the document itself (entity inherits `LockableEntityBase<TKey>`). It carries an actor name, an expiry timestamp, and an optional error state from a previous failed attempt. Locks auto-recover after expiry, so a crashed worker doesn't leave the document permanently stuck.
+
+## Pick-style — decision known up front
+
+When you already know whether you'll update or delete:
+
+```csharp
+await using var scope = await collection.PickForUpdateAsync(id);
+scope.Entity.Data = "updated";
+await scope.CommitAsync();        // writes the change and clears the lock
+
+await using var del = await collection.PickForDeleteAsync(id);
+await del.CommitAsync();          // deletes the document
+```
+
+Both accept `id`, `FilterDefinition<TEntity>`, or `Expression<Func<TEntity, bool>>` predicate, plus optional `timeout`, `actor`, and `completeAction` callback. Disposal without `CommitAsync` releases the lock unchanged.
+
+## Unified lock — decide at commit time
+
+When you need to inspect the document before deciding:
+
+```csharp
+await using var scope = await collection.LockAsync(id);
+if (ShouldDelete(scope.Entity))
+{
+    await scope.CommitAsync(CommitMode.Delete);
+}
+else
+{
+    var updated = scope.Entity with { Data = "updated" };
+    await scope.CommitAsync(CommitMode.Update, updated);
+}
+```
+
+`AbandonAsync()` releases without changes. `SetErrorStateAsync(ex)` records an exception on the lock so retries can see what failed previously. Disposal without commit calls `AbandonAsync`. Same semantics as `PickFor*` — both go through the same internal acquire-lock primitive.
+
+## Multi-document lease
+
+To inspect several documents and decide each one's fate before committing them all:
+
+```csharp
+await using var lease = await collection.LockManyAsync(new[] { id1, id2, id3 });
+
+foreach (var doc in lease.Documents)
+{
+    if (ShouldDelete(doc))
+        lease.MarkForDelete(doc.Id);
+    else if (HasChanges(doc))
+        lease.MarkForUpdate(doc with { Data = "..." });
+    // else: leave unmarked — released unchanged at commit
+}
+
+var summary = await lease.CommitAsync();
+// summary.Updated / Deleted / ReleasedUnchanged / Failures
+```
+
+Acquisition is sequential, ordered by key — so two leases targeting overlapping sets always acquire in the same order. No AB / BA deadlocks. If any acquisition fails, partial locks are rolled back.
+
+Commit is sequential by default: each marked decision is applied in order, and per-decision failures are collected into `summary.Failures` rather than thrown. For all-or-nothing semantics, pass `transactional: true`:
+
+```csharp
+var summary = await lease.CommitAsync(transactional: true);
+// All decisions land or none do. A single failed decision aborts the transaction.
+```
+
+Transactional commit requires a replica set or sharded MongoDB cluster (see [Transactions](transactions.md)).
+
+`LockManyAsync` also accepts a `FilterDefinition<TEntity>` or an `Expression<Func<TEntity, bool>>` — both resolve to an id list at acquire time.
+
+## See also
+
+- [Transactions](transactions.md) — combining locks with multi-collection atomicity
+- [API: ILockableRepositoryCollection&lt;TEntity, TKey&gt;](xref:Tharga.MongoDB.Lockable.ILockableRepositoryCollection`2)
+- [API: DocumentLease&lt;TEntity&gt;](xref:Tharga.MongoDB.Lockable.DocumentLease`1)

--- a/docs/articles/mcp-integration.md
+++ b/docs/articles/mcp-integration.md
@@ -1,0 +1,78 @@
+# MCP integration
+
+The [`Tharga.MongoDB.Mcp`](https://www.nuget.org/packages/Tharga.MongoDB.Mcp) package exposes MongoDB monitoring data and admin actions over [MCP (Model Context Protocol)](https://modelcontextprotocol.io). AI agents (Claude, Cursor, etc.) can query collections, inspect monitoring data, and trigger admin actions — without SSH-ing to a prod box for `mongosh`.
+
+## Install + register
+
+```
+dotnet add package Tharga.MongoDB.Mcp
+```
+
+```csharp
+services.AddThargaMcp(mcp =>
+{
+    mcp.AddMongoDB();
+});
+
+app.UseThargaMcp();
+```
+
+The provider is registered on `McpScope.System` and surfaces only to system-level MCP callers.
+
+## Data access levels
+
+Default exposure is **metadata only** — nothing that returns or modifies actual document data. Opt in for more:
+
+```csharp
+services.AddThargaMcp(mcp =>
+{
+    mcp.AddMongoDB(o =>
+    {
+        o.DataAccess = DataAccessLevel.DataRead;       // adds tools/resources that read document data
+        // o.DataAccess = DataAccessLevel.DataReadWrite; // also adds tools that modify data (e.g. mongodb.clean)
+    });
+});
+```
+
+Anything above the configured level is filtered out of `tools/list` and `resources/list`, and rejected at `tools/call` / `resources/read` with an `IsError` response.
+
+## Resources
+
+| URI | Level | Description |
+|---|---|---|
+| `mongodb://collections` | Metadata | Collections with stats, indexes, clean status |
+| `mongodb://clients` | Metadata | Connected remote monitoring agents |
+| `mongodb://monitoring` | DataRead | Recent + slow calls, summaries, error summary, connection-pool state (calls embed filter values, hence the gating) |
+
+## Tools
+
+| Tool | Level | Args |
+|---|---|---|
+| `mongodb.touch` | Metadata | `databaseName`, `collectionName`, optional `configurationName` |
+| `mongodb.rebuild_index` | Metadata | `databaseName`, `collectionName`, optional `configurationName`, `force` |
+| `mongodb.restore_all_indexes` | Metadata | optional `configurationName` / `databaseName` filters |
+| `mongodb.drop_index` | Metadata | drops indexes not declared in code |
+| `mongodb.reset_cache` | Metadata | resets the in-memory monitor cache |
+| `mongodb.clear_call_history` | Metadata | clears recent + slow call history |
+| `mongodb.find_duplicates` | DataRead | `databaseName`, `collectionName`, `indexName`; returns duplicate-key tuples |
+| `mongodb.explain` | DataRead | `callKey` (Guid); returns explain plan + original filter |
+| `mongodb.clean` | DataReadWrite | deletes orphaned / invalid documents |
+| `mongodb.get_document` | DataRead | `id` is auto-detected as Guid → ObjectId → string; returns MongoDB Extended JSON |
+| `mongodb.list_documents` | DataRead | `limit` (default 20, max 200), `skip`, JSON `filter`, JSON `sort` |
+| `mongodb.compare_schema` | DataRead | three-way diff: C# entity properties vs registered type names vs field set observed in sample (default 50 docs, max 500) |
+
+## Document inspection
+
+`mongodb.get_document`, `mongodb.list_documents`, and `mongodb.compare_schema` let an authorized agent diagnose schema drift and migration fallout via MCP — the same loop typically done via `mongosh` on a production shell, but through the MCP plumbing you already use for everything else.
+
+- All three are `DataRead` — hidden by default. Opt in via `o.DataAccess = DataAccessLevel.DataRead`.
+- Documents are returned as MongoDB Extended JSON — the exact shape stored in MongoDB, never round-tripped through the C# serializer.
+- `compare_schema` reflects on the entity type's public properties and compares against the sampled field set. Top-level fields only — nested-document drift is a known limitation.
+- Per-tenant databases (`DatabasePart` / per-team DBs) work directly: pass the resolved `databaseName` from `mongodb://collections`.
+- Remote-only collections (`Registration.NotInCode`) are not yet supported — these tools throw a clear error. Adding remote routing requires extending `IRemoteActionDispatcher` and the Monitor.Server pipeline; planned as a follow-up.
+
+## See also
+
+- [API: MongoDbMcpOptions](xref:Tharga.MongoDB.Mcp.MongoDbMcpOptions)
+- [API: DataAccessLevel](xref:Tharga.MongoDB.Mcp.DataAccessLevel)
+- [Monitoring](monitoring.md) — the data the MCP surface exposes

--- a/docs/articles/monitoring.md
+++ b/docs/articles/monitoring.md
@@ -1,0 +1,83 @@
+# Monitoring
+
+Every database call (filter, sort, latency, exception, explain plan) is captured by the built-in `IDatabaseMonitor`. The monitor tracks collection metadata such as document counts, sizes, indexes and clean status. By default it persists state to a `_monitor` collection in MongoDB so data survives restarts and is shared across instances.
+
+## Storage modes
+
+| Mode | Behaviour |
+|---|---|
+| `Database` (default) | Persists to the `_monitor` collection. State survives restarts. |
+| `Memory` | In-memory only. State is lost on restart. |
+
+Configure via `appsettings.json`:
+
+```json
+"MongoDB": {
+  "Monitor": {
+    "Enabled": true,
+    "StorageMode": "Database",
+    "LastCallsToKeep": 1000,
+    "SlowCallsToKeep": 200
+  }
+}
+```
+
+Or by code via `services.AddMongoDB(o => o.Monitor = new MonitorOptions { ... })`.
+
+## Source identification
+
+All monitoring data is tagged with a source name. Default: `{MachineName}/{AssemblyName}`. Override via `Monitor.SourceName`. The Blazor call view shows a Source column when calls from multiple sources are present.
+
+## Command monitoring
+
+Enable driver-level command timing to see how much of "Action" time is real MongoDB server time vs thread-pool wait. Disabled by default; enable with `Monitor.EnableCommandMonitoring = true`. Steps then include breakdowns like:
+
+- **FetchCollection**: `Driver: listIndexes 2.10ms | Other: 0.45ms`
+- **Action**: `Driver: find 12.34ms | Other: 3.21ms`
+
+Useful for distinguishing slow database from slow serialization or application contention.
+
+## Centralised monitoring
+
+For a single dashboard pane covering many MongoDB-talking services, install [`Tharga.MongoDB.Monitor.Client`](https://www.nuget.org/packages/Tharga.MongoDB.Monitor.Client) on each agent and [`Tharga.MongoDB.Monitor.Server`](https://www.nuget.org/packages/Tharga.MongoDB.Monitor.Server) on the central server.
+
+**Agent:**
+
+```csharp
+builder.AddMongoDB();
+builder.AddMongoDbMonitorClient(sendTo: "https://monitor-server", apiKey: "...");
+```
+
+**Server:**
+
+```csharp
+builder.AddMongoDB();
+builder.AddMongoDbMonitorServer(primaryApiKey: "...");
+
+var app = builder.Build();
+app.UseMongoDbMonitorServer();
+```
+
+Agents push call events fire-and-forget over [Tharga.Communication](https://www.nuget.org/packages/Tharga.Communication) (SignalR-backed). The server ingests them into its local `IDatabaseMonitor` so the [Blazor admin UI](https://www.nuget.org/packages/Tharga.MongoDB.Blazor) renders local + remote data side by side. When the server is unavailable or not configured, the agent has zero overhead.
+
+## API key rotation
+
+Configure both `primaryApiKey` and `secondaryApiKey` on the server during a rotation window — either is accepted. Agents can also load keys from `appsettings.json` or User Secrets via the `Tharga:Communication:ApiKey` configuration path.
+
+## Remote action delegation
+
+When the server dashboard displays collections from remote agents, actions like *touch*, *drop index*, *restore index*, *clean* are automatically delegated to the agent that owns the collection. No extra configuration — if `Monitor.Client` and `Monitor.Server` are installed, it works out of the box.
+
+## Live subscriptions
+
+Live data (queue depth, ongoing calls) is only forwarded when someone is actively viewing the relevant tab. Blazor components subscribe on mount and unsubscribe on dispose. Collection metadata and completed calls are always forwarded.
+
+## Reset
+
+`IDatabaseMonitor.ResetAsync()` clears all cached state (in-memory + persisted). The Blazor `CollectionView` exposes a Reset button that calls this.
+
+## See also
+
+- [API: IDatabaseMonitor](xref:Tharga.MongoDB.IDatabaseMonitor)
+- [API: MonitorOptions](xref:Tharga.MongoDB.Configuration.MonitorOptions)
+- [Blazor admin UI components](https://www.nuget.org/packages/Tharga.MongoDB.Blazor)

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -1,0 +1,14 @@
+- name: Overview
+  href: index.md
+- name: Getting started
+  href: getting-started.md
+- name: Lockable collections
+  href: lockable-collections.md
+- name: Transactions
+  href: transactions.md
+- name: Keyset pagination
+  href: keyset-pagination.md
+- name: Monitoring
+  href: monitoring.md
+- name: MCP integration
+  href: mcp-integration.md

--- a/docs/articles/transactions.md
+++ b/docs/articles/transactions.md
@@ -1,0 +1,62 @@
+# Transactions
+
+Multi-document writes can be wrapped in a MongoDB transaction so they all commit atomically (or all roll back on exception). Works across multiple collections in the same cluster, and supports both Disk and Lockable repositories — including taking and committing locks inside the same transaction.
+
+## Basic usage
+
+```csharp
+await mongoDbServiceFactory.WithTransactionAsync(async (session, ct) =>
+{
+    await jobsRepo.AddAsync(job, session);
+    await statsRepo.AddAsync(stat, session);
+
+    await using var scope = await accountRepo.LockAsync(accountId, session: session);
+    await scope.CommitAsync(CommitMode.Update, scope.Entity with { Balance = newBalance });
+});
+```
+
+The session is created on the cluster identified by `configurationName` (default if null). The driver retries on transient transaction errors automatically. Body exceptions abort and rethrow.
+
+## The common case — `LockManyAsync` + transactional commit
+
+For the most common pattern — *lock N docs, decide each, commit atomically* — you don't need to touch `IClientSessionHandle` at all:
+
+```csharp
+await using var lease = await coll.LockManyAsync(ids);
+
+// inspect, mark each one
+foreach (var doc in lease.Documents)
+{
+    if (ShouldCommit(doc))
+        lease.MarkUpdate(doc.Id, doc with { Status = "processed" });
+    else
+        lease.MarkRelease(doc.Id);
+}
+
+var summary = await lease.CommitAsync(transactional: true);
+```
+
+Acquisition stays unchanged (sequential, fast); the commit pass runs inside an internal transaction so all marked decisions land atomically. This avoids the 60-second transaction timeout cost during your "thinking" phase between lock and commit.
+
+## Requirements
+
+- **Replica set or sharded cluster.** MongoDB transactions don't work on standalone deployments; the driver throws on `StartTransaction`.
+- All collections inside one transaction must be backed by the same `MongoClient` (same cluster). Cross-cluster transactions aren't supported by MongoDB.
+- Default 60-second transaction timeout — don't try to work around it. For long workflows, do the deciding outside the transaction and only wrap the commit pass.
+
+## Behaviour under an active session
+
+- **Index DDL is skipped** when a session is active (MongoDB forbids index management inside a transaction). Indexes are assured by the next non-transactional call against the collection. If your transaction is the *first* call against a fresh collection on process startup, the index won't be assured until later — warm up the collection at startup with a cheap read.
+- `DropEmptyAsync` (auto-drop after the last delete) is similarly skipped under a session.
+
+## Out of scope
+
+- Cross-cluster transactions
+- Nested transactions / savepoints
+- Long-running transactions (60-second cap is a MongoDB constraint)
+- Session-aware reads (`GetAsync(filter, session)` etc.) — write atomicity is the focus; reads inside the same session are filed as a follow-up
+
+## See also
+
+- [Lockable collections](lockable-collections.md) — the lock-and-decide workflow that pairs with transactional commits
+- [API: MongoDbServiceFactoryTransactionExtensions](xref:Tharga.MongoDB.MongoDbServiceFactoryTransactionExtensions)

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -1,0 +1,55 @@
+{
+  "metadata": [
+    {
+      "src": [
+        {
+          "src": "..",
+          "files": [
+            "Tharga.MongoDB/Tharga.MongoDB.csproj",
+            "Tharga.MongoDB.Blazor/Tharga.MongoDB.Blazor.csproj",
+            "Tharga.MongoDB.Mcp/Tharga.MongoDB.Mcp.csproj",
+            "Tharga.MongoDB.Monitor.Client/Tharga.MongoDB.Monitor.Client.csproj",
+            "Tharga.MongoDB.Monitor.Server/Tharga.MongoDB.Monitor.Server.csproj"
+          ]
+        }
+      ],
+      "dest": "api",
+      "includePrivateMembers": false,
+      "disableGitFeatures": false,
+      "disableDefaultFilter": false,
+      "noRestore": false,
+      "namespaceLayout": "flattened",
+      "memberLayout": "samePage",
+      "EnumSortOrder": "alphabetic",
+      "allowCompilationErrors": false
+    }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": ["**/*.{md,yml}"],
+        "exclude": ["_site/**", "obj/**"]
+      }
+    ],
+    "resource": [
+      {
+        "files": ["images/**", "CNAME"]
+      }
+    ],
+    "output": "_site",
+    "globalMetadata": {
+      "_appName": "Tharga.MongoDB",
+      "_appTitle": "Tharga.MongoDB",
+      "_enableSearch": true,
+      "_disableContribution": false,
+      "_gitContribute": {
+        "repo": "https://github.com/Tharga/MongoDB",
+        "branch": "master"
+      }
+    },
+    "template": ["default", "modern"],
+    "postProcessors": ["ExtractSearchIndex"],
+    "keepFileLink": false,
+    "disableGitFeatures": false
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,53 @@
+---
+_layout: landing
+---
+
+# Tharga.MongoDB
+
+A MongoDB repository toolkit for **.NET 8 / 9 / 10**. Built on `MongoDB.Driver`, with first-class support for dynamic database/collection naming, automatic index assurance, document-level locking, multi-document transactions, keyset pagination, and built-in call monitoring.
+
+## Packages
+
+| Package | What it does |
+|---|---|
+| [Tharga.MongoDB](https://www.nuget.org/packages/Tharga.MongoDB) | Core repository toolkit. Disk + Lockable collection bases, monitoring, transactions, keyset pagination. |
+| [Tharga.MongoDB.Blazor](https://www.nuget.org/packages/Tharga.MongoDB.Blazor) | Drop-in Razor admin UI components (collections, calls, clients, queue, indexes). |
+| [Tharga.MongoDB.Mcp](https://www.nuget.org/packages/Tharga.MongoDB.Mcp) | MCP (Model Context Protocol) provider — exposes monitoring + actions to AI clients. |
+| [Tharga.MongoDB.Monitor.Client](https://www.nuget.org/packages/Tharga.MongoDB.Monitor.Client) | Forwards monitoring data from a remote agent to a central server. |
+| [Tharga.MongoDB.Monitor.Server](https://www.nuget.org/packages/Tharga.MongoDB.Monitor.Server) | Receives monitoring data from agents and aggregates into the local monitor. |
+
+## Quick start
+
+```
+dotnet add package Tharga.MongoDB
+```
+
+```csharp
+builder.AddMongoDB();
+```
+
+```json
+"ConnectionStrings": {
+  "Default": "mongodb://localhost:27017/MyApp{Environment}{Part}"
+}
+```
+
+```csharp
+public record Order : EntityBase<ObjectId>
+{
+    public string CustomerName { get; init; }
+    public DateTime CreatedAt { get; init; }
+}
+
+public class OrderCollection : DiskRepositoryCollectionBase<Order, ObjectId>
+{
+    public OrderCollection(IMongoDbServiceFactory factory) : base(factory) { }
+    public override string CollectionName => "orders";
+}
+```
+
+## Where next
+
+- **[Articles](articles/index.md)** — feature guides: getting started, lockable docs, transactions, pagination, monitoring, MCP
+- **[API reference](xref:Tharga.MongoDB)** — every public type, method, and option, generated from XML doc comments
+- **[GitHub](https://github.com/Tharga/MongoDB)** — source, issues, releases

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,0 +1,6 @@
+- name: Home
+  href: index.md
+- name: Articles
+  href: articles/
+- name: API
+  href: api/


### PR DESCRIPTION
## Summary

- DocFX-driven site under `/docs/` with three top-level navigation tabs:
  - **Home** — landing page with package summary table and quick start
  - **Articles** — 6 feature guides: getting started, lockable collections, transactions, keyset pagination, monitoring, MCP integration
  - **API** — auto-generated reference from XML doc comments on every public type across all 5 packages (~217 managed reference pages)
- Custom domain wired via `docs/CNAME` → `mongodb.tharga.net`.
- New GitHub Actions workflow (`.github/workflows/docs.yml`) installs DocFX, runs `docfx docs/docfx.json`, and publishes `_site/` to GitHub Pages on each master push that touches `docs/` or any package source. Uses `actions/upload-pages-artifact` + `actions/deploy-pages` with the standard `github-pages` environment.

## Required actions after merge

1. **Repo settings → Pages → Source**: switch to "GitHub Actions" (the modern flow that `actions/deploy-pages` expects).
2. **DNS** at the registrar: add `CNAME` record `mongodb` → `tharga.github.io`.
3. GitHub auto-detects the CNAME file in the artifact and verifies the domain. HTTPS provisions automatically once DNS propagates.

## Test plan

- [x] `docfx docs/docfx.json` builds locally with **0 warnings, 0 errors** on docfx 2.78.5
- [x] `_site/` contains 225 html files: home, 7 article pages (incl. TOC), 217 API reference pages
- [x] `_site/CNAME` is present and contains `mongodb.tharga.net`
- [ ] Workflow runs green on master after merge → site appears at `https://tharga.github.io/MongoDB/` (then at `https://mongodb.tharga.net/` after DNS)