### PR TITLE
feat(mcp): Atlas administration tools (Phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -891,6 +891,30 @@ Providers are registered with `McpScope.System`, so they are only exposed on the
 - Per-tenant databases (`DatabasePart` / per-team DBs) work directly: pass the resolved `databaseName` from `mongodb://collections`. No special "part" parameter needed.
 - Remote-only collections (`Registration.NotInCode`) are not yet supported — these tools throw a clear error. Adding remote routing requires extending `IRemoteActionDispatcher` and the Monitor.Server pipeline; planned as a follow-up.
 
+### Atlas Administration tools
+
+When `MongoDbMcpOptions.Atlas` is set, the package also exposes a curated read-only slice of the MongoDB Atlas Administration API as MCP tools — diagnose Atlas Performance Advisor suggestions or open alerts from any MCP client without re-implementing the Atlas integration per consumer.
+
+```csharp
+services.AddThargaMcp(mcp => mcp.AddMongoDB(o =>
+{
+    o.Atlas = new MongoDbApiAccess
+    {
+        PublicKey  = "<atlas-public-key>",
+        PrivateKey = "<atlas-private-key>",
+        GroupId    = "<atlas-project-id>",
+    };
+}));
+```
+
+| Tool | Level | Args |
+|---|---|---|
+| `atlas.list_clusters` | Metadata | (no args) — returns clusters in the configured Atlas project |
+| `atlas.get_performance_advisor_suggestions` | Metadata | `clusterName` (from `atlas.list_clusters`) — returns the suggested-index list per the Atlas UI |
+| `atlas.get_open_alerts` | Metadata | (no args) — returns currently-firing alerts in the project |
+
+All three target Atlas Administration API v2. Auth is HTTP Digest via the public/private API key pair, the same pattern used by the firewall integration in `Tharga.MongoDB`. Leaving `Atlas` unset keeps the surface entirely opt-in — no Atlas tools are advertised unless the option is configured.
+
 ---
 
 ## Aggregation Queries

--- a/Tharga.MongoDB.Mcp/Atlas/AtlasMongoDbToolProvider.cs
+++ b/Tharga.MongoDB.Mcp/Atlas/AtlasMongoDbToolProvider.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Tharga.Mcp;
+
+namespace Tharga.MongoDB.Mcp.Atlas;
+
+/// <summary>
+/// Exposes a curated read-only slice of the MongoDB Atlas Administration API as MCP tools.
+/// All tools are <see cref="DataAccessLevel.Metadata"/>-gated and System scope. Atlas
+/// credentials live in <see cref="MongoDbMcpOptions.Atlas"/> — the provider is only registered
+/// when that property is non-null (see <see cref="ThargaMcpBuilderExtensions.AddMongoDB"/>).
+/// </summary>
+internal sealed class AtlasMongoDbToolProvider : IMcpToolProvider
+{
+    private const string ListClustersToolName = "atlas.list_clusters";
+    private const string SuggestedIndexesToolName = "atlas.get_performance_advisor_suggestions";
+    private const string OpenAlertsToolName = "atlas.get_open_alerts";
+
+    private static readonly JsonElement EmptyArgSchema = JsonSerializer.Deserialize<JsonElement>("""
+        {
+          "type": "object",
+          "properties": {}
+        }
+        """);
+
+    private static readonly JsonElement SuggestedIndexesArgSchema = JsonSerializer.Deserialize<JsonElement>("""
+        {
+          "type": "object",
+          "properties": {
+            "clusterName": { "type": "string", "description": "Name of the Atlas cluster (from atlas.list_clusters)." }
+          },
+          "required": ["clusterName"]
+        }
+        """);
+
+    private static readonly McpToolDescriptor[] AllTools =
+    [
+        new McpToolDescriptor
+        {
+            Name = ListClustersToolName,
+            Description = "List clusters in the configured Atlas project. Returns name, type, state, and MongoDB version per cluster.",
+            InputSchema = EmptyArgSchema,
+        },
+        new McpToolDescriptor
+        {
+            Name = SuggestedIndexesToolName,
+            Description = "Atlas Performance Advisor's suggested indexes for a named cluster. Returns the namespaces, fields, and weights — the same data the Atlas UI surfaces under Performance Advisor → Suggested Indexes.",
+            InputSchema = SuggestedIndexesArgSchema,
+        },
+        new McpToolDescriptor
+        {
+            Name = OpenAlertsToolName,
+            Description = "Currently-firing Atlas alerts in the configured project. Returns alert id, event type, status, and creation time.",
+            InputSchema = EmptyArgSchema,
+        },
+    ];
+
+    private readonly MongoDbMcpOptions _options;
+    private readonly AtlasV2HttpClient _client;
+
+    public AtlasMongoDbToolProvider(MongoDbMcpOptions options, AtlasV2HttpClient client)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+    }
+
+    public McpScope Scope => McpScope.System;
+
+    public Task<IReadOnlyList<McpToolDescriptor>> ListToolsAsync(IMcpContext context, CancellationToken cancellationToken)
+    {
+        // All Atlas tools are Metadata level; gate behind the same DataAccess setting as the rest of the package.
+        IReadOnlyList<McpToolDescriptor> filtered = _options.DataAccess >= DataAccessLevel.Metadata
+            ? AllTools
+            : Array.Empty<McpToolDescriptor>();
+        return Task.FromResult(filtered);
+    }
+
+    public async Task<McpToolResult> CallToolAsync(string toolName, JsonElement arguments, IMcpContext context, CancellationToken cancellationToken)
+    {
+        if (_options.DataAccess < DataAccessLevel.Metadata)
+        {
+            return Error($"Tool '{toolName}' requires DataAccessLevel.Metadata but server is configured for DataAccessLevel.{_options.DataAccess}.");
+        }
+
+        var groupId = _options.Atlas?.GroupId;
+        if (string.IsNullOrEmpty(groupId))
+        {
+            return Error("Atlas GroupId is not configured. Set MongoDbMcpOptions.Atlas.GroupId to enable Atlas tools.");
+        }
+
+        try
+        {
+            return toolName switch
+            {
+                ListClustersToolName => await ListClustersAsync(groupId, cancellationToken),
+                SuggestedIndexesToolName => await GetSuggestedIndexesAsync(groupId, arguments, cancellationToken),
+                OpenAlertsToolName => await GetOpenAlertsAsync(groupId, cancellationToken),
+                _ => Error($"Unknown tool: {toolName}"),
+            };
+        }
+        catch (Exception e)
+        {
+            return Error(e.Message);
+        }
+    }
+
+    private async Task<McpToolResult> ListClustersAsync(string groupId, CancellationToken cancellationToken)
+    {
+        var json = await _client.GetJsonAsync($"groups/{Uri.EscapeDataString(groupId)}/clusters", cancellationToken);
+
+        // Surface only the fields callers asked for — keeps the response payload predictable.
+        var clusters = json.TryGetProperty("results", out var results) && results.ValueKind == JsonValueKind.Array
+            ? results.EnumerateArray().Select(c => new
+            {
+                name = c.TryGetProperty("name", out var n) ? n.GetString() : null,
+                clusterType = c.TryGetProperty("clusterType", out var t) ? t.GetString() : null,
+                stateName = c.TryGetProperty("stateName", out var s) ? s.GetString() : null,
+                mongoDBVersion = c.TryGetProperty("mongoDBVersion", out var v) ? v.GetString() : null,
+            }).ToArray()
+            : Array.Empty<object>();
+
+        return Ok(new { clusters });
+    }
+
+    private async Task<McpToolResult> GetSuggestedIndexesAsync(string groupId, JsonElement arguments, CancellationToken cancellationToken)
+    {
+        if (!arguments.TryGetProperty("clusterName", out var clusterEl) || clusterEl.ValueKind != JsonValueKind.String)
+        {
+            return Error("clusterName is required.");
+        }
+        var clusterName = clusterEl.GetString();
+        if (string.IsNullOrWhiteSpace(clusterName)) return Error("clusterName must not be empty.");
+
+        var path = $"groups/{Uri.EscapeDataString(groupId)}/clusters/{Uri.EscapeDataString(clusterName)}/performanceAdvisor/suggestedIndexes";
+        var json = await _client.GetJsonAsync(path, cancellationToken);
+
+        // Forward the relevant fields raw — the schema (namespaces, weight, index keys, query shapes) is well
+        // documented, and surfacing the raw JSON keeps Phase 1 forward-compatible if Atlas adds new fields.
+        return Ok(new
+        {
+            cluster = clusterName,
+            suggestedIndexes = ExtractArray(json, "suggestedIndexes"),
+            shapes = ExtractArray(json, "shapes"),
+        });
+    }
+
+    private async Task<McpToolResult> GetOpenAlertsAsync(string groupId, CancellationToken cancellationToken)
+    {
+        var json = await _client.GetJsonAsync($"groups/{Uri.EscapeDataString(groupId)}/alerts?status=OPEN", cancellationToken);
+
+        var alerts = json.TryGetProperty("results", out var results) && results.ValueKind == JsonValueKind.Array
+            ? results.EnumerateArray().Select(a => new
+            {
+                id = a.TryGetProperty("id", out var i) ? i.GetString() : null,
+                eventTypeName = a.TryGetProperty("eventTypeName", out var et) ? et.GetString() : null,
+                status = a.TryGetProperty("status", out var s) ? s.GetString() : null,
+                created = a.TryGetProperty("created", out var c) ? c.GetString() : null,
+                clusterName = a.TryGetProperty("clusterName", out var cn) ? cn.GetString() : null,
+                hostnameAndPort = a.TryGetProperty("hostnameAndPort", out var hp) ? hp.GetString() : null,
+            }).ToArray()
+            : Array.Empty<object>();
+
+        return Ok(new { alerts });
+    }
+
+    private static JsonElement ExtractArray(JsonElement root, string property)
+    {
+        return root.TryGetProperty(property, out var el) && el.ValueKind == JsonValueKind.Array
+            ? el
+            : JsonDocument.Parse("[]").RootElement.Clone();
+    }
+
+    private static McpToolResult Ok(object payload)
+    {
+        return new McpToolResult
+        {
+            Content = [new McpContent { Type = "text", Text = JsonSerializer.Serialize(payload) }],
+        };
+    }
+
+    private static McpToolResult Error(string message)
+    {
+        return new McpToolResult
+        {
+            IsError = true,
+            Content = [new McpContent { Type = "text", Text = message }],
+        };
+    }
+}

