### PR TITLE
fix(blazor): CollectionDialog stuck spinner + CallDialog dark-mode pre blocks

### DIFF
--- a/Tharga.MongoDB.Blazor/CallDialog.razor
+++ b/Tharga.MongoDB.Blazor/CallDialog.razor
@@ -1,7 +1,7 @@
 ﻿@using Microsoft.JSInterop
 @using Tharga.Blazor
 @inject ICallLibrary CallLibrary
-@inject IJSRuntime JSRuntime
+@inject IJSRuntime JsRuntime
 
 @if (_model == null)
 {
@@ -74,7 +74,7 @@ else
             </RadzenTabsItem>
             <RadzenTabsItem Text="Filter" Visible="@(!string.IsNullOrEmpty(_model.FilterJson))">
                 <RadzenText TextStyle="TextStyle.Caption" Text="Filter" />
-                <pre style="background:#f5f5f5;padding:0.5rem;border-radius:4px;overflow-x:auto;font-size:0.8rem;white-space:pre-wrap;word-break:break-all;">@_model.FilterJson</pre>
+                <pre style="background:var(--rz-base);padding:0.5rem;border-radius:4px;overflow-x:auto;font-size:0.8rem;white-space:pre-wrap;word-break:break-all;">@_model.FilterJson</pre>
             </RadzenTabsItem>
             <RadzenTabsItem Text="Explain" Visible="@(_model.ExplainProvider != null)">
                 <RadzenRow AlignItems="AlignItems.Center" Gap="0.5rem">
@@ -86,10 +86,13 @@ else
                                       Visible="@(_explainJson == null)"
                                       ButtonStyle="ButtonStyle.Light"
                                       Click="LoadExplainAsync" Disabled="_loadingExplain"/>
-                        <RadzenButton Icon="content_copy" Size="ButtonSize.ExtraSmall"
-                                      Visible="@(_explainJson != null)"
-                                      ButtonStyle="ButtonStyle.Light"
-                                      Click="CopyExplainAsync" title="Copy to clipboard"/>
+                        <div style="text-align:right;">
+                            <RadzenButton Icon="content_copy" Size="ButtonSize.ExtraSmall"
+                                          Text="Copy"
+                                          Visible="@(_explainJson != null)"
+                                          ButtonStyle="ButtonStyle.Light"
+                                          Click="CopyExplainAsync" title="Copy to clipboard"/>
+                        </div>
                     </RadzenColumn>
                 </RadzenRow>
                 @if (_loadingExplain)
@@ -98,7 +101,7 @@ else
                 }
                 else if (_explainJson != null)
                 {
-                    <pre style="background:#f5f5f5;padding:0.5rem;border-radius:4px;overflow-x:auto;font-size:0.75rem;white-space:pre-wrap;word-break:break-all;max-height:400px;">@_explainJson</pre>
+                    <pre style="background:var(--rz-base);padding:0.5rem;border-radius:4px;overflow-x:auto;font-size:0.75rem;white-space:pre-wrap;word-break:break-all;max-height:400px;">@_explainJson</pre>
                 }
             </RadzenTabsItem>
         </Tabs>
@@ -137,6 +140,6 @@ else
 
     private async Task CopyExplainAsync()
     {
-        await JSRuntime.InvokeVoidAsync("navigator.clipboard.writeText", _explainJson);
+        await JsRuntime.InvokeVoidAsync("navigator.clipboard.writeText", _explainJson);
     }
 }

--- a/Tharga.MongoDB.Blazor/CollectionDialog.razor
+++ b/Tharga.MongoDB.Blazor/CollectionDialog.razor
@@ -5,7 +5,13 @@
 @inject NotificationService NotificationService
 @inject DialogService DialogService
 
-@if (_model == null)
+@if (_loadError != null)
+{
+    <RadzenAlert AlertStyle="AlertStyle.Info" Variant="Variant.Flat" Shade="Shade.Lighter" ShowIcon="true" AllowClose="false">
+        @_loadError
+    </RadzenAlert>
+}
+else if (_model == null)
 {
     <Tharga.Blazor.Loading />
 }
@@ -108,6 +114,7 @@ else
 @code {
     private CollectionInfo _model;
     private IndexModel[] _indexModel;
+    private string _loadError;
     private bool _disposed;
     private bool _busy;
 
@@ -146,6 +153,7 @@ else
         if (_disposed || e.CollectionInfo.Key != Fingerprint?.Key) return;
         _model = e.CollectionInfo;
         _indexModel = _model.ToIndexModel().ToArray();
+        _loadError = null;
         if (_disposed) return;
         try { await InvokeAsync(StateHasChanged); } catch (Exception) { }
     }
@@ -234,10 +242,16 @@ else
     private async Task ReloadDataAsync()
     {
         var response = await DatabaseMonitor.GetInstanceAsync(Fingerprint);
-        if (response == null) return;
+        if (response == null)
+        {
+            _loadError = "Collection details are not available — this collection is not tracked by the monitor.";
+            StateHasChanged();
+            return;
+        }
 
         _indexModel = response.ToIndexModel().ToArray();
         _model = response;
+        _loadError = null;
 
         StateHasChanged();
     }


### PR DESCRIPTION
## Summary

Two small bug fixes in `Tharga.MongoDB.Blazor`, both filed by Quilt4Net.Server on 2026-05-07. Bundled because they ship in the same NuGet package and have negligible scope individually.

### Bug A — `CollectionDialog` stuck on loading spinner (Medium)

Opening the detail dialog for a row whose `Registration` is `Dynamic` or `NotInCode` showed the loading spinner forever. Root cause: `ReloadDataAsync` silently bailed when `DatabaseMonitor.GetInstanceAsync` returned `null`, leaving `_model` null and the spinner spinning.

Fix: new `_loadError` state field; set when the monitor returns null; cleared in `OnCollectionInfoChanged` so the dialog recovers gracefully if the monitor starts tracking the fingerprint mid-session. Renders a `RadzenAlert` ahead of the spinner branch.

### Bug B — `CallDialog` dark-mode unreadable `<pre>` blocks (Low)

The Filter and Explain JSON panels hardcoded `background:#f5f5f5;`, making JSON white-on-white under any dark Radzen theme. Replaced with `background:var(--rz-base);` — adapts to both light and dark.

### Additional polish on `CallDialog`

- Renamed the `IJSRuntime` injection from `JSRuntime` to `JsRuntime` (Pascal-case style match).
- Added `Text=\"Copy\"` to the copy-icon button so the action label is explicit, and right-aligned the copy button inside the Explain header so it sits opposite the caption.

## Test plan

- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [x] `dotnet test -c Release --filter \"Category!=Database\"` — 168 / 168 pass
- [ ] Pre-release artifacts publish from this PR
- [ ] Quilt4Net.Server picks up the prerelease and confirms the `Dynamic` / `NotInCode` row dialog now renders the alert; dark-theme JSON is readable; copy button sits to the right
- [ ] After merge, CI releases the next stable; mark both `Tharga/Requests.md` entries Done