### PR TITLE
feat(lockable): structured ExecuteAsync error handler with LockableErrorKind

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,35 @@ var summary = await lease.CommitAsync(transactional: true);
 
 `LockManyAsync` also accepts a `FilterDefinition<TEntity>` or an `Expression<Func<TEntity, bool>>` predicate — both resolve to an id list at acquire time. Transactional commit requires a replica set / sharded MongoDB cluster (see Transactions below).
 
+##### Structured error handling with `ExecuteAsync`
+
+The `EntityScope.ExecuteAsync` extension wraps the common pick → mutate → commit flow into a single call:
+
+```csharp
+await using var scope = await collection.PickForUpdateAsync(id);
+await scope.ExecuteAsync(async job =>
+{
+    job.Data = "updated";
+    return job;             // commit
+    // return null;         // abandon
+});
+```
+
+Errors thrown inside the func record an exception on the lock (`SetErrorStateAsync`); errors during commit (`LockExpiredException`, `LockAlreadyReleasedException`, `CommitException`, transient I/O) propagate. To consolidate every failure path into one callback, pass an `Action<LockableErrorKind, Exception>` handler:
+
+```csharp
+await scope.ExecuteAsync(
+    async job => { job.Data = "updated"; return job; },
+    (kind, e) => kind switch
+    {
+        LockableErrorKind.HandlerError       => _logger.LogError(e, e.Message),
+        LockableErrorKind.LockExpired        => _logger.LogError(e, "Lock expired for {Job}: {Message}", id, e.Message),
+        _                                    => _logger.LogError(e, "Commit error ({Kind}): {Message}", kind, e.Message),
+    });
+```
+
+`LockableErrorKind` covers `HandlerError` / `LockExpired` / `LockAlreadyReleased` / `CommitError`. The legacy `Action<Exception>` overload is still supported (handles only `HandlerError`; commit errors propagate as before) for callers that haven't migrated.
+
 ##### Auto-declared lock indexes
 
 Every `LockableRepositoryCollectionBase<TEntity, TKey>` automatically declares two indexes via `CoreIndices` so the lock-check pattern (`{Lock: null}` or `{Lock.ExceptionInfo: null, Lock.ExpireTime: < now}`) doesn't full-scan:

--- a/Tharga.MongoDB.Tests/Lockable/EntityScopeExtensionsTests.cs
+++ b/Tharga.MongoDB.Tests/Lockable/EntityScopeExtensionsTests.cs
@@ -146,4 +146,74 @@ public class EntityScopeExtensionsTests : LockableTestBase
         after.Data.Should().Be("initial");
         after.Lock.ExceptionInfo.Message.Should().Be("Oups");
     }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task UpdateAndThrow_StructuredHandlerReceivesHandlerErrorKind()
+    {
+        //Arrange
+        var repository = new LockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "initial" };
+        await repository.AddAsync(entity);
+        await using var scope = await repository.PickForUpdateAsync(entity.Id);
+
+        LockableErrorKind? capturedKind = null;
+        Exception capturedException = null;
+
+        //Act
+        var result = await scope.ExecuteAsync(
+            _ => throw new InvalidOperationException("Oups"),
+            (kind, e) => { capturedKind = kind; capturedException = e; });
+
+        //Assert — handler called once with HandlerError kind, no exception escapes the call
+        capturedKind.Should().Be(LockableErrorKind.HandlerError);
+        capturedException.Should().BeOfType<InvalidOperationException>().Which.Message.Should().Be("Oups");
+        // SetErrorStateAsync still ran — exception is recorded on the lock
+        var after = await repository.GetOneAsync(x => true);
+        after.Lock.ExceptionInfo.Message.Should().Be("Oups");
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task UpdateAndThrow_LegacyHandlerStillReceivesException()
+    {
+        //Arrange
+        var repository = new LockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "initial" };
+        await repository.AddAsync(entity);
+        await using var scope = await repository.PickForUpdateAsync(entity.Id);
+
+        Exception captured = null;
+
+        //Act — legacy Action<Exception> overload
+        await scope.ExecuteAsync(
+            _ => throw new InvalidOperationException("Oups"),
+            (Action<Exception>)(e => captured = e));
+
+        //Assert — exception flows to the legacy handler unchanged
+        captured.Should().BeOfType<InvalidOperationException>().Which.Message.Should().Be("Oups");
+        var after = await repository.GetOneAsync(x => true);
+        after.Lock.ExceptionInfo.Message.Should().Be("Oups");
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task NullStructuredHandler_HandlerErrorPropagates()
+    {
+        //Arrange
+        var repository = new LockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "initial" };
+        await repository.AddAsync(entity);
+        await using var scope = await repository.PickForUpdateAsync(entity.Id);
+
+        //Act — explicitly null structured handler
+        var act = () => scope.ExecuteAsync(
+            _ => throw new InvalidOperationException("Oups"),
+            (Action<LockableErrorKind, Exception>)null);
+
+        //Assert — same propagation behavior as before this overload existed
+        await act.Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("Oups");
+    }
 }