--- a/Tharga.MongoDB.Mcp/Atlas/AtlasV2HttpClient.cs
+++ b/Tharga.MongoDB.Mcp/Atlas/AtlasV2HttpClient.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Tharga.MongoDB.Configuration;
+
+namespace Tharga.MongoDB.Mcp.Atlas;
+
+/// <summary>
+/// Thin <see cref="HttpClient"/> wrapper for the MongoDB Atlas Administration API v2.
+/// Uses HTTP Digest auth via public/private API keys, the same pattern as the firewall feature
+/// in <c>Tharga.MongoDB</c>. Long-lived; register as a singleton.
+/// </summary>
+internal sealed class AtlasV2HttpClient : IDisposable
+{
+    // Atlas v2 uses calendar-versioned media types; pick a stable date that the public API
+    // contract will continue to honor. Bump when we want to opt into newer fields.
+    private const string MediaType = "application/vnd.atlas.2024-08-05+json";
+    private const string BaseUrl = "https://cloud.mongodb.com/api/atlas/v2/";
+
+    private readonly HttpClient _client;
+    private readonly HttpMessageHandler _ownedHandler;
+
+    /// <param name="access">Atlas API access credentials. PublicKey/PrivateKey are required; GroupId is consumed by the tool layer.</param>
+    /// <param name="handler">
+    /// Optional message handler. Tests pass a mock handler to intercept requests; production leaves this null
+    /// and the client builds its own <see cref="HttpClientHandler"/> with digest credentials.
+    /// </param>
+    public AtlasV2HttpClient(MongoDbApiAccess access, HttpMessageHandler handler = null)
+    {
+        if (access == null) throw new ArgumentNullException(nameof(access));
+        if (string.IsNullOrEmpty(access.PublicKey)) throw new ArgumentException("PublicKey is required.", nameof(access));
+        if (string.IsNullOrEmpty(access.PrivateKey)) throw new ArgumentException("PrivateKey is required.", nameof(access));
+
+        if (handler == null)
+        {
+            _ownedHandler = new HttpClientHandler
+            {
+                Credentials = new NetworkCredential(access.PublicKey, access.PrivateKey),
+            };
+            _client = new HttpClient(_ownedHandler);
+        }
+        else
+        {
+            // Caller-supplied handler — tests own its lifetime.
+            _client = new HttpClient(handler, disposeHandler: false);
+        }
+
+        _client.BaseAddress = new Uri(BaseUrl);
+        _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaType));
+    }
+
+    /// <summary>
+    /// GETs <paramref name="relativePath"/> and returns the parsed JSON body (cloned so callers can keep it past the document's lifetime).
+    /// Throws if the response is not 2xx.
+    /// </summary>
+    public async Task<JsonElement> GetJsonAsync(string relativePath, CancellationToken cancellationToken)
+    {
+        using var response = await _client.GetAsync(relativePath, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return doc.RootElement.Clone();
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        _ownedHandler?.Dispose();
+    }
+}

