### PR TITLE
feat(monitor-client): IServiceCollection overload of AddMongoDbMonitorClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,6 +695,16 @@ builder.AddMongoDB();
 builder.AddMongoDbMonitorClient(sendTo: "https://monitor-server");
 ```
 
+For hosts that only expose `IServiceCollection` at registration time — for example a `Tharga.Wpf` agent whose `App.Register(HostBuilderContext context, IServiceCollection services)` callback has no builder in scope — use the `IServiceCollection` overload:
+
+```csharp
+services.AddMongoDbMonitorClient(
+    configuration: context.Configuration,
+    sendTo: "https://monitor-server");
+```
+
+Both overloads behave identically once `sendTo` is set.
+
 The forwarder subscribes to call events and sends `CallDto` via fire-and-forget. When the server is unavailable or not configured, there is zero overhead. The hub endpoint defaults to `/mongodb-monitor`.
 
 ### Receiving remote monitoring data

--- a/Tharga.MongoDB.Monitor.Client/MonitorClientRegistration.cs
+++ b/Tharga.MongoDB.Monitor.Client/MonitorClientRegistration.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Linq;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Tharga.Communication.Client;
@@ -54,5 +56,34 @@ public static class MonitorClientRegistration
         builder.Services.AddHostedService<MonitorForwarder>();
 
         return builder;
+    }
+
+    /// <summary>
+    /// <see cref="IServiceCollection"/> overload of <see cref="AddMongoDbMonitorClient(IHostApplicationBuilder, string, string)"/>
+    /// for hosts that only expose <see cref="IServiceCollection"/> at registration time — for example
+    /// Tharga.Wpf, whose <c>App.Register(HostBuilderContext context, IServiceCollection services)</c>
+    /// signature has no builder in scope. Delegates to the builder overload via a minimal
+    /// <see cref="ServicesOnlyHostApplicationBuilder"/> adapter so there is no logic duplication.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configuration">The application configuration. Used by Tharga.Communication to read its <c>Tharga:Communication</c> section. Registered as <see cref="IConfiguration"/> on <paramref name="services"/> if not already there.</param>
+    /// <param name="sendTo">The server URL to connect to. Required.</param>
+    /// <param name="apiKey">Optional API key for authenticating with the server.</param>
+    public static IServiceCollection AddMongoDbMonitorClient(this IServiceCollection services, IConfiguration configuration, string sendTo = null, string apiKey = null)
+    {
+        if (services == null) throw new ArgumentNullException(nameof(services));
+
+        // Tharga.Communication 0.1.5's AddThargaCommunicationClient pulls IConfiguration via
+        // services.BuildServiceProvider().GetService<IConfiguration>(). Register the caller's
+        // IConfiguration if nothing is registered yet — typical IHostApplicationBuilder hosts
+        // register it before user callbacks run, but minimal IServiceCollection hosts may not.
+        if (configuration != null && services.All(d => d.ServiceType != typeof(IConfiguration)))
+        {
+            services.AddSingleton(configuration);
+        }
+
+        var builder = new ServicesOnlyHostApplicationBuilder(services);
+        builder.AddMongoDbMonitorClient(sendTo, apiKey);
+        return services;
     }
 }

--- a/Tharga.MongoDB.Monitor.Client/README.md
+++ b/Tharga.MongoDB.Monitor.Client/README.md
@@ -15,7 +15,16 @@ builder.AddMongoDbMonitorClient(
     apiKey: builder.Configuration["MongoMonitor:ApiKey"]);     // optional, must match one of the server's primary/secondary keys
 ```
 
-If `sendTo` is null/empty the client is a no-op — convenient for local dev.
+For hosts that only expose `IServiceCollection` at registration time — for example a `Tharga.Wpf`-based agent whose `App.Register(HostBuilderContext context, IServiceCollection services)` callback has no builder in scope — use the `IServiceCollection` overload instead:
+
+```csharp
+services.AddMongoDbMonitorClient(
+    configuration: context.Configuration,
+    sendTo: "https://monitor.example.com/",
+    apiKey: context.Configuration["MongoMonitor:ApiKey"]);
+```
+
+If `sendTo` is null/empty the client is a no-op — convenient for local dev. Both overloads behave identically once `sendTo` is set.
 
 ## What it sends
 

