### PR TITLE
feat: expose CoreIndices and document auto-declared Lock indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,21 @@ var summary = await lease.CommitAsync(transactional: true);
 
 `LockManyAsync` also accepts a `FilterDefinition<TEntity>` or an `Expression<Func<TEntity, bool>>` predicate — both resolve to an id list at acquire time. Transactional commit requires a replica set / sharded MongoDB cluster (see Transactions below).
 
+##### Auto-declared lock indexes
+
+Every `LockableRepositoryCollectionBase<TEntity, TKey>` automatically declares two indexes via `CoreIndices` so the lock-check pattern (`{Lock: null}` or `{Lock.ExceptionInfo: null, Lock.ExpireTime: < now}`) doesn't full-scan:
+
+| Name | Keys | Covers |
+|---|---|---|
+| `Lock` | `{Lock: 1}` | The `Lock == null` branch — unlocked documents. |
+| `LockStatus` | `{Lock.ExceptionInfo: 1, Lock.ExpireTime: 1, Lock.LockTime: 1}` | The expired-lock branch + lock-age diagnostics. |
+
+Consumers don't need to add these to their `Indices` override — they're applied alongside any consumer-declared indexes on first collection access (per [Index assurance modes](#index-assurance-modes) above). The merged set is exposed via the `CoreIndices` property if you need to inspect or assert on it from your own tests.
+
+If a consumer's query pattern adds extra fields (e.g. `{Lock: 1, State: 1}` for state-filtered scans), declare those compounds in the consumer's `Indices` — they merge with `CoreIndices` rather than replacing it.
+
+For collections that pre-date the upgrade and are missing these indexes in production, see [Re-applying indexes after a code change](#re-applying-indexes-after-a-code-change) — the `RestoreAllIndicesAsync` API, the *Assure all indices* Blazor toolbar action, and the `mongodb.restore_all_indexes` MCP tool all force a re-apply across tracked collections.
+
 ---
 
 ### Transactions

--- a/Tharga.MongoDB.Tests/LockableCoreIndicesShapeTest.cs
+++ b/Tharga.MongoDB.Tests/LockableCoreIndicesShapeTest.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections;
 using System.Linq;
-using System.Reflection;
 using FluentAssertions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
@@ -24,9 +22,7 @@ public class LockableCoreIndicesShapeTest
     [Fact]
     public void CoreIndices_CoverLockField()
     {
-        var sut = CreateSut();
-
-        var rendered = RenderCoreIndices(sut);
+        var rendered = RenderCoreIndices(CreateSut());
 
         rendered.Should().ContainSingle(x => x.Name == "Lock")
             .Which.Keys.Names.Should().BeEquivalentTo(new[] { "Lock" });
@@ -39,9 +35,7 @@ public class LockableCoreIndicesShapeTest
         //   Lock.ExceptionInfo == null AND Lock.ExpireTime < now
         // The compound LockStatus index covers ExceptionInfo, ExpireTime, LockTime
         // — so the same index also serves diagnostic queries that filter by lock time.
-        var sut = CreateSut();
-
-        var rendered = RenderCoreIndices(sut);
+        var rendered = RenderCoreIndices(CreateSut());
 
         var lockStatus = rendered.Should().ContainSingle(x => x.Name == "LockStatus").Subject;
         lockStatus.Keys.Names.Should().BeEquivalentTo(
@@ -50,7 +44,7 @@ public class LockableCoreIndicesShapeTest
     }
 
     /// <summary>
-    /// Pure-reflection test — does not hit MongoDB. Use a Loose factory mock that
+    /// Pure unit test — does not hit MongoDB. Use a Loose factory mock that
     /// returns a Loose IMongoDbService so the base ctor's eager
     /// <c>GetMongoDbService(...)</c> call succeeds without opening a connection.
     /// Inheriting from <see cref="MongoDbTestBase"/> would force a real MongoDB on
@@ -70,20 +64,7 @@ public class LockableCoreIndicesShapeTest
         var serializer = registry.GetSerializer<LockableTestEntity>();
         var args = new RenderArgs<LockableTestEntity>(serializer, registry);
 
-        // CoreIndices is internal on the base class, and BindingFlags.NonPublic|Instance
-        // doesn't find inherited non-public members on a derived type — walk up explicitly.
-        var type = sut.GetType();
-        PropertyInfo prop = null;
-        while (type != null && prop == null)
-        {
-            prop = type.GetProperty("CoreIndices",
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
-            type = type.BaseType;
-        }
-        prop.Should().NotBeNull("CoreIndices should be reachable via reflection on the lockable base");
-
-        var indices = (IEnumerable)prop.GetValue(sut);
-        return indices.Cast<CreateIndexModel<LockableTestEntity>>()
+        return sut.CoreIndices
             .Select(x => (x.Options.Name, x.Keys.Render(args)))
             .ToArray();
     }

--- a/Tharga.MongoDB/Disk/GenericDiskRepositoryCollection.cs
+++ b/Tharga.MongoDB/Disk/GenericDiskRepositoryCollection.cs
@@ -25,7 +25,7 @@ internal class GenericDiskRepositoryCollection<TEntity, TKey> : DiskRepositoryCo
     public override bool CleanOnStartup => _proxy?.CleanOnStartup ?? base.CleanOnStartup;
     public override int? FetchSize => _proxy?.FetchSize ?? base.FetchSize;
     public override IEnumerable<CreateIndexModel<TEntity>> Indices => _proxy?.Indices ?? base.Indices;
-    internal override IEnumerable<CreateIndexModel<TEntity>> CoreIndices => _proxy?.CoreIndices ?? base.CoreIndices;
+    public override IEnumerable<CreateIndexModel<TEntity>> CoreIndices => _proxy?.CoreIndices ?? base.CoreIndices;
     public override IEnumerable<Type> Types => _proxy?.Types ?? base.Types;
 
     internal RepositoryCollectionBase<TEntity, TKey> GetProxy() => _proxy;

--- a/Tharga.MongoDB/Lockable/LockableRepositoryCollectionBase.cs
+++ b/Tharga.MongoDB/Lockable/LockableRepositoryCollectionBase.cs
@@ -30,7 +30,7 @@ public class LockableRepositoryCollectionBase<TEntity, TKey> : RepositoryCollect
 
     internal override IRepositoryCollection<TEntity, TKey> BaseCollection => Disk;
     private DiskRepositoryCollectionBase<TEntity, TKey> Disk => _disk ??= new GenericDiskRepositoryCollection<TEntity, TKey>(_mongoDbServiceFactory, _databaseContext ?? new DatabaseContext { CollectionName = CollectionName, DatabasePart = DatabasePart, ConfigurationName = ConfigurationName }, _logger, this);
-    internal override IEnumerable<CreateIndexModel<TEntity>> CoreIndices =>
+    public override IEnumerable<CreateIndexModel<TEntity>> CoreIndices =>
     [
         new(Builders<TEntity>.IndexKeys.Ascending(x => x.Lock), new CreateIndexOptions { Name = nameof(LockableEntityBase.Lock) }),
         new(

--- a/Tharga.MongoDB/RepositoryCollectionBase.cs
+++ b/Tharga.MongoDB/RepositoryCollectionBase.cs
@@ -58,7 +58,7 @@ public abstract class RepositoryCollectionBase<TEntity, TKey> : RepositoryCollec
     public virtual CreateStrategy CreateCollectionStrategy => _mongoDbService.CreateCollectionStrategy();
     public virtual int? FetchSize => _mongoDbService.GetFetchSize();
     public virtual IEnumerable<CreateIndexModel<TEntity>> Indices => null;
-    internal virtual IEnumerable<CreateIndexModel<TEntity>> CoreIndices => null;
+    public virtual IEnumerable<CreateIndexModel<TEntity>> CoreIndices => null;
     public virtual IEnumerable<Type> Types => null;
 
     //Read


### PR DESCRIPTION
## Summary

`LockableRepositoryCollectionBase` has auto-declared `Lock` + `LockStatus` indexes since `2.0.17` (commit `67710d8`, April 2025), but `CoreIndices` was `internal virtual` — consumers couldn't inspect what was already registered, leading to a downstream request (Eplicta, 2026-05-02, High) asking for indexes that were already there.

- Promote `CoreIndices` from `internal virtual` to `public virtual` on `RepositoryCollectionBase`, with matching `public override` on the `LockableRepositoryCollectionBase` declaration and on the `GenericDiskRepositoryCollection` proxy delegate.
- README: new *Auto-declared lock indexes* subsection under `ILockableRepositoryCollection`, listing the two indexes, the merge with consumer-declared `Indices`, and pointing to the existing *Re-applying indexes after a code change* section for the migration story (`RestoreAllIndicesAsync` API, *Assure all indices* Blazor toolbar action, and `mongodb.restore_all_indexes` MCP tool).
- Simplified `LockableCoreIndicesShapeTest` — the reflection walk is no longer needed now that `CoreIndices` is public.

No behavior change. The existing lockdown test that pins both indexes prevents future drift.

## Test plan

- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [x] `dotnet test -c Release --filter "Category!=Database"` — 168 / 168 pass
- [ ] Pre-release artifacts publish from this PR
- [ ] After merge, CI releases the next stable; reply on Eplicta `requests.md` with the version + an Eplicta-side nudge (verify Tharga.MongoDB version, confirm `AssureIndex` not `Disabled`, run `mongodb.restore_all_indexes` once per tenant DB)