--- a/Tharga.MongoDB.Mcp/MongoDbMcpOptions.cs
+++ b/Tharga.MongoDB.Mcp/MongoDbMcpOptions.cs
@@ -1,3 +1,5 @@
+using Tharga.MongoDB.Configuration;
+
 namespace Tharga.MongoDB.Mcp;
 
 /// <summary>
@@ -10,4 +12,12 @@ public class MongoDbMcpOptions
     /// Default is <see cref="DataAccessLevel.Metadata"/>: only metadata and admin tools/resources are listed and callable.
     /// </summary>
     public DataAccessLevel DataAccess { get; set; } = DataAccessLevel.Metadata;
+
+    /// <summary>
+    /// Optional MongoDB Atlas Administration API access. When set, the package registers a separate
+    /// MCP tool provider with read-only Atlas tools (<c>atlas.list_clusters</c>,
+    /// <c>atlas.get_performance_advisor_suggestions</c>, <c>atlas.get_open_alerts</c>) on the System scope.
+    /// Leave null to disable — the Atlas tool surface is opt-in.
+    /// </summary>
+    public MongoDbApiAccess Atlas { get; set; }
 }

--- a/Tharga.MongoDB.Mcp/README.md
+++ b/Tharga.MongoDB.Mcp/README.md
@@ -45,6 +45,30 @@ The provider is registered on the `System` MCP scope, so it only surfaces to sys
 **Tools (DataReadWrite)**
 - `mongodb.clean` — apply collection cleaners
 