--- a/Tharga.MongoDB/Lockable/EntityScopeExtensions.cs
+++ b/Tharga.MongoDB/Lockable/EntityScopeExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 
 namespace Tharga.MongoDB.Lockable;
@@ -13,10 +14,15 @@ public static class EntityScopeExtensions
     /// <typeparam name="TKey">Type of the key.</typeparam>
     /// <param name="item">The entity scope.</param>
     /// <param name="func">The function to be executed within the scope.</param>
-    /// <param name="errorHandler">Provide an error handler instead of an exception beeing thrown.</param>
-    /// <returns></returns>
+    /// <param name="errorHandler">
+    /// Receives a <see cref="LockableErrorKind"/> discriminator and the exception for every failure path —
+    /// errors thrown by <paramref name="func"/> as well as commit-side exceptions
+    /// (<see cref="LockExpiredException"/>, <see cref="LockAlreadyReleasedException"/>, <see cref="CommitException"/>,
+    /// any other commit failure). When <c>null</c> (default), the original exception propagates with its
+    /// stack trace intact — same behavior as before this overload existed.
+    /// </param>
     /// <exception cref="ArgumentNullException"></exception>
-    public static async Task<T> ExecuteAsync<T, TKey>(this EntityScope<T, TKey> item, Func<T, Task<T>> func, Action<Exception> errorHandler = null)
+    public static async Task<T> ExecuteAsync<T, TKey>(this EntityScope<T, TKey> item, Func<T, Task<T>> func, Action<LockableErrorKind, Exception> errorHandler = null)
         where T : LockableEntityBase<TKey>
     {
         if (item == null) return null;
@@ -38,13 +44,51 @@ public static class EntityScopeExtensions
             await item.SetErrorStateAsync(e);
             if (errorHandler != null)
             {
-                errorHandler.Invoke(e);
+                errorHandler.Invoke(LockableErrorKind.HandlerError, e);
                 return entity ?? item.Entity;
             }
 
             throw;
         }
 
-        return await item.CommitAsync(entity);
+        try
+        {
+            return await item.CommitAsync(entity);
+        }
+        catch (Exception e) when (errorHandler != null)
+        {
+            var kind = e switch
+            {
+                LockExpiredException => LockableErrorKind.LockExpired,
+                LockAlreadyReleasedException => LockableErrorKind.LockAlreadyReleased,
+                _ => LockableErrorKind.CommitError,
+            };
+            errorHandler.Invoke(kind, e);
+            return entity;
+        }
+    }
+
+    /// <summary>
+    /// Backwards-compatible overload — pass an <see cref="Action{Exception}"/> to handle
+    /// errors thrown by <paramref name="func"/> only; commit-side exceptions still propagate.
+    /// New code should prefer the <see cref="LockableErrorKind"/> overload, which routes every
+    /// failure path through a single callback.
+    /// </summary>
+    public static Task<T> ExecuteAsync<T, TKey>(this EntityScope<T, TKey> item, Func<T, Task<T>> func, Action<Exception> errorHandler)
+        where T : LockableEntityBase<TKey>
+    {
+        if (errorHandler == null) throw new ArgumentNullException(nameof(errorHandler), $"{nameof(errorHandler)} needs to be provided. Pass null to the {nameof(LockableErrorKind)} overload to skip error handling.");
+
+        return ExecuteAsync(item, func, (kind, e) =>
+        {
+            if (kind == LockableErrorKind.HandlerError)
+            {
+                errorHandler.Invoke(e);
+            }
+            else
+            {
+                ExceptionDispatchInfo.Capture(e).Throw();
+            }
+        });
     }
 }