--- a/Tharga.MongoDB.Monitor.Client/ServicesOnlyHostApplicationBuilder.cs
+++ b/Tharga.MongoDB.Monitor.Client/ServicesOnlyHostApplicationBuilder.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Tharga.MongoDB.Monitor.Client;
+
+/// <summary>
+/// Minimal <see cref="IHostApplicationBuilder"/> adapter used by the
+/// <see cref="MonitorClientRegistration.AddMongoDbMonitorClient(IServiceCollection, IConfiguration, string, string)"/>
+/// overload to delegate to the existing builder-based overload without duplicating
+/// any of its body. Exposes only <see cref="Services"/> and <see cref="Properties"/>
+/// because that is what <c>AddMongoDbMonitorClient</c> and Tharga.Communication's
+/// <c>AddThargaCommunicationClient</c> (0.1.5) actually use. Other members throw
+/// <see cref="NotSupportedException"/> so future upstream changes that start using
+/// them fail loudly and visibly rather than silently misbehaving.
+/// </summary>
+internal sealed class ServicesOnlyHostApplicationBuilder : IHostApplicationBuilder
+{
+    public ServicesOnlyHostApplicationBuilder(IServiceCollection services)
+    {
+        Services = services ?? throw new ArgumentNullException(nameof(services));
+        Properties = new Dictionary<object, object>();
+    }
+
+    public IServiceCollection Services { get; }
+
+    public IDictionary<object, object> Properties { get; }
+
+    private const string NotSupportedMessage =
+        "ServicesOnlyHostApplicationBuilder is a services-only adapter used internally by AddMongoDbMonitorClient(IServiceCollection, ...). "
+        + "Only Services and Properties are supported.";
+
+    public IConfigurationManager Configuration => throw new NotSupportedException(NotSupportedMessage);
+
+    public IHostEnvironment Environment => throw new NotSupportedException(NotSupportedMessage);
+
+    public ILoggingBuilder Logging => throw new NotSupportedException(NotSupportedMessage);
+
+    public IMetricsBuilder Metrics => throw new NotSupportedException(NotSupportedMessage);
+
+    public void ConfigureContainer<TContainerBuilder>(IServiceProviderFactory<TContainerBuilder> factory, Action<TContainerBuilder> configure = null)
+        where TContainerBuilder : notnull
+        => throw new NotSupportedException(NotSupportedMessage);
+}