+## Atlas (optional)
+
+When you set `MongoDbMcpOptions.Atlas` to a `MongoDbApiAccess` (Public/Private API key + Group/Project ID), the package additionally registers read-only MongoDB Atlas Administration tools on the System scope:
+
+```csharp
+builder.Services.AddThargaMcp(mcp => mcp.AddMongoDB(o =>
+{
+    o.Atlas = new MongoDbApiAccess
+    {
+        PublicKey  = "<atlas-public-key>",
+        PrivateKey = "<atlas-private-key>",
+        GroupId    = "<atlas-project-id>",
+    };
+}));
+```
+
+| Tool | Purpose |
+|---|---|
+| `atlas.list_clusters` | Clusters in the configured Atlas project — name, type, state, MongoDB version. |
+| `atlas.get_performance_advisor_suggestions` | Atlas Performance Advisor's suggested-index list for a named cluster (the same data the Atlas UI surfaces). Takes `clusterName`. |
+| `atlas.get_open_alerts` | Currently-firing Atlas alerts in the project. |
+
+Atlas tools are gated by the same `DataAccessLevel.Metadata` minimum as the rest of the package. Leaving `Atlas` unset keeps the surface entirely opt-in.
+
 ## Documentation
 
 Full docs and configuration reference: [github.com/Tharga/MongoDB](https://github.com/Tharga/MongoDB).

--- a/Tharga.MongoDB.Mcp/ThargaMcpBuilderExtensions.cs
+++ b/Tharga.MongoDB.Mcp/ThargaMcpBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using Tharga.Mcp;
+using Tharga.MongoDB.Mcp.Atlas;
 
 namespace Tharga.MongoDB.Mcp;
 
@@ -11,10 +12,12 @@ public static class ThargaMcpBuilderExtensions
 {
     /// <summary>
     /// Registers <see cref="MongoDbResourceProvider"/> and <see cref="MongoDbToolProvider"/>, exposing
-    /// MongoDB collection data, monitoring data, and admin tools on the System scope.
+    /// MongoDB collection data, monitoring data, and admin tools on the System scope. When
+    /// <see cref="MongoDbMcpOptions.Atlas"/> is configured, additionally registers
+    /// <see cref="AtlasMongoDbToolProvider"/> and an <see cref="AtlasV2HttpClient"/> singleton.
     /// </summary>
     /// <param name="builder">The MCP builder.</param>
-    /// <param name="configure">Optional callback to configure <see cref="MongoDbMcpOptions"/>. If omitted, defaults are used (<see cref="DataAccessLevel.Metadata"/>).</param>
+    /// <param name="configure">Optional callback to configure <see cref="MongoDbMcpOptions"/>. If omitted, defaults are used (<see cref="DataAccessLevel.Metadata"/>, no Atlas access).</param>
     public static IThargaMcpBuilder AddMongoDB(this IThargaMcpBuilder builder, Action<MongoDbMcpOptions> configure = null)
     {
         var options = new MongoDbMcpOptions();
@@ -23,6 +26,13 @@ public static class ThargaMcpBuilderExtensions
 
         builder.AddResourceProvider<MongoDbResourceProvider>();
         builder.AddToolProvider<MongoDbToolProvider>();
+
+        if (options.Atlas != null)
+        {
+            builder.Services.AddSingleton(sp => new AtlasV2HttpClient(options.Atlas));
+            builder.AddToolProvider<AtlasMongoDbToolProvider>();
+        }
+
         return builder;
     }
 }

--- a/Tharga.MongoDB.Tests/AtlasMongoDbToolProviderTests.cs
+++ b/Tharga.MongoDB.Tests/AtlasMongoDbToolProviderTests.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using Tharga.Mcp;
+using Tharga.MongoDB.Configuration;
+using Tharga.MongoDB.Mcp;
+using Tharga.MongoDB.Mcp.Atlas;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests;
+
+public class AtlasMongoDbToolProviderTests
+{
+    private readonly Mock<IMcpContext> _contextMock;
+
+    public AtlasMongoDbToolProviderTests()
+    {
+        _contextMock = new Mock<IMcpContext>();
+        _contextMock.Setup(c => c.Scope).Returns(McpScope.System);
+        _contextMock.Setup(c => c.IsDeveloper).Returns(true);
+    }
+
+    private static MongoDbApiAccess Access => new()
+    {
+        PublicKey = "pub-key",
+        PrivateKey = "priv-key",
+        GroupId = "group-123",
+    };
+
+    private static (AtlasMongoDbToolProvider Provider, RecordingHandler Handler) CreateProvider(
+        Dictionary<string, string> responseByPath,
+        DataAccessLevel level = DataAccessLevel.Metadata,
+        MongoDbApiAccess access = null)
+    {
+        var handler = new RecordingHandler(responseByPath);
+        var client = new AtlasV2HttpClient(access ?? Access, handler);
+        var options = new MongoDbMcpOptions { DataAccess = level, Atlas = access ?? Access };
+        return (new AtlasMongoDbToolProvider(options, client), handler);
+    }
+
+    [Fact]
+    public void Scope_IsSystem()
+    {
+        var (provider, _) = CreateProvider(new Dictionary<string, string>());
+        provider.Scope.Should().Be(McpScope.System);
+    }
+
+    [Fact]
+    public async Task ListTools_AtMetadata_ReturnsAllThreeAtlasTools()
+    {
+        var (provider, _) = CreateProvider(new Dictionary<string, string>());
+        var tools = await provider.ListToolsAsync(_contextMock.Object, CancellationToken.None);
+
+        tools.Select(t => t.Name).Should().BeEquivalentTo(
+            "atlas.list_clusters",
+            "atlas.get_performance_advisor_suggestions",
+            "atlas.get_open_alerts");
+    }
+
+    [Fact]
+    public async Task CallTool_WithoutAtlasAccess_ReturnsError()
+    {
+        var handler = new RecordingHandler(new Dictionary<string, string>());
+        var client = new AtlasV2HttpClient(Access, handler);
+        var options = new MongoDbMcpOptions { Atlas = null };
+        var provider = new AtlasMongoDbToolProvider(options, client);
+
+        var result = await provider.CallToolAsync("atlas.list_clusters", JsonDocument.Parse("{}").RootElement, _contextMock.Object, CancellationToken.None);
+
+        result.IsError.Should().BeTrue();
+        result.Content[0].Text.Should().Contain("GroupId is not configured");
+    }
+
+    [Fact]
+    public async Task ListClusters_HitsExpectedUrl_AndProjectsResults()
+    {
+        const string body = """
+            {
+              "results": [
+                { "name": "Cluster0", "clusterType": "REPLICASET", "stateName": "IDLE", "mongoDBVersion": "7.0.5", "ignored": "yes" },
+                { "name": "Cluster1", "clusterType": "SHARDED",   "stateName": "UPDATING", "mongoDBVersion": "7.0.4" }
+              ],
+              "totalCount": 2
+            }
+            """;
+        var (provider, handler) = CreateProvider(new Dictionary<string, string>
+        {
+            ["/api/atlas/v2/groups/group-123/clusters"] = body,
+        });
+
+        var result = await provider.CallToolAsync("atlas.list_clusters", JsonDocument.Parse("{}").RootElement, _contextMock.Object, CancellationToken.None);
+
+        result.IsError.Should().BeFalse();
+        var payload = JsonDocument.Parse(result.Content[0].Text).RootElement;
+        var clusters = payload.GetProperty("clusters").EnumerateArray().ToArray();
+        clusters.Should().HaveCount(2);
+        clusters[0].GetProperty("name").GetString().Should().Be("Cluster0");
+        clusters[0].GetProperty("clusterType").GetString().Should().Be("REPLICASET");
+        clusters[0].GetProperty("stateName").GetString().Should().Be("IDLE");
+        clusters[0].GetProperty("mongoDBVersion").GetString().Should().Be("7.0.5");
+        clusters[0].TryGetProperty("ignored", out _).Should().BeFalse("only the documented fields should leak through");
+
+        handler.Requests.Should().ContainSingle()
+            .Which.Headers.Accept.ToString().Should().Contain("vnd.atlas.");
+    }
+
+    [Fact]
+    public async Task SuggestedIndexes_RequiresClusterName()
+    {
+        var (provider, _) = CreateProvider(new Dictionary<string, string>());
+        var args = JsonDocument.Parse("{}").RootElement;
+
+        var result = await provider.CallToolAsync("atlas.get_performance_advisor_suggestions", args, _contextMock.Object, CancellationToken.None);
+
+        result.IsError.Should().BeTrue();
+        result.Content[0].Text.Should().Contain("clusterName is required");
+    }
+
+    [Fact]
+    public async Task SuggestedIndexes_HitsClusterScopedUrl_AndForwardsRawArrays()
+    {
+        const string body = """
+            {
+              "shapes": [{ "namespace": "db.coll", "id": "shape-1", "avgMs": 12.5 }],
+              "suggestedIndexes": [
+                { "namespace": "db.coll", "weight": 740527872, "index": [{ "Lock": 1 }] }
+              ]
+            }
+            """;
+        var (provider, handler) = CreateProvider(new Dictionary<string, string>
+        {
+            ["/api/atlas/v2/groups/group-123/clusters/Cluster0/performanceAdvisor/suggestedIndexes"] = body,
+        });
+        var args = JsonDocument.Parse("""{ "clusterName": "Cluster0" }""").RootElement;
+
+        var result = await provider.CallToolAsync("atlas.get_performance_advisor_suggestions", args, _contextMock.Object, CancellationToken.None);
+
+        result.IsError.Should().BeFalse();
+        var payload = JsonDocument.Parse(result.Content[0].Text).RootElement;
+        payload.GetProperty("cluster").GetString().Should().Be("Cluster0");
+        payload.GetProperty("suggestedIndexes").GetArrayLength().Should().Be(1);
+        payload.GetProperty("shapes").GetArrayLength().Should().Be(1);
+        payload.GetProperty("suggestedIndexes")[0].GetProperty("weight").GetInt64().Should().Be(740527872L);
+
+        handler.Requests.Should().HaveCount(1);
+        handler.Requests[0].RequestUri.PathAndQuery.Should().Be("/api/atlas/v2/groups/group-123/clusters/Cluster0/performanceAdvisor/suggestedIndexes");
+    }
+
+    [Fact]
+    public async Task OpenAlerts_HitsAlertsUrl_WithStatusOpenQuery_AndProjectsResults()
+    {
+        const string body = """
+            {
+              "results": [
+                { "id": "alert-1", "eventTypeName": "OUTSIDE_METRIC_THRESHOLD", "status": "OPEN", "created": "2026-05-09T12:00:00Z", "clusterName": "Cluster0", "hostnameAndPort": "host-1.mongodb.net:27017", "secret": "ignore me" }
+              ]
+            }
+            """;
+        var (provider, handler) = CreateProvider(new Dictionary<string, string>
+        {
+            ["/api/atlas/v2/groups/group-123/alerts?status=OPEN"] = body,
+        });
+
+        var result = await provider.CallToolAsync("atlas.get_open_alerts", JsonDocument.Parse("{}").RootElement, _contextMock.Object, CancellationToken.None);
+
+        result.IsError.Should().BeFalse();
+        var payload = JsonDocument.Parse(result.Content[0].Text).RootElement;
+        var alerts = payload.GetProperty("alerts").EnumerateArray().ToArray();
+        alerts.Should().HaveCount(1);
+        alerts[0].GetProperty("id").GetString().Should().Be("alert-1");
+        alerts[0].GetProperty("eventTypeName").GetString().Should().Be("OUTSIDE_METRIC_THRESHOLD");
+        alerts[0].GetProperty("status").GetString().Should().Be("OPEN");
+        alerts[0].GetProperty("clusterName").GetString().Should().Be("Cluster0");
+        alerts[0].TryGetProperty("secret", out _).Should().BeFalse();
+
+        handler.Requests[0].RequestUri.Query.Should().Contain("status=OPEN");
+    }
+
+    [Fact]
+    public async Task UnknownTool_ReturnsError()
+    {
+        var (provider, _) = CreateProvider(new Dictionary<string, string>());
+
+        var result = await provider.CallToolAsync("atlas.bogus", JsonDocument.Parse("{}").RootElement, _contextMock.Object, CancellationToken.None);
+
+        result.IsError.Should().BeTrue();
+        result.Content[0].Text.Should().Contain("Unknown tool");
+    }
+
+    /// <summary>
+    /// Test-only handler that matches the request URL's PathAndQuery against a canned response map
+    /// and records every outbound request for assertion.
+    /// </summary>
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly IReadOnlyDictionary<string, string> _responses;
+        public List<HttpRequestMessage> Requests { get; } = new();
+
+        public RecordingHandler(Dictionary<string, string> responses)
+        {
+            _responses = responses;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            var key = request.RequestUri.PathAndQuery;
+            if (_responses.TryGetValue(key, out var body))
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json"),
+                });
+            }
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                Content = new StringContent($"no canned response for {key}"),
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds three read-only MongoDB Atlas Administration API v2 tools to `Tharga.MongoDB.Mcp`, opt-in via `MongoDbMcpOptions.Atlas`. Closes the Eplicta request to consolidate Atlas Performance Advisor / alerts diagnostics under MCP so each consumer doesn't re-implement the Atlas REST integration with its own copy of the API keys.