--- a/Tharga.MongoDB/Lockable/LockableErrorKind.cs
+++ b/Tharga.MongoDB/Lockable/LockableErrorKind.cs
@@ -1,0 +1,21 @@
+namespace Tharga.MongoDB.Lockable;
+
+/// <summary>
+/// Discriminator passed to the unified error handler on the <c>EntityScopeExtensions.ExecuteAsync</c> overload
+/// that takes <c>Action&lt;LockableErrorKind, Exception&gt;</c>, so callers can route every error type from a
+/// single callback without try/catching individual exception classes.
+/// </summary>
+public enum LockableErrorKind
+{
+    /// <summary>Exception thrown by the user-provided <c>func</c> before commit.</summary>
+    HandlerError,
+
+    /// <summary>The lock timed out before <c>CommitAsync</c> completed (<see cref="LockExpiredException"/>).</summary>
+    LockExpired,
+
+    /// <summary>The lock was already released before commit was attempted (<see cref="LockAlreadyReleasedException"/>).</summary>
+    LockAlreadyReleased,
+
+    /// <summary>Other commit failure — typically <see cref="CommitException"/> or a transient I/O error.</summary>
+    CommitError,
+}


### PR DESCRIPTION
Closes #86.

## Summary

Eliminates the need for separate try/catch blocks alongside the existing error handler to deal with commit-side exceptions (`LockExpiredException`, `LockAlreadyReleasedException`, `CommitException`, transient I/O). A new `Action<LockableErrorKind, Exception>` overload routes every failure path through one callback with a kind discriminator.

- **`LockableErrorKind` enum** — `HandlerError` / `LockExpired` / `LockAlreadyReleased` / `CommitError`.
- **New `ExecuteAsync` overload** taking `Action<LockableErrorKind, Exception>` with default `null`. `CommitAsync` wrapped in a typed catch filter that maps the exception to its kind. `errorHandler = null` preserves prior propagation behavior.
- **Legacy `Action<Exception>` overload** kept for backwards compatibility, but now requires the handler arg explicitly (no default) — needed to avoid call-site ambiguity at `scope.ExecuteAsync(func)`, which now routes unambiguously to the new overload with identical behavior. Body delegates via `ExceptionDispatchInfo.Capture(e).Throw()` so commit-error rethrow keeps the original stack trace.
- **Tests** — 3 Database-tagged additions covering the structured handler, legacy handler still works, null-handler propagation.
- **README** — new *Structured error handling with `ExecuteAsync`* subsection.

No internal callers affected (only the test suite uses `scope.ExecuteAsync`, all without a handler).

## API impact

- New public type: `LockableErrorKind`.
- New public extension overload: `ExecuteAsync<T, TKey>(EntityScope, Func<T, Task<T>>, Action<LockableErrorKind, Exception>)`.
- Soft-breaking on the legacy `Action<Exception>` overload — the third arg is now required (no default). Any existing caller passing the handler explicitly is unaffected; callers calling `scope.ExecuteAsync(func)` (no handler) silently route to the new overload with identical behavior.

## Test plan

- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [x] `dotnet test --filter "Category!=Database"` — 168 / 168 pass
- [ ] Database-tagged tests pass locally (need a real MongoDB)
- [ ] Pre-release artifacts publish from this PR
- [ ] After merge, CI releases the next stable patch; close #86 referencing the version