--- a/Tharga.MongoDB.Tests/MonitorClientRegistrationTests.cs
+++ b/Tharga.MongoDB.Tests/MonitorClientRegistrationTests.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Tharga.Communication.Client;
+using Tharga.MongoDB.Monitor.Client;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests;
+
+public class MonitorClientRegistrationTests
+{
+    private static IConfiguration EmptyConfiguration()
+        => new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>()).Build();
+
+    [Fact]
+    public void OnServices_RegistersMonitorForwarder()
+    {
+        var services = new ServiceCollection();
+
+        services.AddMongoDbMonitorClient(EmptyConfiguration(), sendTo: "https://hub.example/monitor");
+
+        services.Should().Contain(d => d.ServiceType == typeof(IHostedService) && d.ImplementationType == typeof(MonitorForwarder));
+    }
+
+    [Fact]
+    public void OnServices_RegistersConfigurationIfMissing()
+    {
+        var services = new ServiceCollection();
+        var config = EmptyConfiguration();
+
+        services.AddMongoDbMonitorClient(config, sendTo: "https://hub.example/monitor");
+
+        var registered = services.FirstOrDefault(d => d.ServiceType == typeof(IConfiguration));
+        registered.Should().NotBeNull("IConfiguration should be registered so Tharga.Communication can resolve it");
+        registered!.ImplementationInstance.Should().BeSameAs(config);
+    }
+
+    [Fact]
+    public void OnServices_DoesNotOverrideExistingConfiguration()
+    {
+        var services = new ServiceCollection();
+        var existing = EmptyConfiguration();
+        services.AddSingleton<IConfiguration>(existing);
+
+        var fresh = EmptyConfiguration();
+        services.AddMongoDbMonitorClient(fresh, sendTo: "https://hub.example/monitor");
+
+        var registered = services.First(d => d.ServiceType == typeof(IConfiguration));
+        registered.ImplementationInstance.Should().BeSameAs(existing, "the existing IConfiguration registration must not be replaced");
+    }
+
+    [Fact]
+    public void OnServices_SkipsWhenSendToIsEmpty()
+    {
+        var services = new ServiceCollection();
+
+        services.AddMongoDbMonitorClient(EmptyConfiguration(), sendTo: null);
+
+        services.Should().NotContain(d => d.ImplementationType == typeof(MonitorForwarder),
+            "with no sendTo the registration is a no-op, matching the existing builder overload");
+    }
+
+    [Fact]
+    public void OnServices_PassesSendToAndApiKeyToCommunicationOptions()
+    {
+        var services = new ServiceCollection();
+
+        services.AddMongoDbMonitorClient(
+            EmptyConfiguration(),
+            sendTo: "https://hub.example/monitor",
+            apiKey: "secret-key");
+
+        var options = services.BuildServiceProvider().GetRequiredService<IOptions<Tharga.Communication.Client.CommunicationOptions>>().Value;
+        options.ServerAddress.Should().Be("https://hub.example/monitor");
+        options.ApiKey.Should().Be("secret-key");
+        options.Pattern.Should().Be(MonitorConstants.DefaultHubPattern);
+    }
+}


### PR DESCRIPTION
Closes #97.

## Summary

Hosts that only expose `IServiceCollection` at registration time — for example `Tharga.Wpf`, whose `App.Register(HostBuilderContext context, IServiceCollection services)` signature has no builder in scope — now have a clean path to wire up the monitor client.

New overload:

```csharp
IServiceCollection AddMongoDbMonitorClient(
    this IServiceCollection services,
    IConfiguration configuration,
    string sendTo = null,
    string apiKey = null);
```

Delegates to the existing `IHostApplicationBuilder` overload via a minimal `ServicesOnlyHostApplicationBuilder` adapter so there is zero logic duplication. The adapter exposes `Services` and `Properties`; every other member throws `NotSupportedException` so future `Tharga.Communication` changes that rely on `Configuration` / `Environment` / `Logging` / `Metrics` fail loudly rather than silently.

`IConfiguration` is registered on the services collection only when the caller hasn't already done so — typical `IHostApplicationBuilder` hosts register it before user callbacks run; minimal `IServiceCollection` hosts may not.

## Tests

5 new unit tests in `MonitorClientRegistrationTests.cs`:
- `OnServices_RegistersMonitorForwarder`
- `OnServices_RegistersConfigurationIfMissing`
- `OnServices_DoesNotOverrideExistingConfiguration`
- `OnServices_SkipsWhenSendToIsEmpty`
- `OnServices_PassesSendToAndApiKeyToCommunicationOptions` — end-to-end verification that the delegated path carries the args through to `Tharga.Communication.Client.CommunicationOptions`.

(Caught a gotcha while writing the last one: two `CommunicationOptions` types in scope — `Tharga.Communication.Client.CommunicationOptions` plus a global-namespace one. The test fully qualifies; production code is unaffected.)

## READMEs

Both `Tharga.MongoDB.Monitor.Client/README.md` and the main `README.md` show both overloads with the `Tharga.Wpf` usage shape.

## Test plan

- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [x] `dotnet test --filter \"Category!=Database\"` — 181 / 181 pass (was 176, +5 new)
- [ ] Pre-release artifacts publish from this PR
- [ ] Eplicta picks up the prerelease and confirms the WPF agent wires up
- [ ] After merge, CI releases the next stable patch; comment release version on #97