## Tools (System scope, `DataAccessLevel.Metadata`)

- `atlas.list_clusters` — clusters in the configured project (name, type, state, MongoDB version).
- `atlas.get_performance_advisor_suggestions` — Performance Advisor's suggested-index list for a named cluster (the data Eplicta cited as the motivating use case).
- `atlas.get_open_alerts` — currently-firing Atlas alerts.

## Implementation

- New `AtlasV2HttpClient` (internal) — HTTP-Digest auth via `NetworkCredential`, base URL `/api/atlas/v2/`, versioned media type `application/vnd.atlas.2024-08-05+json`. Constructor accepts an optional `HttpMessageHandler` so tests can inject canned responses.
- New `AtlasMongoDbToolProvider` — registered alongside the existing `MongoDbToolProvider` only when `MongoDbMcpOptions.Atlas` is set. Cluster and alert tools project anonymous types with documented fields only; `suggestedIndexes` / `shapes` are passed through as raw `JsonElement` to stay forward-compatible with Atlas's evolving response shape.
- 8 unit tests covering scope, tool list, missing-Atlas error, URL construction, projection, raw-array forwarding, and unknown-tool rejection. Uses a `RecordingHandler` that matches `PathAndQuery` against canned JSON — no real HTTP.
- Both READMEs updated with config sample and tool table.

Phase 2 will add `drop_index_suggestions`, `schema_advice`, `slow_query_log`, and `cluster_metrics`, driven by the next bottleneck Eplicta hits.

## API impact

- New public property `MongoDbMcpOptions.Atlas` (`MongoDbApiAccess`, nullable). Existing consumers see no behavior change unless they set it.
- New internal types `AtlasV2HttpClient`, `AtlasMongoDbToolProvider` — not part of the public API surface.

## Test plan

- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [x] `dotnet test --filter \"Category!=Database\"` — 176 / 176 pass (was 168, +8 Atlas tests)
- [ ] Pre-release artifacts publish from this PR
- [ ] Eplicta upgrades to the prerelease and confirms the three tools work against their Atlas project
- [ ] After merge, CI releases next stable; reply on Eplicta `requests.md` with version + Phase 1 tool list, and queue Phase 2 (`drop_index_suggestions`, `schema_advice`, `slow_query_log`, `cluster_metrics`) as follow-ups