### PR TITLE
feat(lockable): standalone renewable lock mechanism (short lease + ExtendAsync / keep-alive)

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,20 @@ If a consumer's query pattern adds extra fields (e.g. `{Lock: 1, State: 1}` for 
 
 For collections that pre-date the upgrade and are missing these indexes in production, see [Re-applying indexes after a code change](#re-applying-indexes-after-a-code-change) — the `RestoreAllIndicesAsync` API, the *Assure all indices* Blazor toolbar action, and the `mongodb.restore_all_indexes` MCP tool all force a re-apply across tracked collections.
 
+##### Renewable locks (lease renewal / keep-alive)
+
+For work whose duration is unpredictable, `RenewableLockRepositoryCollectionBase<TEntity, TKey>` (namespace `Tharga.MongoDB.Lockable.Renewable`) is a standalone variant where the lease can be set short and the lock owner extends it until finished — a lock always expires unless the owner asks for more time, so crash recovery is bounded by the short lease while healthy long jobs keep renewing:
+
+```csharp
+await using var scope = await collection.PickForDeleteAsync(id, TimeSpan.FromMinutes(5), actor);
+await using var keepAlive = scope.StartKeepAlive(new LockKeepAliveOptions { MaxTotalDuration = TimeSpan.FromHours(2) });
+// link scope.LockLost into the job's CancellationToken to abort early if the lock is ever stolen
+await RunLongJobAsync(scope.Entity);
+await scope.CommitAsync();
+```
+
+It mirrors `ILockableRepositoryCollection` one to one (scopes inherit `EntityScope`/`LockScope`, adding `ExtendAsync`, `StartKeepAlive` and a `LockLost` token), shares the on-disk lock format so both implementations interoperate on the same collections, and swapping in (or back) is just changing the repository collection's base class. See [Renewable lockable collections](https://mongodb.tharga.net/articles/renewable-lockable-collections.html) for the full semantics.
+
 ---
 
 ### Transactions

--- a/Tharga.MongoDB.Tests/Lockable/Renewable/Base/RenewableLockableTestBase.cs
+++ b/Tharga.MongoDB.Tests/Lockable/Renewable/Base/RenewableLockableTestBase.cs
@@ -1,0 +1,13 @@
+using Tharga.MongoDB.Tests.Lockable.Base;
+
+namespace Tharga.MongoDB.Tests.Lockable.Renewable.Base;
+
+/// <summary>
+/// Shared base for renewable-lock tests. Reuses the Mongo/service-factory wiring and per-test
+/// database teardown from <see cref="LockableTestBase"/>; renewable tests construct a
+/// <see cref="RenewableLockableTestRepositoryCollection"/> (or the strict variant) against the
+/// inherited factory.
+/// </summary>
+public abstract class RenewableLockableTestBase : LockableTestBase
+{
+}

--- a/Tharga.MongoDB.Tests/Lockable/Renewable/Base/RenewableLockableTestRepositoryCollection.cs
+++ b/Tharga.MongoDB.Tests/Lockable/Renewable/Base/RenewableLockableTestRepositoryCollection.cs
@@ -1,0 +1,15 @@
+using MongoDB.Bson;
+using Tharga.MongoDB.Lockable.Renewable;
+using Tharga.MongoDB.Tests.Support;
+
+namespace Tharga.MongoDB.Tests.Lockable.Renewable.Base;
+
+internal class RenewableLockableTestRepositoryCollection : RenewableLockRepositoryCollectionBase<LockableTestEntity, ObjectId>
+{
+    public RenewableLockableTestRepositoryCollection(IMongoDbServiceFactory mongoDbServiceFactory)
+        : base(mongoDbServiceFactory)
+    {
+    }
+
+    protected override bool RequireActor => false;
+}

--- a/Tharga.MongoDB.Tests/Lockable/Renewable/Base/StrictRenewableLockableTestRepositoryCollection.cs
+++ b/Tharga.MongoDB.Tests/Lockable/Renewable/Base/StrictRenewableLockableTestRepositoryCollection.cs
@@ -1,0 +1,22 @@
+using MongoDB.Bson;
+using Tharga.MongoDB.Lockable.Renewable;
+using Tharga.MongoDB.Tests.Support;
+
+namespace Tharga.MongoDB.Tests.Lockable.Renewable.Base;
+
+/// <summary>
+/// Test-only renewable collection pinned to strict-TTL behaviour by overriding
+/// AllowDelayedCommit, mirroring the StrictTtlTestRepositoryCollection used by the
+/// non-renewable DelayedCommitTests. Used to verify that an expired renewal throws
+/// LockExpiredException on a strict collection.
+/// </summary>
+internal sealed class StrictRenewableLockableTestRepositoryCollection : RenewableLockRepositoryCollectionBase<LockableTestEntity, ObjectId>
+{
+    public StrictRenewableLockableTestRepositoryCollection(IMongoDbServiceFactory mongoDbServiceFactory)
+        : base(mongoDbServiceFactory)
+    {
+    }
+
+    protected override bool RequireActor => false;
+    protected override bool AllowDelayedCommit => false;
+}

--- a/Tharga.MongoDB.Tests/Lockable/Renewable/ExtendLockTests.cs
+++ b/Tharga.MongoDB.Tests/Lockable/Renewable/ExtendLockTests.cs
@@ -1,0 +1,287 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Bson;
+using Tharga.MongoDB.Lockable;
+using Tharga.MongoDB.Lockable.Renewable;
+using Tharga.MongoDB.Tests.Lockable.Renewable.Base;
+using Tharga.MongoDB.Tests.Support;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests.Lockable.Renewable;
+
+/// <summary>
+/// Contract tests for ExtendLockAsync / RenewableEntityScope.ExtendAsync.
+/// All timing constants are intentionally generous so the suite stays green on a loaded CI machine.
+/// </summary>
+[Collection("Sequential")]
+[CollectionDefinition("Sequential", DisableParallelization = true)]
+public class ExtendLockTests : RenewableLockableTestBase
+{
+    // ---- timing constants (generous for CI) ----
+    private static readonly TimeSpan ShortLease = TimeSpan.FromMilliseconds(200);
+    private static readonly TimeSpan PastOriginalLease = TimeSpan.FromMilliseconds(600);
+    private static readonly TimeSpan LongExtension = TimeSpan.FromSeconds(30);
+
+    // ---- helpers ----
+    private static LockableTestEntity NewEntity(string data = "initial") =>
+        new() { Id = ObjectId.GenerateNewId(), Data = data };
+
+    // ---------------------------------------------------------------
+    // 1. ExtendAsync moves ExpireTime; strict-TTL commit still succeeds.
+    // ---------------------------------------------------------------
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task ExtendAsync_MovesExpireTime_AndStrictCommitSucceeds()
+    {
+        var sut = new StrictRenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = NewEntity();
+        await sut.AddAsync(entity);
+
+        await using var scope = await sut.PickForUpdateAsync(entity.Id, timeout: ShortLease);
+
+        var newExpiry = await scope.ExtendAsync(LongExtension);
+
+        // The returned expiry should be well past the original lease.
+        newExpiry.Should().BeAfter(DateTime.UtcNow.Add(ShortLease));
+
+        // Verify that the in-DB ExpireTime actually moved.
+        var midFlight = await sut.GetWithLockInfoAsync().FirstAsync();
+        midFlight.Lock.ExpireTime.Should().BeCloseTo(newExpiry, TimeSpan.FromSeconds(2));
+
+        // Wait past the original (un-extended) TTL.
+        await Task.Delay(PastOriginalLease);
+
+        // Strict collection: commit should succeed because the extension is still valid.
+        var updated = scope.Entity with { Data = "extended-then-committed", Count = 1 };
+        var committed = await scope.CommitAsync(updated);
+
+        committed.Data.Should().Be("extended-then-committed");
+        committed.Count.Should().Be(1);
+        var post = await sut.GetOneAsync(entity.Id);
+        post.Data.Should().Be("extended-then-committed");
+        post.Lock.Should().BeNull();
+    }
+
+    // ---------------------------------------------------------------
+    // 2. ExtendAsync throws LockLostException when another actor stole the lock.
+    //    LockLost token must be cancelled as a side-effect.
+    // ---------------------------------------------------------------
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task ExtendAsync_Throws_LockLost_WhenStolen()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = NewEntity();
+        await sut.AddAsync(entity);
+
+        // First actor picks with a short lease.
+        var firstScope = await sut.PickForUpdateAsync(entity.Id, timeout: ShortLease);
+
+        // Wait past TTL so the document becomes available for re-pick.
+        await Task.Delay(PastOriginalLease);
+
+        // Second actor steals the lock.
+        await using var secondScope = await sut.PickForUpdateAsync(entity.Id, timeout: LongExtension);
+        secondScope.Should().NotBeNull();
+
+        // First actor tries to extend — must throw LockLostException.
+        Func<Task> act = () => firstScope.ExtendAsync(LongExtension);
+        await act.Should().ThrowAsync<LockLostException>();
+
+        // LockLost token must be cancelled after a LockLostException.
+        firstScope.LockLost.IsCancellationRequested.Should().BeTrue();
+
+        await secondScope.CommitAsync(secondScope.Entity with { Data = "stolen" });
+    }
+
+    // ---------------------------------------------------------------
+    // 3. ExtendAsync throws LockLostException when document was deleted externally.
+    // ---------------------------------------------------------------
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task ExtendAsync_Throws_LockLost_WhenDocumentDeleted()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = NewEntity();
+        await sut.AddAsync(entity);
+
+        var scope = await sut.PickForUpdateAsync(entity.Id, timeout: LongExtension);
+
+        // External delete bypasses the lock.
+        await sut.DeleteManyAsync(DeleteMode.Any);
+
+        Func<Task> act = () => scope.ExtendAsync(LongExtension);
+        await act.Should().ThrowAsync<LockLostException>();
+    }
+
+    // ---------------------------------------------------------------
+    // 4. ExtendAsync succeeds on a non-strict collection even when the lock has expired
+    //    but has NOT been stolen (LockKey still matches).
+    // ---------------------------------------------------------------
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task ExtendAsync_Succeeds_WhenExpiredButNotStolen()
+    {
+        // RenewableLockableTestRepositoryCollection is non-strict (AllowDelayedCommit = true).
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = NewEntity();
+        await sut.AddAsync(entity);
+
+        await using var scope = await sut.PickForUpdateAsync(entity.Id, timeout: ShortLease);
+
+        // Let the lease expire without another actor touching it.
+        await Task.Delay(PastOriginalLease);
+
+        // Non-strict: extension of an expired-but-not-stolen lock must succeed.
+        Func<Task> act = () => scope.ExtendAsync(LongExtension);
+        await act.Should().NotThrowAsync();
+
+        // Lock should not be lost.
+        scope.LockLost.IsCancellationRequested.Should().BeFalse();
+
+        await scope.CommitAsync(scope.Entity with { Data = "extended-after-expiry" });
+    }
+
+    // ---------------------------------------------------------------
+    // 5. ExtendAsync on a STRICT collection throws LockExpiredException when the lease
+    //    has expired (lock is intact — LockLost must NOT be cancelled).
+    // ---------------------------------------------------------------
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task ExtendAsync_Throws_LockExpired_WhenExpired_OnStrictCollection()
+    {
+        var sut = new StrictRenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = NewEntity();
+        await sut.AddAsync(entity);
+
+        var scope = await sut.PickForUpdateAsync(entity.Id, timeout: ShortLease);
+
+        await Task.Delay(PastOriginalLease);
+
+        Func<Task> act = () => scope.ExtendAsync(LongExtension);
+        await act.Should().ThrowAsync<LockExpiredException>();
+
+        // LockExpiredException is NOT a lock-lost event; the token must remain un-cancelled.
+        scope.LockLost.IsCancellationRequested.Should().BeFalse();
+    }
+
+    // ---------------------------------------------------------------
+    // 6. ExtendAsync throws LockAlreadyReleasedException after the scope has been committed.
+    // ---------------------------------------------------------------
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task ExtendAsync_Throws_LockAlreadyReleased_AfterCommit()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = NewEntity();
+        await sut.AddAsync(entity);
+
+        var scope = await sut.PickForUpdateAsync(entity.Id, timeout: LongExtension);
+        await scope.CommitAsync(scope.Entity with { Data = "committed" });
+
+        Func<Task> act = () => scope.ExtendAsync(LongExtension);
+        await act.Should().ThrowAsync<LockAlreadyReleasedException>();
+    }
+
+    // ---------------------------------------------------------------
+    // 7. ExtendAsync prevents an about-to-expire lock from being picked by another actor.
+    // ---------------------------------------------------------------
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task ExtendAsync_PreventsExpiredPickup()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = NewEntity();
+        await sut.AddAsync(entity);
+
+        await using var scope = await sut.PickForUpdateAsync(entity.Id, timeout: ShortLease);
+
+        // Extend before the lock expires so it will be valid for another 30 s.
+        await scope.ExtendAsync(LongExtension);
+
+        // A second actor must NOT be able to pick the (now extended) lock.
+        Func<Task> act = () => sut.PickForUpdateAsync(entity.Id, timeout: ShortLease);
+        await act.Should().ThrowAsync<LockException>("the lock is still valid after extension");
+
+        await scope.CommitAsync(scope.Entity with { Data = "protected" });
+    }
+
+    // ---------------------------------------------------------------
+    // 8. ExtendAsync on a RenewableLockScope (LockAsync path) works; commit succeeds after extension past original TTL.
+    // ---------------------------------------------------------------
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task ExtendAsync_OnRenewableLockScope_Works()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = NewEntity();
+        await sut.AddAsync(entity);
+
+        await using var scope = await sut.LockAsync(entity.Id, timeout: ShortLease);
+
+        var newExpiry = await scope.ExtendAsync(LongExtension);
+        newExpiry.Should().BeAfter(DateTime.UtcNow.Add(ShortLease));
+
+        // Wait past original TTL.
+        await Task.Delay(PastOriginalLease);
+
+        var updated = scope.Entity with { Data = "lockscope-extended" };
+        var committed = await scope.CommitAsync(CommitMode.Update, updated);
+
+        committed.Data.Should().Be("lockscope-extended");
+        var post = await sut.GetOneAsync(entity.Id);
+        post.Lock.Should().BeNull();
+    }
+
+    // ---------------------------------------------------------------
+    // 9. ExtendAsync with zero or negative extension throws ArgumentException.
+    //    This is a pure-logic guard; no Mongo round-trip needed.
+    //    Assumption: ArgumentException is thrown synchronously before any DB call.
+    // ---------------------------------------------------------------
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task ExtendAsync_NegativeOrZeroExtension_ThrowsArgumentException()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = NewEntity();
+        await sut.AddAsync(entity);
+
+        await using var scope = await sut.PickForUpdateAsync(entity.Id, timeout: LongExtension);
+
+        Func<Task> zeroAct = () => scope.ExtendAsync(TimeSpan.Zero);
+        await zeroAct.Should().ThrowAsync<ArgumentException>();
+
+        Func<Task> negativeAct = () => scope.ExtendAsync(TimeSpan.FromSeconds(-1));
+        await negativeAct.Should().ThrowAsync<ArgumentException>();
+
+        // Scope should still be usable after the guard throws.
+        await scope.CommitAsync(scope.Entity with { Data = "after-guard-throws" });
+    }
+
+    // ---------------------------------------------------------------
+    // 10. Regression: renewal then external delete; commit surfaces the 'Cannot find entity' error.
+    // ---------------------------------------------------------------
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task Renew_Then_DeleteDocument_Then_Commit_SurfacesCannotFindEntity()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = NewEntity();
+        await sut.AddAsync(entity);
+
+        var scope = await sut.PickForUpdateAsync(entity.Id, timeout: LongExtension);
+
+        // Extend successfully while the document still exists.
+        await scope.ExtendAsync(LongExtension);
+
+        // External delete after the successful extension.
+        await sut.DeleteManyAsync(DeleteMode.Any);
+
+        // Commit must surface an error about the missing entity, not silently succeed or mask with a renewal error.
+        Func<Task> act = () => scope.CommitAsync(scope.Entity with { Data = "should-fail" });
+        await act.Should().ThrowAsync<InvalidOperationException>(
+            because: "the document no longer exists; commit must report the missing entity");
+    }
+}

--- a/Tharga.MongoDB.Tests/Lockable/Renewable/KeepAliveTests.cs
+++ b/Tharga.MongoDB.Tests/Lockable/Renewable/KeepAliveTests.cs
@@ -1,0 +1,234 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Bson;
+using Tharga.MongoDB.Lockable;
+using Tharga.MongoDB.Lockable.Renewable;
+using Tharga.MongoDB.Tests.Lockable.Renewable.Base;
+using Tharga.MongoDB.Tests.Support;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests.Lockable.Renewable;
+
+/// <summary>
+/// Contract tests for StartKeepAlive / the background renewal loop.
+/// All timing constants are intentionally generous so the suite stays green on a loaded CI machine.
+/// </summary>
+[Collection("Sequential")]
+[CollectionDefinition("Sequential", DisableParallelization = true)]
+public class KeepAliveTests : RenewableLockableTestBase
+{
+    // ---- timing constants (generous for CI) ----
+
+    /// <summary>Short lease that expires quickly, forcing renewal to be meaningful.</summary>
+    private static readonly TimeSpan ShortLease = TimeSpan.FromMilliseconds(250);
+
+    /// <summary>Keep-alive interval: renew every ~80 ms (< ShortLease / 3).</summary>
+    private static readonly TimeSpan KeepAliveInterval = TimeSpan.FromMilliseconds(80);
+
+    /// <summary>How long to hold the lock under keep-alive in the happy-path test (6 × lease).</summary>
+    private static readonly TimeSpan HoldDuration = TimeSpan.FromMilliseconds(1500);
+
+    /// <summary>A generous window to allow background tasks to react after a trigger.</summary>
+    private static readonly TimeSpan ReactionWindow = TimeSpan.FromMilliseconds(1000);
+
+    /// <summary>A lock timeout long enough that it does not interfere with the test logic.</summary>
+    private static readonly TimeSpan LongLease = TimeSpan.FromSeconds(30);
+
+    // ---- helpers ----
+    private static LockableTestEntity NewEntity(string data = "initial") =>
+        new() { Id = ObjectId.GenerateNewId(), Data = data };
+
+    // ---------------------------------------------------------------
+    // 1. Keep-alive carries a strict-TTL commit past many lease cycles.
+    // ---------------------------------------------------------------
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task StartKeepAlive_CarriesStrictCommitPastManyLeases()
+    {
+        var sut = new StrictRenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = NewEntity();
+        await sut.AddAsync(entity);
+
+        await using var scope = await sut.PickForUpdateAsync(entity.Id, timeout: ShortLease);
+
+        var options = new LockKeepAliveOptions
+        {
+            Interval = KeepAliveInterval,
+            Extension = ShortLease
+        };
+        await using var keepAlive = scope.StartKeepAlive(options);
+
+        // Hold well past a single lease cycle.
+        await Task.Delay(HoldDuration);
+
+        // Strict collection: commit must succeed because keep-alive kept renewing.
+        var updated = scope.Entity with { Data = "keep-alive-committed", Count = 99 };
+        var committed = await scope.CommitAsync(updated);
+
+        committed.Data.Should().Be("keep-alive-committed");
+        committed.Count.Should().Be(99);
+        var post = await sut.GetOneAsync(entity.Id);
+        post.Lock.Should().BeNull();
+    }
+
+    // ---------------------------------------------------------------
+    // 2. After abandon, the lock is released; ExpireTime does not advance further.
+    // ---------------------------------------------------------------
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task StartKeepAlive_StopsOnAbandon_LockReleased()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = NewEntity();
+        await sut.AddAsync(entity);
+
+        var scope = await sut.PickForUpdateAsync(entity.Id, timeout: ShortLease);
+        var options = new LockKeepAliveOptions { Interval = KeepAliveInterval, Extension = ShortLease };
+        await using var keepAlive = scope.StartKeepAlive(options);
+
+        // Let the loop tick a couple of times.
+        await Task.Delay(KeepAliveInterval * 3);
+
+        // Abandon — this stops the keep-alive loop via StopAsync.
+        await scope.AbandonAsync();
+
+        // Lock must be cleared immediately.
+        var post = await sut.GetOneAsync(entity.Id);
+        post.Lock.Should().BeNull("abandoning the scope must clear the lock regardless of keep-alive");
+
+        // Give the loop a moment to prove it does NOT advance ExpireTime after release.
+        await Task.Delay(KeepAliveInterval * 3);
+
+        // The document has no lock; no further renewals can have occurred.
+        var postPost = await sut.GetOneAsync(entity.Id);
+        postPost.Lock.Should().BeNull();
+    }
+
+    // ---------------------------------------------------------------
+    // 3. LockLost is cancelled within a few keep-alive intervals when another actor steals the lock.
+    // ---------------------------------------------------------------
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task StartKeepAlive_CancelsLockLost_WhenStolen()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = NewEntity();
+        await sut.AddAsync(entity);
+
+        var firstScope = await sut.PickForUpdateAsync(entity.Id, timeout: ShortLease);
+
+        Exception caughtFailure = null;
+        var options = new LockKeepAliveOptions
+        {
+            Interval = KeepAliveInterval,
+            Extension = ShortLease,
+            OnRenewalFailure = ex => caughtFailure = ex
+        };
+        await using var keepAlive = firstScope.StartKeepAlive(options);
+
+        // Force-release the document so another actor can pick it.
+        await sut.ReleaseOneAsync(entity.Id, ReleaseMode.LockedOnly);
+
+        // Second actor picks with a long lease so the first actor's next renewal attempt will find a mismatched LockKey.
+        await using var secondScope = await sut.PickForUpdateAsync(entity.Id, timeout: LongLease);
+
+        // Wait for the keep-alive loop to attempt a renewal and detect the mismatch.
+        await Task.Delay(KeepAliveInterval * 4 + ReactionWindow);
+
+        firstScope.LockLost.IsCancellationRequested.Should().BeTrue(
+            "the keep-alive loop must cancel LockLost when a renewal finds the lock has been stolen");
+
+        caughtFailure.Should().BeOfType<LockLostException>(
+            "OnRenewalFailure must be invoked with LockLostException on a stolen lock");
+
+        await secondScope.CommitAsync(secondScope.Entity with { Data = "stolen-and-committed" });
+    }
+
+    // ---------------------------------------------------------------
+    // 4. Anti-zombie cap: keep-alive stops after MaxTotalDuration; another actor can then pick.
+    // ---------------------------------------------------------------
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task StartKeepAlive_MaxTotalDuration_StopsRenewing_OtherActorCanPick()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = NewEntity();
+        await sut.AddAsync(entity);
+
+        await using var scope = await sut.PickForUpdateAsync(entity.Id, timeout: ShortLease);
+
+        // Set MaxTotalDuration to just over one keep-alive interval so the cap triggers quickly.
+        var cap = KeepAliveInterval * 2;
+        var options = new LockKeepAliveOptions
+        {
+            Interval = KeepAliveInterval,
+            Extension = ShortLease,
+            MaxTotalDuration = cap
+        };
+        await using var keepAlive = scope.StartKeepAlive(options);
+
+        // Wait for the cap to fire and for the lock to expire naturally (no more renewals).
+        await Task.Delay(cap + ShortLease + ReactionWindow);
+
+        // The lock is expired and no longer being renewed — another actor must be able to pick it.
+        var secondScope = await sut.PickForUpdateAsync(entity.Id, timeout: LongLease);
+        secondScope.Should().NotBeNull("once the anti-zombie cap stops renewals the lock must be acquirable again");
+        await secondScope.CommitAsync(secondScope.Entity with { Data = "zombie-capped" });
+    }
+
+    // ---------------------------------------------------------------
+    // 5. StartKeepAlive called a second time throws InvalidOperationException.
+    // ---------------------------------------------------------------
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task StartKeepAlive_CalledTwice_ThrowsInvalidOperation()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = NewEntity();
+        await sut.AddAsync(entity);
+
+        await using var scope = await sut.PickForUpdateAsync(entity.Id, timeout: LongLease);
+
+        await using var firstHandle = scope.StartKeepAlive(new LockKeepAliveOptions { Interval = KeepAliveInterval });
+
+        Action act = () => scope.StartKeepAlive(new LockKeepAliveOptions { Interval = KeepAliveInterval });
+        act.Should().Throw<InvalidOperationException>("keep-alive may only be started once per scope");
+
+        await scope.CommitAsync(scope.Entity with { Data = "started-twice-guard" });
+    }
+
+    // ---------------------------------------------------------------
+    // 6. Releasing a scope while a renewal is in-flight must not throw from either side,
+    //    and the final DB state must be Lock == null.
+    // ---------------------------------------------------------------
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task Release_WhileRenewalInFlight_NeitherThrows_LockEndsNull()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = NewEntity();
+        await sut.AddAsync(entity);
+
+        // Very tight interval to maximise the chance of a race between renewal and release.
+        var tightOptions = new LockKeepAliveOptions
+        {
+            Interval = TimeSpan.FromMilliseconds(50),
+            Extension = LongLease
+        };
+
+        var scope = await sut.PickForUpdateAsync(entity.Id, timeout: LongLease);
+        await using var keepAlive = scope.StartKeepAlive(tightOptions);
+
+        // Release concurrently while the loop is busy renewing.
+        Func<Task> releaseAct = () => scope.AbandonAsync();
+        await releaseAct.Should().NotThrowAsync("release must never throw even when a renewal is in-flight");
+
+        // Give the loop a moment to fully drain.
+        await Task.Delay(TimeSpan.FromMilliseconds(200));
+
+        var post = await sut.GetOneAsync(entity.Id);
+        post.Lock.Should().BeNull("the lock must be cleared after abandon regardless of concurrent renewals");
+    }
+}

--- a/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableDelayedCommitTests.cs
+++ b/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableDelayedCommitTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Bson;
+using Tharga.MongoDB.Lockable;
+using Tharga.MongoDB.Tests.Lockable.Renewable.Base;
+using Tharga.MongoDB.Tests.Support;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests.Lockable.Renewable;
+
+/// <summary>
+/// Renewable port of <see cref="Tharga.MongoDB.Tests.Lockable.DelayedCommitTests"/>.
+/// Pins the AllowDelayedCommit feature against the renewable collection — verifies that
+/// the same delayed-commit semantics hold when using RenewableLockRepositoryCollectionBase.
+/// </summary>
+[Collection("Sequential")]
+[CollectionDefinition("Sequential", DisableParallelization = true)]
+public class RenewableDelayedCommitTests : RenewableLockableTestBase
+{
+    private static readonly TimeSpan ShortTtl = TimeSpan.FromMilliseconds(100);
+    private static readonly TimeSpan PastTtl = TimeSpan.FromMilliseconds(500);
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task CommitAsync_Succeeds_WhenLockExpired_AndNoOtherWriter()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "initial" };
+        await sut.AddAsync(entity);
+
+        await using var scope = await sut.LockAsync(entity.Id, timeout: ShortTtl);
+        var updated = scope.Entity with { Data = "delayed-commit", Count = 1 };
+
+        // Wait past the TTL — the LockKey is still ours, but the lock is past ExpireTime.
+        await Task.Delay(PastTtl);
+
+        // Default: AllowDelayedCommit = true → commit succeeds despite expiry.
+        var committed = await scope.CommitAsync(CommitMode.Update, updated);
+
+        committed.Data.Should().Be("delayed-commit");
+        committed.Count.Should().Be(1);
+        var post = await sut.GetOneAsync(entity.Id);
+        post.Data.Should().Be("delayed-commit");
+        post.Count.Should().Be(1);
+        post.Lock.Should().BeNull("a successful delayed commit must clear the lock just like an on-time commit");
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task CommitAsync_StrictMode_ThrowsLockExpired_WhenCollectionOverridesAllowDelayedCommitFalse()
+    {
+        var sut = new StrictRenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "initial" };
+        await sut.AddAsync(entity);
+
+        await using var scope = await sut.LockAsync(entity.Id, timeout: ShortTtl);
+        var updated = scope.Entity with { Data = "would-be-delayed" };
+
+        await Task.Delay(PastTtl);
+
+        // The override pins this collection to strict-TTL — commit must throw.
+        var act = async () => await scope.CommitAsync(CommitMode.Update, updated);
+
+        await act.Should().ThrowAsync<LockExpiredException>();
+
+        var post = await sut.GetOneAsync(entity.Id);
+        post.Data.Should().Be("initial", "the failed commit must not have written the staged change");
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task CommitAsync_StrictMode_ThrowsLockExpired_WhenFactoryAllowDelayedCommitIsFalse()
+    {
+        // Simulate the global DatabaseOptions.AllowDelayedCommit = false case by flipping the
+        // factory's exposed value. In production, the value is set from DatabaseOptions at
+        // registration time (MongoDbRegistrationExtensions); the factory is the seam the
+        // collection reads.
+        _mongoDbServiceFactory.AllowDelayedCommit = false;
+        try
+        {
+            var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+            var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "initial" };
+            await sut.AddAsync(entity);
+
+            await using var scope = await sut.LockAsync(entity.Id, timeout: ShortTtl);
+            var updated = scope.Entity with { Data = "would-be-delayed" };
+
+            await Task.Delay(PastTtl);
+
+            var act = async () => await scope.CommitAsync(CommitMode.Update, updated);
+
+            await act.Should().ThrowAsync<LockExpiredException>();
+        }
+        finally
+        {
+            // Restore for any other tests in the same fixture instance.
+            _mongoDbServiceFactory.AllowDelayedCommit = true;
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task CommitAsync_OnTimeCommit_StillSucceeds_AndDoesNotLogDelayedMessage()
+    {
+        // Regression guard: the new path must not affect ordinary on-time commits.
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "initial" };
+        await sut.AddAsync(entity);
+
+        await using var scope = await sut.LockAsync(entity.Id, timeout: TimeSpan.FromSeconds(5));
+        var updated = scope.Entity with { Data = "on-time" };
+
+        var committed = await scope.CommitAsync(CommitMode.Update, updated);
+
+        committed.Data.Should().Be("on-time");
+        var post = await sut.GetOneAsync(entity.Id);
+        post.Data.Should().Be("on-time");
+        post.Lock.Should().BeNull();
+    }
+}

--- a/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableDeleteManyTests.cs
+++ b/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableDeleteManyTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Bson;
+using Tharga.MongoDB.Tests.Lockable.Renewable.Base;
+using Tharga.MongoDB.Tests.Support;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests.Lockable.Renewable;
+
+[Collection("Sequential")]
+[CollectionDefinition("Sequential", DisableParallelization = true)]
+public class RenewableDeleteManyTests : RenewableLockableTestBase
+{
+    [Theory]
+    [Trait("Category", "Database")]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    public async Task DeleteManyAsync(int count)
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        for (var i = 0; i < count; i++)
+        {
+            await sut.AddAsync(new LockableTestEntity { Id = ObjectId.GenerateNewId() });
+        }
+
+        //Act
+        var result = await sut.DeleteManyUnlockedAsync(x => true);
+
+        //Assert
+        result.Should().Be(count);
+
+        var stored = await sut.GetAsync(x => true).ToArrayAsync();
+        stored.Should().HaveCount(0);
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task DeleteWhenOneIsLocked()
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var generateNewId = ObjectId.GenerateNewId();
+        await sut.AddAsync(new LockableTestEntity { Id = generateNewId });
+        await sut.AddAsync(new LockableTestEntity { Id = ObjectId.GenerateNewId() });
+        await sut.PickForUpdateAsync(generateNewId);
+
+        //Act
+        var result = await sut.DeleteManyUnlockedAsync(x => true);
+
+        //Assert
+        result.Should().Be(1);
+
+        var stored = await sut.GetAsync(x => true).ToArrayAsync();
+        stored.Should().HaveCount(1);
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task DeleteWhenOneIsExpired()
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var generateNewId = ObjectId.GenerateNewId();
+        await sut.AddAsync(new LockableTestEntity { Id = generateNewId });
+        await sut.AddAsync(new LockableTestEntity { Id = ObjectId.GenerateNewId() });
+        await sut.PickForUpdateAsync(generateNewId, TimeSpan.Zero);
+        await Task.Delay(50); //Cross the zero-timeout expiry boundary deterministically under load.
+
+        //Act
+        var result = await sut.DeleteManyUnlockedAsync(x => true);
+
+        //Assert
+        result.Should().Be(2);
+
+        var stored = await sut.GetAsync(x => true).ToArrayAsync();
+        stored.Should().HaveCount(0);
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task DeleteWhenOneHasError()
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var generateNewId = ObjectId.GenerateNewId();
+        await sut.AddAsync(new LockableTestEntity { Id = generateNewId });
+        await sut.AddAsync(new LockableTestEntity { Id = ObjectId.GenerateNewId() });
+        var scoped = await sut.PickForUpdateAsync(generateNewId, TimeSpan.FromSeconds(1));
+        await scoped.SetErrorStateAsync(new Exception("some issue"));
+        await Task.Delay(TimeSpan.FromSeconds(1));
+
+        //Act
+        var result = await sut.DeleteManyUnlockedAsync(x => true);
+
+        //Assert
+        result.Should().Be(1);
+
+        var stored = await sut.GetAsync(x => true).ToArrayAsync();
+        stored.Should().HaveCount(1);
+    }
+}

--- a/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableDeleteOneTests.cs
+++ b/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableDeleteOneTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Bson;
+using Tharga.MongoDB.Lockable;
+using Tharga.MongoDB.Tests.Lockable.Renewable.Base;
+using Tharga.MongoDB.Tests.Support;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests.Lockable.Renewable;
+
+[Collection("Sequential")]
+[CollectionDefinition("Sequential", DisableParallelization = true)]
+public class RenewableDeleteOneTests : RenewableLockableTestBase
+{
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task DeleteOneAsync()
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(entity);
+
+        //Act
+        var result = await sut.DeleteOneAsync(entity.Id);
+
+        //Assert
+        result.Should().Be(entity);
+        (await sut.CountAsync(x => true)).Should().Be(0);
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task DeleteWhenLocked()
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(entity);
+        await sut.PickForUpdateAsync(entity.Id, actor: "some actor");
+
+        //Act
+        var act = () => sut.DeleteOneAsync(entity.Id);
+
+        //Assert
+        await act.Should()
+            .ThrowAsync<LockException>()
+            .WithMessage($"Entity with id '{entity.Id}' is locked by 'some actor' for *.");
+        (await sut.CountAsync(x => true)).Should().Be(1);
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task DeleteWhenExpired()
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(entity);
+        var scope = await sut.PickForUpdateAsync(entity.Id, actor: "some actor");
+        await scope.SetErrorStateAsync(new Exception("Some issue."));
+
+        //Act
+        var act = () => sut.DeleteOneAsync(entity.Id);
+
+        //Assert
+        await act.Should()
+            .ThrowAsync<LockErrorException>()
+            .WithMessage($"Entity with id '{entity.Id}' has an exception attached.");
+        (await sut.CountAsync(x => true)).Should().Be(1);
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task DeleteWithError()
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(entity);
+        var scope = await sut.PickForUpdateAsync(entity.Id, actor: "some actor", timeout: TimeSpan.FromSeconds(1));
+        await scope.SetErrorStateAsync(new Exception("some error"));
+        await Task.Delay(TimeSpan.FromSeconds(1));
+
+        //Act
+        var act = () => sut.DeleteOneAsync(entity.Id);
+
+        //Assert
+        await act.Should()
+            .ThrowAsync<LockException>()
+            .WithMessage($"Entity with id '{entity.Id}' has an exception attached.");
+        (await sut.CountAsync(x => true)).Should().Be(1);
+    }
+}

--- a/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableEntityScopeExtensionsTests.cs
+++ b/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableEntityScopeExtensionsTests.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Bson;
+using Tharga.MongoDB.Lockable;
+using Tharga.MongoDB.Tests.Lockable.Renewable.Base;
+using Tharga.MongoDB.Tests.Support;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests.Lockable.Renewable;
+
+[Collection("Sequential")]
+[CollectionDefinition("Sequential", DisableParallelization = true)]
+public class RenewableEntityScopeExtensionsTests : RenewableLockableTestBase
+{
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task UpdateAndAbandon()
+    {
+        //Arrange
+        var repository = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "initial" };
+        await repository.AddAsync(entity);
+        await using var scope = await repository.PickForUpdateAsync(entity.Id);
+
+        //Act
+        var result = await scope.ExecuteAsync(e =>
+        {
+            e.Data = "updated";
+            return Task.FromResult<LockableTestEntity>(default);
+        });
+
+        //Assert
+        result.Should().BeNull();
+        var after = await repository.GetOneAsync(x => true);
+        after.Data.Should().Be("initial");
+        after.Lock.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task UpdateAndCommit()
+    {
+        //Arrange
+        var repository = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "initial" };
+        await repository.AddAsync(entity);
+        await using var scope = await repository.PickForUpdateAsync(entity.Id);
+
+        //Act
+        var result = await scope.ExecuteAsync(e => Task.FromResult(e with { Data = "updated" }));
+
+        //Assert
+        result.Should().NotBeNull();
+        result.Data.Should().Be("updated");
+        var after = await repository.GetOneAsync(x => true);
+        after.Data.Should().Be("updated");
+        after.Lock.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task UpdateAndThrow()
+    {
+        //Arrange
+        var repository = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "initial" };
+        await repository.AddAsync(entity);
+        await using var scope = await repository.PickForUpdateAsync(entity.Id);
+
+        //Act
+        var act = () => scope.ExecuteAsync(e =>
+        {
+            e.Data = "updated";
+            throw new InvalidOperationException("Oups");
+        });
+
+        //Assert
+        await act.Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("Oups");
+
+        var after = await repository.GetOneAsync(x => true);
+        after.Data.Should().Be("initial");
+        after.Lock.ExceptionInfo.Message.Should().Be("Oups");
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task DeleteAndAbandon()
+    {
+        //Arrange
+        var repository = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "initial" };
+        await repository.AddAsync(entity);
+        await using var scope = await repository.PickForDeleteAsync(entity.Id);
+
+        //Act
+        var result = await scope.ExecuteAsync(e => Task.FromResult<LockableTestEntity>(default));
+
+        //Assert
+        result.Should().BeNull();
+        var after = await repository.GetOneAsync(x => true);
+        after.Data.Should().Be("initial");
+        after.Lock.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task DeleteAndCommit()
+    {
+        //Arrange
+        var repository = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "initial" };
+        await repository.AddAsync(entity);
+        await using var scope = await repository.PickForDeleteAsync(entity.Id);
+
+        //Act
+        var result = await scope.ExecuteAsync(Task.FromResult);
+
+        //Assert
+        result.Should().NotBeNull();
+        var after = await repository.GetOneAsync(x => true);
+        after.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task DeleteAndThrow()
+    {
+        //Arrange
+        var repository = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "initial" };
+        await repository.AddAsync(entity);
+        await using var scope = await repository.PickForDeleteAsync(entity.Id);
+
+        //Act
+        var act = () => scope.ExecuteAsync(_ => throw new InvalidOperationException("Oups"));
+
+        //Assert
+        await act.Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("Oups");
+
+        var after = await repository.GetOneAsync(x => true);
+        after.Data.Should().Be("initial");
+        after.Lock.ExceptionInfo.Message.Should().Be("Oups");
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task UpdateAndThrow_StructuredHandlerReceivesHandlerErrorKind()
+    {
+        //Arrange
+        var repository = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "initial" };
+        await repository.AddAsync(entity);
+        await using var scope = await repository.PickForUpdateAsync(entity.Id);
+
+        LockableErrorKind? capturedKind = null;
+        Exception capturedException = null;
+
+        //Act
+        var result = await scope.ExecuteAsync(
+            _ => throw new InvalidOperationException("Oups"),
+            (kind, e) => { capturedKind = kind; capturedException = e; });
+
+        //Assert — handler called once with HandlerError kind, no exception escapes the call
+        capturedKind.Should().Be(LockableErrorKind.HandlerError);
+        capturedException.Should().BeOfType<InvalidOperationException>().Which.Message.Should().Be("Oups");
+        // SetErrorStateAsync still ran — exception is recorded on the lock
+        var after = await repository.GetOneAsync(x => true);
+        after.Lock.ExceptionInfo.Message.Should().Be("Oups");
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task UpdateAndThrow_LegacyHandlerStillReceivesException()
+    {
+        //Arrange
+        var repository = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "initial" };
+        await repository.AddAsync(entity);
+        await using var scope = await repository.PickForUpdateAsync(entity.Id);
+
+        Exception captured = null;
+
+        //Act — legacy Action<Exception> overload
+        await scope.ExecuteAsync(
+            _ => throw new InvalidOperationException("Oups"),
+            (Action<Exception>)(e => captured = e));
+
+        //Assert — exception flows to the legacy handler unchanged
+        captured.Should().BeOfType<InvalidOperationException>().Which.Message.Should().Be("Oups");
+        var after = await repository.GetOneAsync(x => true);
+        after.Lock.ExceptionInfo.Message.Should().Be("Oups");
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task NullStructuredHandler_HandlerErrorPropagates()
+    {
+        //Arrange
+        var repository = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "initial" };
+        await repository.AddAsync(entity);
+        await using var scope = await repository.PickForUpdateAsync(entity.Id);
+
+        //Act — explicitly null structured handler
+        var act = () => scope.ExecuteAsync(
+            _ => throw new InvalidOperationException("Oups"),
+            (Action<LockableErrorKind, Exception>)null);
+
+        //Assert — same propagation behavior as before this overload existed
+        await act.Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("Oups");
+    }
+}

--- a/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableExecuteAsyncGuardTests.cs
+++ b/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableExecuteAsyncGuardTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Tharga.MongoDB.Disk;
+using Tharga.MongoDB.Tests.Lockable.Renewable.Base;
+using Tharga.MongoDB.Tests.Support;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests.Lockable.Renewable;
+
+[Collection("Sequential")]
+[CollectionDefinition("Sequential", DisableParallelization = true)]
+public class RenewableExecuteAsyncGuardTests : RenewableLockableTestBase
+{
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task OperationRead_Allowed()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+
+        var count = await sut.ExecuteAsync(col => col.CountDocumentsAsync(FilterDefinition<LockableTestEntity>.Empty), Operation.Read);
+
+        count.Should().Be(0);
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task OperationCreate_Allowed()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+
+        var result = await sut.ExecuteAsync(async col =>
+        {
+            await col.InsertOneAsync(entity);
+            return true;
+        }, Operation.Create);
+
+        result.Should().BeTrue();
+        (await sut.GetOneAsync(entity.Id)).Should().NotBeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task OperationUpdate_Throws()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+
+        var act = () => sut.ExecuteAsync(col => Task.FromResult(true), Operation.Update);
+
+        var ex = await act.Should().ThrowAsync<InvalidOperationException>();
+        ex.Which.Message.Should().Contain(nameof(Operation.Update));
+        ex.Which.Message.Should().Contain("lock-acquire/commit cycle");
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task OperationDelete_Throws()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+
+        var act = () => sut.ExecuteAsync(col => Task.FromResult(true), Operation.Delete);
+
+        var ex = await act.Should().ThrowAsync<InvalidOperationException>();
+        ex.Which.Message.Should().Contain(nameof(Operation.Delete));
+        ex.Which.Message.Should().Contain("lock-acquire/commit cycle");
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task OperationUpdate_WithCancellationToken_Throws()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+
+        var act = () => sut.ExecuteAsync((col, _) => Task.FromResult(true), Operation.Update, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task IndexCreate_OperationCreate_Works()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        const string indexName = "Data_Unique_Idx";
+
+        var ok = await sut.ExecuteAsync(async col =>
+        {
+            await col.Indexes.CreateOneAsync(new CreateIndexModel<LockableTestEntity>(
+                Builders<LockableTestEntity>.IndexKeys.Ascending(x => x.Data),
+                new CreateIndexOptions { Unique = true, Name = indexName }));
+            return true;
+        }, Operation.Create);
+
+        ok.Should().BeTrue();
+
+        var indexes = await sut.ExecuteAsync(col => col.Indexes.List().ToListAsync(), Operation.Read);
+        indexes.Select(i => i["name"].AsString).Should().Contain(indexName);
+    }
+}

--- a/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableGetLockedTests.cs
+++ b/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableGetLockedTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Bson;
+using Tharga.MongoDB.Lockable;
+using Tharga.MongoDB.Tests.Lockable.Renewable.Base;
+using Tharga.MongoDB.Tests.Support;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests.Lockable.Renewable;
+
+[Collection("Sequential")]
+[CollectionDefinition("Sequential", DisableParallelization = true)]
+public class RenewableGetLockedTests : RenewableLockableTestBase
+{
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task GetLockedExceptions()
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var lockableTestEntity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(lockableTestEntity);
+        await sut.AddAsync(new LockableTestEntity { Id = ObjectId.GenerateNewId() });
+        await sut.AddAsync(new LockableTestEntity { Id = ObjectId.GenerateNewId() });
+        var scope = await sut.PickForUpdateAsync(lockableTestEntity.Id);
+        await scope.SetErrorStateAsync(new Exception("Some issue"));
+
+        //Act
+        var items = await sut.GetLockedAsync(LockMode.Exception).ToArrayAsync();
+
+        //Assert
+        items.Length.Should().Be(1);
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task GetLockedExpired()
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var lockableTestEntity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(lockableTestEntity);
+        await sut.AddAsync(new LockableTestEntity { Id = ObjectId.GenerateNewId() });
+        await sut.AddAsync(new LockableTestEntity { Id = ObjectId.GenerateNewId() });
+        await sut.PickForUpdateAsync(lockableTestEntity.Id, TimeSpan.Zero);
+        await Task.Delay(50); //Cross the zero-timeout expiry boundary deterministically under load.
+
+        //Act
+        var items = await sut.GetExpiredAsync().ToArrayAsync();
+
+        //Assert
+        items.Length.Should().Be(1);
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task GetLockedLocked()
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var lockableTestEntity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(lockableTestEntity);
+        await sut.AddAsync(new LockableTestEntity { Id = ObjectId.GenerateNewId() });
+        await sut.AddAsync(new LockableTestEntity { Id = ObjectId.GenerateNewId() });
+        await sut.PickForUpdateAsync(lockableTestEntity.Id);
+
+        //Act
+        var items = await sut.GetLockedAsync(LockMode.Locked).ToArrayAsync();
+
+        //Assert
+        items.Length.Should().Be(1);
+    }
+}

--- a/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableGetUnlockedTests.cs
+++ b/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableGetUnlockedTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Bson;
+using Tharga.MongoDB.Tests.Lockable.Renewable.Base;
+using Tharga.MongoDB.Tests.Support;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests.Lockable.Renewable;
+
+[Collection("Sequential")]
+[CollectionDefinition("Sequential", DisableParallelization = true)]
+public class RenewableGetUnlockedTests : RenewableLockableTestBase
+{
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task Basic()
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var lockableTestEntity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        var entityWithLock = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(entityWithLock);
+        await sut.PickForUpdateAsync(entityWithLock.Id);
+
+        var entityEithException = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(entityEithException);
+        var scope = await sut.PickForUpdateAsync(entityEithException.Id);
+        await scope.SetErrorStateAsync(new Exception("Some issue"));
+
+        var entityThatTimedOut = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(entityThatTimedOut);
+        await sut.PickForUpdateAsync(entityThatTimedOut.Id, TimeSpan.Zero);
+
+        await sut.AddAsync(new LockableTestEntity { Id = ObjectId.GenerateNewId() });
+        await sut.AddAsync(new LockableTestEntity { Id = ObjectId.GenerateNewId() });
+
+        //Act
+        var items = await sut.GetUnlockedAsync().ToArrayAsync();
+
+        //Assert
+        items.Length.Should().Be(3);
+    }
+}

--- a/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableLockManyTests.cs
+++ b/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableLockManyTests.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Tharga.MongoDB.Lockable;
+using Tharga.MongoDB.Tests.Lockable.Renewable.Base;
+using Tharga.MongoDB.Tests.Support;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests.Lockable.Renewable;
+
+[Collection("Sequential")]
+[CollectionDefinition("Sequential", DisableParallelization = true)]
+public class RenewableLockManyTests : RenewableLockableTestBase
+{
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task LockManyMixedDecisions_AppliesEachAndReturnsSummary()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var a = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "a" };
+        var b = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "b" };
+        var c = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "c" };
+        await sut.AddAsync(a);
+        await sut.AddAsync(b);
+        await sut.AddAsync(c);
+
+        await using var lease = await sut.LockManyAsync([a.Id, b.Id, c.Id]);
+
+        // Update a
+        var updatedA = lease.Documents.Single(x => x.Id == a.Id) with { Data = "a-updated" };
+        lease.MarkForUpdate(updatedA);
+        // Delete b
+        lease.MarkForDelete(b.Id);
+        // c left unmarked → released unchanged
+
+        var summary = await lease.CommitAsync();
+
+        summary.Updated.Should().Be(1);
+        summary.Deleted.Should().Be(1);
+        summary.ReleasedUnchanged.Should().Be(1);
+        summary.Failures.Should().BeEmpty();
+
+        (await sut.GetOneAsync(a.Id)).Data.Should().Be("a-updated");
+        (await sut.GetOneAsync(b.Id)).Should().BeNull();
+        var postC = await sut.GetOneAsync(c.Id);
+        postC.Data.Should().Be("c");
+        postC.Lock.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task LockManyAcquireFailure_RollsBackPartialLocks()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var a = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        var b = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        var c = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(a);
+        await sut.AddAsync(b);
+        await sut.AddAsync(c);
+
+        // Pre-lock one of them so the LockManyAsync mid-acquire fails.
+        await using var blocker = await sut.LockAsync(b.Id);
+
+        Func<Task> act = async () => await sut.LockManyAsync(new[] { a.Id, b.Id, c.Id }, timeout: TimeSpan.FromMilliseconds(10));
+
+        await act.Should().ThrowAsync<LockException>();
+
+        // Other two must be lockable again — partial lock on whichever was acquired first should have rolled back.
+        await using var sa = await sut.LockAsync(a.Id, timeout: TimeSpan.FromSeconds(1));
+        await using var sc = await sut.LockAsync(c.Id, timeout: TimeSpan.FromSeconds(1));
+        sa.Should().NotBeNull();
+        sc.Should().NotBeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task LockManyEmptyIdList_ReturnsEmptyLease()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+
+        await using var lease = await sut.LockManyAsync(Array.Empty<ObjectId>());
+
+        lease.Documents.Should().BeEmpty();
+        var summary = await lease.CommitAsync();
+        summary.Updated.Should().Be(0);
+        summary.Deleted.Should().Be(0);
+        summary.ReleasedUnchanged.Should().Be(0);
+        summary.Failures.Should().BeEmpty();
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task LockManyMarkUnknownId_ThrowsArgumentException()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var a = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(a);
+
+        await using var lease = await sut.LockManyAsync([a.Id]);
+
+        Action act = () => lease.MarkForDelete(ObjectId.GenerateNewId());
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task LockManyDisposeWithoutCommit_ReleasesAllLocks()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var a = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        var b = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(a);
+        await sut.AddAsync(b);
+
+        await (await sut.LockManyAsync([a.Id, b.Id])).DisposeAsync();
+
+        // Both should be lockable again.
+        await using var sa = await sut.LockAsync(a.Id, timeout: TimeSpan.FromSeconds(1));
+        await using var sb = await sut.LockAsync(b.Id, timeout: TimeSpan.FromSeconds(1));
+        sa.Should().NotBeNull();
+        sb.Should().NotBeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task LockManyByFilter_LocksMatchingDocuments()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var a = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "group" };
+        var b = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "group" };
+        var c = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "other" };
+        await sut.AddAsync(a);
+        await sut.AddAsync(b);
+        await sut.AddAsync(c);
+
+        var filter = Builders<LockableTestEntity>.Filter.Eq(x => x.Data, "group");
+        await using var lease = await sut.LockManyAsync(filter);
+
+        lease.Documents.Should().HaveCount(2);
+        lease.Documents.Select(x => x.Id).Should().BeEquivalentTo(new[] { a.Id, b.Id });
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task LockManyByPredicate_LocksMatchingDocuments()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var a = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Count = 5 };
+        var b = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Count = 5 };
+        var c = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Count = 1 };
+        await sut.AddAsync(a);
+        await sut.AddAsync(b);
+        await sut.AddAsync(c);
+
+        await using var lease = await sut.LockManyAsync(x => x.Count == 5);
+
+        lease.Documents.Should().HaveCount(2);
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task LockManyRemarkSameId_LastDecisionWins()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var a = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "a" };
+        await sut.AddAsync(a);
+
+        await using var lease = await sut.LockManyAsync([a.Id]);
+
+        // First mark Update, then re-mark as Delete — Delete should win.
+        var updatedA = lease.Documents.Single() with { Data = "should-not-stick" };
+        lease.MarkForUpdate(updatedA);
+        lease.MarkForDelete(a.Id);
+
+        var summary = await lease.CommitAsync();
+
+        summary.Deleted.Should().Be(1);
+        summary.Updated.Should().Be(0);
+        (await sut.GetOneAsync(a.Id)).Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task LockManyCommitTwice_Throws()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var a = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(a);
+
+        await using var lease = await sut.LockManyAsync([a.Id]);
+        await lease.CommitAsync();
+
+        Func<Task> act = async () => await lease.CommitAsync();
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+}

--- a/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableLockTests.cs
+++ b/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableLockTests.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Tharga.MongoDB.Lockable;
+using Tharga.MongoDB.Lockable.Renewable;
+using Tharga.MongoDB.Tests.Lockable.Renewable.Base;
+using Tharga.MongoDB.Tests.Support;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests.Lockable.Renewable;
+
+[Collection("Sequential")]
+[CollectionDefinition("Sequential", DisableParallelization = true)]
+public class RenewableLockTests : RenewableLockableTestBase
+{
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task LockCommitUpdate()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "initial" };
+        await sut.AddAsync(entity);
+
+        await using var scope = await sut.LockAsync(entity.Id);
+        var updated = scope.Entity with { Data = "updated", Count = 1 };
+
+        var committed = await scope.CommitAsync(CommitMode.Update, updated);
+
+        committed.Data.Should().Be("updated");
+        committed.Count.Should().Be(1);
+        var post = await sut.GetOneAsync(entity.Id);
+        post.Data.Should().Be("updated");
+        post.Count.Should().Be(1);
+        post.Lock.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task LockCommitUpdateNoEntity_CommitsOriginalUnchanged()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "initial" };
+        await sut.AddAsync(entity);
+
+        await using var scope = await sut.LockAsync(entity.Id);
+
+        var committed = await scope.CommitAsync(CommitMode.Update);
+
+        committed.Data.Should().Be("initial");
+        var post = await sut.GetOneAsync(entity.Id);
+        post.Data.Should().Be("initial");
+        post.Lock.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task LockCommitDelete()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "to-delete" };
+        await sut.AddAsync(entity);
+
+        await using var scope = await sut.LockAsync(entity.Id);
+        await scope.CommitAsync(CommitMode.Delete);
+
+        (await sut.CountAsync(x => true)).Should().Be(0);
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task LockAbandon_LeavesEntityUnchangedAndUnlocked()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "original" };
+        await sut.AddAsync(entity);
+
+        var scope = await sut.LockAsync(entity.Id);
+        await scope.AbandonAsync();
+
+        var post = await sut.GetOneAsync(entity.Id);
+        post.Data.Should().Be("original");
+        post.Lock.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task LockDisposeWithoutCommit_ReleasesLock()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(entity);
+
+        // Lock and dispose without committing
+        await (await sut.LockAsync(entity.Id)).DisposeAsync();
+
+        // Should be lockable again
+        await using var scope = await sut.LockAsync(entity.Id);
+        scope.Should().NotBeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task LockAlreadyLocked_ThrowsLockException()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(entity);
+
+        await using var first = await sut.LockAsync(entity.Id);
+
+        Func<Task> act = async () => await sut.LockAsync(entity.Id, timeout: TimeSpan.FromMilliseconds(10));
+
+        await act.Should().ThrowAsync<LockException>();
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task LockSetErrorState_RecordsExceptionOnLock()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(entity);
+
+        var scope = await sut.LockAsync(entity.Id);
+        await scope.SetErrorStateAsync(new InvalidOperationException("boom"));
+
+        var post = await sut.GetOneAsync(entity.Id);
+        post.Lock.Should().NotBeNull();
+        post.Lock.ExceptionInfo.Should().NotBeNull();
+        post.Lock.ExceptionInfo.Message.Should().Be("boom");
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task LockCommitAfterRelease_Throws()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(entity);
+
+        var scope = await sut.LockAsync(entity.Id);
+        await scope.AbandonAsync();
+
+        Func<Task> act = async () => await scope.CommitAsync(CommitMode.Update);
+
+        await act.Should().ThrowAsync<LockAlreadyReleasedException>();
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task LockByFilter_LocksMatchingDocument()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "match" };
+        await sut.AddAsync(entity);
+
+        var filter = Builders<LockableTestEntity>.Filter.Eq(x => x.Data, "match");
+        await using var scope = await sut.LockAsync(filter);
+
+        scope.Entity.Id.Should().Be(entity.Id);
+        await scope.CommitAsync(CommitMode.Update);
+
+        (await sut.GetOneAsync(entity.Id)).Lock.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task LockByPredicate_LocksMatchingDocument()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "p-match" };
+        await sut.AddAsync(entity);
+
+        await using var scope = await sut.LockAsync(x => x.Data == "p-match");
+
+        scope.Entity.Id.Should().Be(entity.Id);
+        await scope.CommitAsync(CommitMode.Update);
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task LockByFilter_NoMatch_ReturnsNull()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+
+        var filter = Builders<LockableTestEntity>.Filter.Eq(x => x.Data, "nope");
+        var scope = await sut.LockAsync(filter);
+
+        scope.Should().BeNull();
+    }
+}

--- a/Tharga.MongoDB.Tests/Lockable/Renewable/RenewablePickForDeleteTests.cs
+++ b/Tharga.MongoDB.Tests/Lockable/Renewable/RenewablePickForDeleteTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Bson;
+using Tharga.MongoDB.Tests.Lockable.Base;
+using Tharga.MongoDB.Tests.Lockable.Renewable.Base;
+using Tharga.MongoDB.Tests.Support;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests.Lockable.Renewable;
+
+[Collection("Sequential")]
+[CollectionDefinition("Sequential", DisableParallelization = true)]
+public class RenewablePickForDeleteTests : RenewableLockableTestBase
+{
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task PickForDeleteCommit()
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(entity);
+        await using var result = await sut.PickForDeleteAsync(entity.Id);
+
+        //Act
+        var r = await result.CommitAsync();
+
+        //Assert
+        r.Should().Be(entity);
+        (await sut.CountAsync(x => true)).Should().Be(0);
+    }
+
+    [Theory]
+    [InlineData(ActionHelper.EndAction.Abandon, ActionHelper.EndAction.Abandon, false)]
+    [InlineData(ActionHelper.EndAction.Abandon, ActionHelper.EndAction.Commit, false)]
+    [InlineData(ActionHelper.EndAction.Abandon, ActionHelper.EndAction.Exception, false)]
+    [InlineData(ActionHelper.EndAction.Commit, ActionHelper.EndAction.Abandon, true)]
+    [InlineData(ActionHelper.EndAction.Commit, ActionHelper.EndAction.Commit, true)]
+    [InlineData(ActionHelper.EndAction.Commit, ActionHelper.EndAction.Exception, true)]
+    [InlineData(ActionHelper.EndAction.Exception, ActionHelper.EndAction.Abandon, false)]
+    [InlineData(ActionHelper.EndAction.Exception, ActionHelper.EndAction.Commit, false)]
+    [InlineData(ActionHelper.EndAction.Exception, ActionHelper.EndAction.Exception, false)]
+    [Trait("Category", "Database")]
+    public async Task CloseTwice(ActionHelper.EndAction first, ActionHelper.EndAction then, bool deleted)
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(entity);
+        await using var scope = await sut.PickForDeleteAsync(entity.Id);
+        var firstAct = ActionHelper.Action(first, scope);
+
+        await firstAct.Invoke();
+
+        //Act
+        var act = ActionHelper.Action(then, scope);
+
+        //Assert
+        await act.Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("Entity has already been released.");
+        var item = await sut.GetOneAsync(entity.Id);
+        if (deleted)
+        {
+            item.Should().BeNull();
+        }
+        else
+        {
+            item.Should().NotBeNull();
+        }
+    }
+}

--- a/Tharga.MongoDB.Tests/Lockable/Renewable/RenewablePickForUpdateTests.cs
+++ b/Tharga.MongoDB.Tests/Lockable/Renewable/RenewablePickForUpdateTests.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Bson;
+using Tharga.MongoDB.Lockable;
+using Tharga.MongoDB.Lockable.Renewable;
+using Tharga.MongoDB.Tests.Lockable.Base;
+using Tharga.MongoDB.Tests.Lockable.Renewable.Base;
+using Tharga.MongoDB.Tests.Support;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests.Lockable.Renewable;
+
+[Collection("Sequential")]
+[CollectionDefinition("Sequential", DisableParallelization = true)]
+public class RenewablePickForUpdateTests : RenewableLockableTestBase
+{
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task PickForUpdateCommitSame()
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "initial" };
+        await sut.AddAsync(entity);
+        await using var scope = await sut.PickForUpdateAsync(entity.Id);
+        scope.Entity.Data = "updated";
+
+        //Act
+        var r = await scope.CommitAsync();
+
+        //Assert
+        r.Should().Be(scope.Entity);
+        r.Data.Should().Be("updated");
+        (await sut.CountAsync(x => true)).Should().Be(1);
+        var post = await sut.GetAsync(x => x.Id == entity.Id).FirstAsync();
+        post.Data.Should().Be("updated");
+        (await sut.CountAsync(x => true)).Should().Be(1);
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task PickForUpdateCommitOther()
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "initial" };
+        await sut.AddAsync(entity);
+        await using var scope = await sut.PickForUpdateAsync(entity.Id);
+        var updated = scope.Entity with { Count = 1, Data = "updated" };
+
+        //Act
+        var r = await scope.CommitAsync(updated);
+
+        //Assert
+        r.Should().Be(updated);
+        r.Data.Should().Be("updated");
+        var post = await sut.GetAsync(x => x.Id == entity.Id).FirstAsync();
+        post.Count.Should().Be(1);
+        post.Data.Should().Be("updated");
+        post.Lock.Should().BeNull();
+        (await sut.CountAsync(x => true)).Should().Be(1);
+        (await sut.GetLockedAsync(LockMode.Exception).CountAsync()).Should().Be(0);
+    }
+
+    //--->
+
+    [Theory]
+    [InlineData(ActionHelper.EndAction.Abandon, ActionHelper.EndAction.Abandon, false)]
+    [InlineData(ActionHelper.EndAction.Abandon, ActionHelper.EndAction.Commit, false)]
+    [InlineData(ActionHelper.EndAction.Abandon, ActionHelper.EndAction.Exception, false)]
+    [InlineData(ActionHelper.EndAction.Commit, ActionHelper.EndAction.Abandon, true)]
+    [InlineData(ActionHelper.EndAction.Commit, ActionHelper.EndAction.Commit, true)]
+    [InlineData(ActionHelper.EndAction.Commit, ActionHelper.EndAction.Exception, true)]
+    [InlineData(ActionHelper.EndAction.Exception, ActionHelper.EndAction.Abandon, false)]
+    [InlineData(ActionHelper.EndAction.Exception, ActionHelper.EndAction.Commit, false)]
+    [InlineData(ActionHelper.EndAction.Exception, ActionHelper.EndAction.Exception, false)]
+    [Trait("Category", "Database")]
+    public async Task CloseTwice(ActionHelper.EndAction first, ActionHelper.EndAction then, bool updated)
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "initial" };
+        await sut.AddAsync(entity);
+        await using var scope = await sut.PickForUpdateAsync(entity.Id);
+        scope.Entity.Data = "updated";
+        var firstAct = ActionHelper.Action(first, scope);
+
+        await firstAct.Invoke();
+
+        //Act
+        var act = ActionHelper.Action(then, scope);
+
+        //Assert
+        await act.Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("Entity has already been released.");
+        var item = await sut.GetOneAsync(entity.Id);
+        item.Should().NotBeNull();
+        if (updated)
+        {
+            item.Data.Should().Be("updated");
+        }
+        else
+        {
+            item.Data.Should().Be("initial");
+        }
+    }
+}

--- a/Tharga.MongoDB.Tests/Lockable/Renewable/RenewablePickTests.cs
+++ b/Tharga.MongoDB.Tests/Lockable/Renewable/RenewablePickTests.cs
@@ -1,0 +1,383 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Bson;
+using Tharga.MongoDB.Lockable;
+using Tharga.MongoDB.Lockable.Renewable;
+using Tharga.MongoDB.Tests.Lockable.Renewable.Base;
+using Tharga.MongoDB.Tests.Support;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests.Lockable.Renewable;
+
+/// <summary>
+/// Tests that have the same outcome for PickForUpdate and PickForDelete — renewable variant.
+/// </summary>
+[Collection("Sequential")]
+[CollectionDefinition("Sequential", DisableParallelization = true)]
+public class RenewablePickTests : RenewableLockableTestBase
+{
+    [Theory]
+    [InlineData(PickType.Update)]
+    [InlineData(PickType.Delete)]
+    [Trait("Category", "Database")]
+    public async Task PickEntity(PickType type)
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(entity);
+
+        //Act
+        await using var scope = await PickAsync(type, sut, entity.Id);
+
+        //Assert
+        scope.Entity.Should().NotBeNull();
+        scope.Entity.Should().Be(entity);
+        var item = await sut.GetOneAsync(entity.Id);
+        item.Should().NotBeNull();
+        item.Lock.Should().NotBeNull();
+        item.Lock.ExceptionInfo.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(PickType.Update)]
+    [InlineData(PickType.Delete)]
+    [Trait("Category", "Database")]
+    public async Task PickLockedEntity(PickType type)
+    {
+        //Arrange
+        var firstActor = "some actor";
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(entity);
+        await sut.PickForUpdateAsync(entity.Id, actor: firstActor);
+
+        //Act
+        var act = () => PickAsync(type, sut, entity.Id, firstActor);
+
+        //Assert
+        await act.Should()
+            .ThrowAsync<LockException>()
+            .WithMessage($"Entity with id '{entity.Id}' is locked by '{firstActor}' for *.");
+        var item = await sut.GetOneAsync(entity.Id);
+        item.Should().NotBeNull();
+        item.Lock.Should().NotBeNull();
+        item.Lock.ExceptionInfo.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(PickType.Update)]
+    [InlineData(PickType.Delete)]
+    [Trait("Category", "Database")]
+    public async Task PickedEntityWithException(PickType type)
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(entity);
+        await using var scope = await PickAsync(type, sut, entity.Id, "first actor");
+        await scope.SetErrorStateAsync(new Exception("Some issue"));
+
+        //Act
+        var act = () => PickAsync(type, sut, entity.Id, "second actor");
+
+        //Assert
+        await act.Should()
+            .ThrowAsync<LockErrorException>()
+            .WithMessage($"Entity with id '{entity.Id}' has an exception attached.");
+        var item = await sut.GetOneAsync(entity.Id);
+        item.Should().NotBeNull();
+        item.Lock.Should().NotBeNull();
+        item.Lock.ExceptionInfo.Should().NotBeNull();
+    }
+
+    [Theory]
+    [InlineData(PickType.Update)]
+    [InlineData(PickType.Delete)]
+    [Trait("Category", "Database")]
+    public async Task PickedEntityThatDoesNotExist(PickType type)
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+
+        //Act
+        await using var scope = await PickAsync(type, sut, ObjectId.GenerateNewId());
+
+        //Assert
+        scope.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(PickType.Update)]
+    [InlineData(PickType.Delete)]
+    [Trait("Category", "Database")]
+    public async Task PickEntityWithExpiredLock(PickType type)
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(entity);
+        await PickAsync(type, sut, entity.Id, "first actor", TimeSpan.Zero);
+
+        //Act
+        await using var result = await PickAsync(type, sut, entity.Id, "second actor");
+
+        //Assert
+        result.Entity.Should().NotBeNull();
+        result.Entity.Count.Should().Be(entity.Count);
+        var item = await sut.GetOneAsync(entity.Id);
+        item.Should().NotBeNull();
+        item.Lock.Should().NotBeNull();
+        item.Lock.ExceptionInfo.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(PickType.Update)]
+    [InlineData(PickType.Delete)]
+    [Trait("Category", "Database")]
+    public async Task PickThenAbandon(PickType type)
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "initial" };
+        await sut.AddAsync(entity);
+        await using var scope = await PickAsync(type, sut, entity.Id);
+        scope.Entity.Data = "updated";
+
+        //Act
+        await scope.AbandonAsync();
+
+        //Assert
+        var post = await sut.GetAsync(x => x.Id == entity.Id).FirstOrDefaultAsync();
+        post.Data.Should().Be("initial");
+        post.Lock.Should().BeNull();
+        (await sut.CountAsync(x => true)).Should().Be(1);
+        (await sut.GetLockedAsync(LockMode.Exception).CountAsync()).Should().Be(0);
+    }
+
+    [Theory]
+    [InlineData(PickType.Update)]
+    [InlineData(PickType.Delete)]
+    [Trait("Category", "Database")]
+    public async Task PickThenSetError(PickType type)
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "initial" };
+        await sut.AddAsync(entity);
+        await using var scope = await PickAsync(type, sut, entity.Id);
+        scope.Entity.Data = "updated";
+        var key = await sut.GetLockedAsync(LockMode.Locked).FirstOrDefaultAsync(x => x.Entity.Id == entity.Id);
+
+        //Act
+        await scope.SetErrorStateAsync(new Exception("Some issue."));
+
+        //Assert
+        var post = await sut.GetAsync(x => x.Id == entity.Id).FirstAsync();
+        post.Data.Should().Be("initial");
+        post.Lock.Should().NotBeNull();
+        post.Lock.LockKey.Should().Be(key.Lock.LockKey);
+        post.Lock.ExceptionInfo.Message.Should().Be("Some issue.");
+        post.Lock.ExceptionInfo.Type.Should().Be("Exception");
+        (await sut.CountAsync(x => true)).Should().Be(1);
+        (await sut.GetLockedAsync(LockMode.Exception).CountAsync()).Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData(PickType.Update)]
+    [InlineData(PickType.Delete)]
+    [Trait("Category", "Database")]
+    public async Task PickEntityWithExpiredLockThatHaveErrors(PickType type)
+    {
+        ////Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(entity);
+        var scope = await sut.PickForUpdateAsync(entity.Id, actor: "first actor", timeout: TimeSpan.FromSeconds(1));
+        await scope.SetErrorStateAsync(new Exception("Some issue"));
+        await Task.Delay(TimeSpan.FromSeconds(1));
+
+        //Act
+        var act = () => PickAsync(type, sut, entity.Id, "second actor");
+
+        //Assert
+        await act.Should()
+            .ThrowAsync<LockErrorException>()
+            .WithMessage($"Entity with id '{entity.Id}' has an exception attached.");
+        var item = await sut.GetOneAsync(entity.Id);
+        item.Should().NotBeNull();
+        item.Lock.Should().NotBeNull();
+        item.Lock.ExceptionInfo.Should().NotBeNull();
+    }
+
+    [Theory]
+    [InlineData(PickType.Update)]
+    [InlineData(PickType.Delete)]
+    [Trait("Category", "Database")]
+    public async Task PickAndCommitTooLate(PickType type)
+    {
+        // Behaviour changed by the lockable-delayed-commit feature: when the lock is past
+        // expiry but no other writer has touched the document (LockKey still matches),
+        // the commit succeeds. This used to throw LockExpiredException; now it doesn't.
+        // The LockKey atomicity check still drives safety — see PickAndCommitTooLateWhenOtherHavePicked
+        // for the "another writer picked" case.
+        //Arrange
+        var firstActor = "some actor";
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "initial" };
+        await sut.AddAsync(entity);
+        var timeSpan = TimeSpan.Zero;
+        await using var scope = await PickAsync(type, sut, entity.Id, firstActor, timeSpan);
+        var updated = scope.Entity with { Count = 1, Data = "updated" };
+
+        //Act
+        var act = () => scope.CommitAsync(updated);
+
+        //Assert — delayed commit succeeds, document reflects the staged change.
+        await act.Should().NotThrowAsync();
+        var item = await sut.GetOneAsync(entity.Id);
+        if (type == PickType.Delete)
+        {
+            item.Should().BeNull("a delayed PickForDelete commit must actually delete");
+        }
+        else
+        {
+            item.Should().NotBeNull();
+            item.Data.Should().Be("updated");
+            item.Count.Should().Be(1);
+            item.Lock.Should().BeNull("a successful delayed commit clears the lock");
+        }
+    }
+
+    [Theory]
+    [InlineData(PickType.Update)]
+    [InlineData(PickType.Delete)]
+    [Trait("Category", "Database")]
+    public async Task PickAndSetErrorTooLate(PickType type)
+    {
+        //Arrange
+        var firstActor = "some actor";
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "initial" };
+        await sut.AddAsync(entity);
+        var timeSpan = TimeSpan.Zero;
+        await using var scope = await PickAsync(type, sut, entity.Id, firstActor, timeSpan);
+
+        //Act
+        var act = () => scope.SetErrorStateAsync(new Exception("some issue."));
+
+        //Assert
+        await act.Should()
+            .ThrowAsync<LockExpiredException>()
+            .WithMessage($"Too late to release entity of type {nameof(LockableTestEntity)} locked by *");
+        var item = await sut.GetOneAsync(entity.Id);
+        item.Should().NotBeNull();
+        item.Lock.Should().NotBeNull();
+        item.Lock.ExceptionInfo.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(PickType.Update)]
+    [InlineData(PickType.Delete)]
+    [Trait("Category", "Database")]
+    public async Task PickAndAbandonTooLate(PickType type)
+    {
+        //Arrange
+        var firstActor = "some actor";
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "initial" };
+        await sut.AddAsync(entity);
+        var timeSpan = TimeSpan.Zero;
+        await using var scope = await PickAsync(type, sut, entity.Id, firstActor, timeSpan);
+
+        //Act
+        var act = () => scope.AbandonAsync();
+
+        //Assert
+        await act.Should().NotThrowAsync();
+        var item = await sut.PickForDeleteAsync(entity.Id);
+        item.Should().NotBeNull();
+    }
+
+    [Theory]
+    [InlineData(PickType.Update)]
+    [InlineData(PickType.Delete)]
+    [Trait("Category", "Database")]
+    public async Task PickAndCommitTooLateThenTryToSetException(PickType type)
+    {
+        // Behaviour changed by lockable-delayed-commit: the "too late" commit now
+        // succeeds (when no other writer has touched the doc) rather than throwing.
+        // Setting an exception on the now-released scope still throws
+        // LockAlreadyReleasedException — the scope-already-released guard is unchanged.
+        //Arrange
+        var firstActor = "some actor";
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "initial" };
+        await sut.AddAsync(entity);
+        var timeSpan = TimeSpan.Zero;
+        await using var scope = await PickAsync(type, sut, entity.Id, firstActor, timeSpan);
+        var updated = scope.Entity with { Count = 1, Data = "updated" };
+        var preAct = () => scope.CommitAsync(updated);
+        await preAct.Should().NotThrowAsync("delayed commit succeeds when no other writer has touched the document");
+
+        //Act
+        var act = () => scope.SetErrorStateAsync(new Exception("some issue."));
+
+        //Assert
+        await act.Should()
+            .ThrowAsync<LockAlreadyReleasedException>()
+            .WithMessage("Entity has already been released.");
+    }
+
+    [Theory]
+    [InlineData(PickType.Update)]
+    [InlineData(PickType.Delete)]
+    [Trait("Category", "Database")]
+    public async Task PickAndCommitTooLateWhenOtherHavePicked(PickType type)
+    {
+        // The safety guarantee of lockable-delayed-commit: when ANOTHER writer has picked
+        // the expired lock, the original scope's LockKey is no longer current, and the
+        // delayed commit MUST fail. The exception type is no longer LockExpiredException
+        // (the strict-TTL gate was dropped) — instead the Mongo-side filter mismatch on
+        // LockKey surfaces as InvalidOperationException from ReleaseAsync's "Cannot find
+        // entity before release" guard.
+        //Arrange
+        var firstActor = "some actor";
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "initial" };
+        await sut.AddAsync(entity);
+        var timeSpan = TimeSpan.FromSeconds(1);
+        var scope = await PickAsync(type, sut, entity.Id, firstActor, timeSpan);
+        var updated = scope.Entity with { Count = 1, Data = "updated" };
+        await Task.Delay(timeSpan);
+        await using var otherScope = await PickAsync(type, sut, entity.Id, firstActor, TimeSpan.FromSeconds(2));
+        await otherScope.CommitAsync(scope.Entity with { Count = 1, Data = "hijacked" });
+        await Task.Delay(timeSpan);
+
+        //Act
+        var act = () => scope.CommitAsync(updated);
+
+        //Assert
+        await act.Should().ThrowAsync<InvalidOperationException>();
+
+        await scope.DisposeAsync();
+    }
+
+    private static async Task<RenewableEntityScope<LockableTestEntity, ObjectId>> PickAsync(PickType type, RenewableLockableTestRepositoryCollection sut, ObjectId entityId, string actor = "some actor", TimeSpan? timeSpan = default, Func<CallbackResult<LockableTestEntity>, Task> completeAction = default)
+    {
+        RenewableEntityScope<LockableTestEntity, ObjectId> scope = null;
+        if (type == PickType.Update)
+            scope = await sut.PickForUpdateAsync(entityId, actor: actor, timeout: timeSpan, completeAction: completeAction);
+        else if (type == PickType.Delete)
+            scope = await sut.PickForDeleteAsync(entityId, actor: actor, timeout: timeSpan, completeAction: completeAction);
+        return scope;
+    }
+
+    public enum PickType
+    {
+        Update,
+        Delete
+    }
+}

--- a/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableReleaseAsyncTests.cs
+++ b/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableReleaseAsyncTests.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Bson;
+using Tharga.MongoDB.Lockable;
+using Tharga.MongoDB.Tests.Lockable.Renewable.Base;
+using Tharga.MongoDB.Tests.Support;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests.Lockable.Renewable;
+
+[Collection("Sequential")]
+[CollectionDefinition("Sequential", DisableParallelization = true)]
+public class RenewableReleaseAsyncTests : RenewableLockableTestBase
+{
+    [Theory]
+    [InlineData(ReleaseMode.ExceptionOnly, 1)]
+    [InlineData(ReleaseMode.LockedOnly, 0)]
+    [InlineData(ReleaseMode.Any, 0)]
+    [Trait("Category", "Database")]
+    public async Task ReleaseLockedAsync(ReleaseMode mode, int locked)
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var lockedEntity = new LockableTestEntity
+        {
+            Id = ObjectId.GenerateNewId(), Lock = new Lock { LockTime = DateTime.UtcNow, LockKey = Guid.NewGuid(), ExpireTime = DateTime.UtcNow.AddSeconds(30) }
+        };
+        await sut.AddAsync(lockedEntity);
+
+        //Act
+        var result = await sut.ReleaseOneAsync(lockedEntity.Id, mode);
+
+        //Assert
+        (await sut.CountAsync(x => true)).Should().Be(1);
+        (await sut.GetLockedAsync(LockMode.Locked).ToArrayAsync()).Length.Should().Be(locked);
+        (await sut.GetExpiredAsync().ToArrayAsync()).Length.Should().Be(0);
+        (await sut.GetLockedAsync(LockMode.Exception).ToArrayAsync()).Length.Should().Be(0);
+        (await sut.GetUnlockedAsync().ToArrayAsync()).Length.Should().Be(1 - locked);
+    }
+
+    [Theory]
+    [InlineData(ReleaseMode.ExceptionOnly, 0)]
+    [InlineData(ReleaseMode.LockedOnly, 1)]
+    [InlineData(ReleaseMode.Any, 0)]
+    [Trait("Category", "Database")]
+    public async Task ReleaseExceptionAsync(ReleaseMode mode, int locked)
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var lockedEntity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Lock = new Lock { LockTime = DateTime.UtcNow, LockKey = Guid.NewGuid(), ExceptionInfo = new ExceptionInfo { Message = "Some issue." }, ExpireTime = DateTime.UtcNow.AddSeconds(30) } };
+        await sut.AddAsync(lockedEntity);
+
+        //Act
+        var result = await sut.ReleaseOneAsync(lockedEntity.Id, mode);
+
+        //Assert
+        (await sut.CountAsync(x => true)).Should().Be(1);
+        (await sut.GetLockedAsync(LockMode.Locked).ToArrayAsync()).Length.Should().Be(0);
+        (await sut.GetExpiredAsync().ToArrayAsync()).Length.Should().Be(0);
+        (await sut.GetLockedAsync(LockMode.Exception).ToArrayAsync()).Length.Should().Be(locked);
+        (await sut.GetUnlockedAsync().ToArrayAsync()).Length.Should().Be(1 - locked);
+    }
+
+    [Theory]
+    [InlineData(ReleaseMode.ExceptionOnly)]
+    [InlineData(ReleaseMode.LockedOnly)]
+    [InlineData(ReleaseMode.Any)]
+    [Trait("Category", "Database")]
+    public async Task ReleaseTimeoutAsync(ReleaseMode mode)
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var lockedEntity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Lock = new Lock { LockTime = DateTime.UtcNow, LockKey = Guid.NewGuid(), ExpireTime = DateTime.UtcNow } };
+        await sut.AddAsync(lockedEntity);
+        await Task.Delay(500);
+
+        //Act
+        var result = await sut.ReleaseOneAsync(lockedEntity.Id, mode);
+
+        //Assert
+        //result.Should().Be(mode != ReleaseMode.ExceptionOnly);
+        (await sut.CountAsync(x => true)).Should().Be(1);
+        (await sut.GetLockedAsync(LockMode.Locked).ToArrayAsync()).Length.Should().Be(0);
+        (await sut.GetExpiredAsync().ToArrayAsync()).Length.Should().Be(mode != ReleaseMode.ExceptionOnly ? 0 : 1);
+        (await sut.GetLockedAsync(LockMode.Exception).ToArrayAsync()).Length.Should().Be(0);
+        (await sut.GetUnlockedAsync().ToArrayAsync()).Length.Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData(ReleaseMode.ExceptionOnly)]
+    [InlineData(ReleaseMode.LockedOnly)]
+    [InlineData(ReleaseMode.Any)]
+    [Trait("Category", "Database")]
+    public async Task ReleaseUnlockedAsync(ReleaseMode mode)
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var lockedEntity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(lockedEntity);
+
+        //Act
+        var result = await sut.ReleaseOneAsync(lockedEntity.Id, mode);
+
+        //Assert
+        result.Should().NotBeNull();
+        (await sut.CountAsync(x => true)).Should().Be(1);
+        (await sut.GetLockedAsync(LockMode.Locked).ToArrayAsync()).Length.Should().Be(0);
+        (await sut.GetExpiredAsync().ToArrayAsync()).Length.Should().Be(0);
+        (await sut.GetLockedAsync(LockMode.Exception).ToArrayAsync()).Length.Should().Be(0);
+        (await sut.GetUnlockedAsync().ToArrayAsync()).Length.Should().Be(1);
+    }
+}

--- a/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableReleaseDeleteTests.cs
+++ b/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableReleaseDeleteTests.cs
@@ -1,0 +1,251 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Bson;
+using Tharga.MongoDB.Lockable;
+using Tharga.MongoDB.Lockable.Renewable;
+using Tharga.MongoDB.Tests.Lockable.Base;
+using Tharga.MongoDB.Tests.Lockable.Renewable.Base;
+using Tharga.MongoDB.Tests.Support;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests.Lockable.Renewable;
+
+[Collection("Sequential")]
+[CollectionDefinition("Sequential", DisableParallelization = true)]
+public class RenewableReleaseDeleteTests : RenewableLockableTestBase
+{
+    [Theory]
+    [MemberData(nameof(ReleaseTypes))]
+    [Trait("Category", "Database")]
+    public async Task ReleaseLockedEntity(ReleaseType release)
+    {
+        //Arrange
+        var collection = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var id = ObjectId.GenerateNewId();
+        var entity = new LockableTestEntity { Id = id };
+        await collection.AddAsync(entity);
+        CallbackResult<LockableTestEntity> callbackResult = null;
+        var eventCount = 0;
+        await using var sut = await collection.PickForDeleteAsync(entity.Id, completeAction: e =>
+        {
+            eventCount++;
+            callbackResult = e;
+            return Task.CompletedTask;
+        });
+
+        //Act
+        var act = () => ReleaseAsync(release, sut, sut.Entity with { Count = 1 });
+
+        //Assert
+        await act.Should().NotThrowAsync();
+        eventCount.Should().Be(1);
+        callbackResult.Should().NotBeNull();
+        callbackResult.Before.Id.Should().Be(entity.Id);
+        callbackResult.LockAction.Should().Be(release == ReleaseType.Commit ? LockAction.CommitDeleted : release == ReleaseType.SetErrorState ? LockAction.Exception : LockAction.Abandoned);
+        var item = await collection.GetOneAsync(sut.Entity.Id);
+        if (release == ReleaseType.Commit)
+        {
+            item.Should().BeNull();
+            callbackResult.After.Should().BeNull();
+        }
+        else
+        {
+            item.Should().NotBeNull();
+            callbackResult.After.Id.Should().Be(entity.Id);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(ReleaseTypes))]
+    [Trait("Category", "Database")]
+    public async Task ReleaseEntityWithExpiredLock(ReleaseType release)
+    {
+        //Arrange
+        var collection = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await collection.AddAsync(entity);
+        CallbackResult<LockableTestEntity> callbackResult = null;
+        var eventCount = 0;
+        await using var sut = await collection.PickForDeleteAsync(entity.Id, TimeSpan.Zero, completeAction: e =>
+        {
+            eventCount++;
+            callbackResult = e;
+            return Task.CompletedTask;
+        });
+
+        //Act
+        var act = () => ReleaseAsync(release, sut, sut.Entity with { Count = 1 });
+
+        //Assert — behaviour changed by lockable-delayed-commit: Commit now succeeds for an
+        //expired-but-untouched lock (deleting the doc); the document is removed by the
+        //delayed PickForDelete commit. SetErrorState still throws — exception-release stays strict.
+        if (release == ReleaseType.SetErrorState)
+        {
+            await act.Should()
+                .ThrowAsync<LockExpiredException>()
+                .WithMessage($"Too late to release entity of type {nameof(LockableTestEntity)} locked by *");
+            eventCount.Should().Be(0);
+            callbackResult.Should().BeNull();
+            var item = await collection.GetOneAsync(sut.Entity.Id);
+            item.Should().NotBeNull();
+        }
+        else
+        {
+            await act.Should().NotThrowAsync();
+            if (release == ReleaseType.Commit)
+            {
+                eventCount.Should().Be(1, "the delayed-commit path still fires the completion callback");
+                callbackResult.Should().NotBeNull();
+                callbackResult.LockAction.Should().Be(LockAction.CommitDeleted);
+                var deletedItem = await collection.GetOneAsync(sut.Entity.Id);
+                deletedItem.Should().BeNull("delayed PickForDelete commit must actually delete");
+            }
+            else
+            {
+                eventCount.Should().Be(0);
+                callbackResult.Should().BeNull();
+                var item = await collection.GetOneAsync(sut.Entity.Id);
+                item.Should().NotBeNull();
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(ReleaseTypes))]
+    [Trait("Category", "Database")]
+    public async Task ReleaseEntityTwice(ReleaseType release)
+    {
+        //Arrange
+        var collection = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await collection.AddAsync(entity);
+        var eventCount = 0;
+        CallbackResult<LockableTestEntity> callbackResult = null;
+        await using var sut = await collection.PickForDeleteAsync(entity.Id, completeAction: e =>
+        {
+            eventCount++;
+            callbackResult = e;
+            return Task.CompletedTask;
+        });
+        await ReleaseAsync(release, sut, sut.Entity with { Count = 1 });
+
+        //Act
+        var act = () => ReleaseAsync(release, sut, sut.Entity with { Count = 2 });
+
+        //Assert
+        eventCount.Should().Be(1);
+        callbackResult.Should().NotBeNull();
+        await act.Should()
+            .ThrowAsync<LockAlreadyReleasedException>()
+            .WithMessage("Entity has already been released.");
+        var item = await collection.GetOneAsync(sut.Entity.Id);
+        if (release == ReleaseType.Commit)
+            item.Should().BeNull();
+        else
+            item.Should().NotBeNull();
+    }
+
+    [Theory]
+    [MemberData(nameof(ReleaseTypes))]
+    [Trait("Category", "Database")]
+    public async Task ReleasOtherEntity(ReleaseType release)
+    {
+        //Arrange
+        var collection = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await collection.AddAsync(entity);
+        var eventCount = 0;
+        CallbackResult<LockableTestEntity> callbackResult = null;
+        await using var sut = await collection.PickForDeleteAsync(entity.Id, completeAction: e =>
+        {
+            eventCount++;
+            callbackResult = e;
+            return Task.CompletedTask;
+        });
+
+        //Act
+        var act = () => ReleaseAsync(release, sut, sut.Entity with { Id = ObjectId.GenerateNewId(), Count = 1 });
+
+        //Assert
+        eventCount.Should().Be(0);
+        callbackResult.Should().BeNull();
+        if (release == ReleaseType.Commit)
+        {
+            await act.Should()
+                .ThrowAsync<UnlockDifferentEntityException>()
+                .WithMessage("Cannot release entity with different id. Original was '*");
+        }
+
+        var item = await collection.GetOneAsync(sut.Entity.Id);
+        item.Should().NotBeNull();
+    }
+
+    [Theory]
+    [MemberData(nameof(ReleaseTypes))]
+    [Trait("Category", "Database")]
+    public async Task ReleasEntityLockedByOtherScope(ReleaseType release)
+    {
+        //Arrange
+        var collection = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await collection.AddAsync(entity);
+        var eventCount = 0;
+        CallbackResult<LockableTestEntity> callbackResult = null;
+        await using var sut = await collection.PickForDeleteAsync(entity.Id, TimeSpan.Zero, completeAction: e =>
+        {
+            eventCount++;
+            callbackResult = e;
+            return Task.CompletedTask;
+        });
+
+        //Act
+        var act = () => ReleaseAsync(release, sut, sut.Entity with { Count = 1 });
+
+        //Assert — same as ReleaseEntityWithExpiredLock: delayed PickForDelete commit now
+        //succeeds (deletes the doc); SetErrorState still throws.
+        if (release == ReleaseType.SetErrorState)
+        {
+            await act.Should().ThrowAsync<LockExpiredException>();
+            eventCount.Should().Be(0);
+            callbackResult.Should().BeNull();
+            var item = await collection.GetOneAsync(sut.Entity.Id);
+            item.Should().NotBeNull();
+        }
+        else
+        {
+            await act.Should().NotThrowAsync();
+            if (release == ReleaseType.Commit)
+            {
+                eventCount.Should().Be(1);
+                callbackResult.Should().NotBeNull();
+                var deletedItem = await collection.GetOneAsync(sut.Entity.Id);
+                deletedItem.Should().BeNull();
+            }
+            else
+            {
+                var item = await collection.GetOneAsync(sut.Entity.Id);
+                item.Should().NotBeNull();
+            }
+        }
+    }
+
+    private static Task ReleaseAsync(ReleaseType release, RenewableEntityScope<LockableTestEntity, ObjectId> sut, LockableTestEntity entity)
+    {
+        switch (release)
+        {
+            case ReleaseType.Commit:
+                return sut.CommitAsync(entity);
+            case ReleaseType.Abandon:
+                return sut.AbandonAsync();
+            case ReleaseType.SetErrorState:
+                return sut.SetErrorStateAsync(new Exception("Some issue."));
+            default:
+                throw new ArgumentOutOfRangeException(nameof(release), release, null);
+        }
+    }
+
+    public static IEnumerable<object[]> ReleaseTypes => Enum.GetValues<ReleaseType>().Select(x => new object[] { x });
+}

--- a/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableReleaseUpdateTests.cs
+++ b/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableReleaseUpdateTests.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Bson;
+using Tharga.MongoDB.Lockable;
+using Tharga.MongoDB.Lockable.Renewable;
+using Tharga.MongoDB.Tests.Lockable.Base;
+using Tharga.MongoDB.Tests.Lockable.Renewable.Base;
+using Tharga.MongoDB.Tests.Support;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests.Lockable.Renewable;
+
+[Collection("Sequential")]
+[CollectionDefinition("Sequential", DisableParallelization = true)]
+public class RenewableReleaseUpdateTests : RenewableLockableTestBase
+{
+    [Theory]
+    [MemberData(nameof(ReleaseTypes))]
+    [Trait("Category", "Database")]
+    public async Task ReleaseLockedEntity(ReleaseType release)
+    {
+        //Arrange
+        var collection = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await collection.AddAsync(entity);
+        var eventCount = 0;
+        CallbackResult<LockableTestEntity> callbackResult = null;
+        await using var sut = await collection.PickForUpdateAsync(entity.Id, completeAction: e =>
+        {
+            eventCount++;
+            callbackResult = e;
+            return Task.CompletedTask;
+        });
+
+        //Act
+        var act = () => ReleaseAsync(release, sut, sut.Entity with { Count = 1 });
+
+        //Assert
+        await act.Should().NotThrowAsync();
+        eventCount.Should().Be(1);
+        callbackResult.Should().NotBeNull();
+        callbackResult.Before.Id.Should().Be(entity.Id);
+        callbackResult.After.Id.Should().Be(entity.Id);
+        callbackResult.LockAction.Should().Be(release == ReleaseType.Commit ? LockAction.CommitUpdated : release == ReleaseType.SetErrorState ? LockAction.Exception : LockAction.Abandoned);
+        var item = await collection.GetOneAsync(sut.Entity.Id);
+        item.Should().NotBeNull();
+        if (release != ReleaseType.SetErrorState) item.Lock.Should().BeNull(); else item.Lock.Should().NotBeNull();
+    }
+
+    [Theory]
+    [MemberData(nameof(ReleaseTypes))]
+    [Trait("Category", "Database")]
+    public async Task ReleaseEntityWithExpiredLock(ReleaseType release)
+    {
+        //Arrange
+        var collection = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await collection.AddAsync(entity);
+        var eventCount = 0;
+        CallbackResult<LockableTestEntity> callbackResult = null;
+        await using var sut = await collection.PickForUpdateAsync(entity.Id, TimeSpan.Zero, completeAction: e =>
+        {
+            eventCount++;
+            callbackResult = e;
+            return Task.CompletedTask;
+        });
+
+        //Act
+        var act = () => ReleaseAsync(release, sut, sut.Entity with { Count = 1 });
+
+        //Assert — behaviour changed by lockable-delayed-commit: Commit now succeeds for an
+        //expired-but-untouched lock (LockKey still matches). SetErrorState still throws —
+        //the exception-release path stays strict per the feature spec. Abandon is unchanged.
+        if (release == ReleaseType.SetErrorState)
+        {
+            await act.Should()
+                .ThrowAsync<LockExpiredException>()
+                .WithMessage($"Too late to release entity of type {nameof(LockableTestEntity)} locked by *");
+            eventCount.Should().Be(0);
+            callbackResult.Should().BeNull();
+        }
+        else
+        {
+            await act.Should().NotThrowAsync();
+            if (release == ReleaseType.Commit)
+            {
+                eventCount.Should().Be(1, "the delayed-commit path still fires the completion callback");
+                callbackResult.Should().NotBeNull();
+                callbackResult.LockAction.Should().Be(LockAction.CommitUpdated);
+            }
+            else
+            {
+                eventCount.Should().Be(0, "Abandon does not fire the completion callback");
+                callbackResult.Should().BeNull();
+            }
+        }
+        var item = await collection.GetOneAsync(sut.Entity.Id);
+        item.Should().NotBeNull();
+    }
+
+    [Theory]
+    [MemberData(nameof(ReleaseTypes))]
+    [Trait("Category", "Database")]
+    public async Task ReleaseEntityTwice(ReleaseType release)
+    {
+        //Arrange
+        var collection = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await collection.AddAsync(entity);
+        await using var sut = await collection.PickForUpdateAsync(entity.Id);
+        await ReleaseAsync(release, sut, sut.Entity with { Count = 1 });
+
+        //Act
+        var act = () => ReleaseAsync(release, sut, sut.Entity with { Count = 2 });
+
+        //Assert
+        await act.Should()
+            .ThrowAsync<LockAlreadyReleasedException>()
+            .WithMessage("Entity has already been released.");
+        var item = await collection.GetOneAsync(sut.Entity.Id);
+        item.Should().NotBeNull();
+        if (release != ReleaseType.SetErrorState) item.Lock.Should().BeNull(); else item.Lock.Should().NotBeNull();
+    }
+
+    [Theory]
+    [MemberData(nameof(ReleaseTypes))]
+    [Trait("Category", "Database")]
+    public async Task ReleasOtherEntity(ReleaseType release)
+    {
+        //Arrange
+        var collection = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await collection.AddAsync(entity);
+        await using var sut = await collection.PickForUpdateAsync(entity.Id);
+
+        //Act
+        var act = () => ReleaseAsync(release, sut, sut.Entity with { Id = ObjectId.GenerateNewId(), Count = 1 });
+
+        //Assert
+        if (release == ReleaseType.Commit)
+        {
+            await act.Should()
+                .ThrowAsync<UnlockDifferentEntityException>()
+                .WithMessage("Cannot release entity with different id. Original was '*");
+        }
+
+        var item = await collection.GetOneAsync(sut.Entity.Id);
+        item.Should().NotBeNull();
+    }
+
+    [Theory]
+    [MemberData(nameof(ReleaseTypes))]
+    [Trait("Category", "Database")]
+    public async Task ReleasEntityLockedByOtherScope(ReleaseType release)
+    {
+        //Arrange
+        var collection = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await collection.AddAsync(entity);
+        var eventCount = 0;
+        CallbackResult<LockableTestEntity> callbackResult = null;
+        await using var sut = await collection.PickForUpdateAsync(entity.Id, TimeSpan.Zero, completeAction: e =>
+        {
+            eventCount++;
+            callbackResult = e;
+            return Task.CompletedTask;
+        });
+
+        //Act
+        var act = () => ReleaseAsync(release, sut, sut.Entity with { Count = 1 });
+
+        //Assert — same as ReleaseEntityWithExpiredLock: the lockable-delayed-commit feature
+        //means Commit now succeeds for an immediately-expired pick (LockKey still ours).
+        //SetErrorState still throws; Abandon is unchanged.
+        if (release == ReleaseType.SetErrorState)
+        {
+            await act.Should().ThrowAsync<LockExpiredException>();
+            eventCount.Should().Be(0);
+            callbackResult.Should().BeNull();
+        }
+        else
+        {
+            await act.Should().NotThrowAsync();
+            if (release == ReleaseType.Commit)
+            {
+                eventCount.Should().Be(1);
+                callbackResult.Should().NotBeNull();
+            }
+        }
+        var item = await collection.GetOneAsync(sut.Entity.Id);
+        item.Should().NotBeNull();
+    }
+
+    private static Task ReleaseAsync(ReleaseType release, RenewableEntityScope<LockableTestEntity, ObjectId> sut, LockableTestEntity entity)
+    {
+        switch (release)
+        {
+            case ReleaseType.Commit:
+                return sut.CommitAsync(entity);
+            case ReleaseType.Abandon:
+                return sut.AbandonAsync();
+            case ReleaseType.SetErrorState:
+                return sut.SetErrorStateAsync(new Exception("Some issue."));
+            default:
+                throw new ArgumentOutOfRangeException(nameof(release), release, null);
+        }
+    }
+
+    public static IEnumerable<object[]> ReleaseTypes => Enum.GetValues<ReleaseType>().Select(x => new object[] { x });
+}

--- a/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableTransactionsTests.cs
+++ b/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableTransactionsTests.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Tharga.MongoDB.Lockable;
+using Tharga.MongoDB.Tests.Lockable.Renewable.Base;
+using Tharga.MongoDB.Tests.Support;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests.Lockable.Renewable;
+
+[Collection("Sequential")]
+[CollectionDefinition("Sequential", DisableParallelization = true)]
+public class RenewableTransactionsTests : RenewableLockableTestBase
+{
+    [Fact]
+    [Trait("Category", "Database")]
+    [Trait("Category", "RequiresReplicaSet")]
+    public async Task WithTransactionAsync_Renewable_CommitsAtomically()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "before" };
+        await sut.AddAsync(entity);
+
+        await _mongoDbServiceFactory.WithTransactionAsync(async (session, ct) =>
+        {
+            await using var scope = await sut.LockAsync(entity.Id, session: session);
+            await scope.CommitAsync(CommitMode.Update, scope.Entity with { Data = "after" });
+        });
+
+        var post = await sut.GetOneAsync(entity.Id);
+        post.Data.Should().Be("after");
+        post.Lock.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    [Trait("Category", "RequiresReplicaSet")]
+    public async Task WithTransactionAsync_Renewable_RollbackOnException_LeavesEntityUnchanged()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "before" };
+        await sut.AddAsync(entity);
+
+        Func<Task> act = async () =>
+        {
+            await _mongoDbServiceFactory.WithTransactionAsync(async (session, ct) =>
+            {
+                await using var scope = await sut.LockAsync(entity.Id, session: session);
+                await scope.CommitAsync(CommitMode.Update, scope.Entity with { Data = "should-not-stick" });
+                throw new InvalidOperationException("triggered abort");
+            });
+        };
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+
+        var post = await sut.GetOneAsync(entity.Id);
+        post.Data.Should().Be("before");
+        post.Lock.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    [Trait("Category", "RequiresReplicaSet")]
+    public async Task LockManyAsync_TransactionalCommit_AllOrNothing()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var a = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "a" };
+        var b = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "b" };
+        await sut.AddAsync(a);
+        await sut.AddAsync(b);
+
+        await using var lease = await sut.LockManyAsync(new[] { a.Id, b.Id });
+
+        lease.MarkForUpdate(lease.Documents.Single(d => d.Id == a.Id) with { Data = "a-updated" });
+        lease.MarkForUpdate(lease.Documents.Single(d => d.Id == b.Id) with { Data = "b-updated" });
+
+        var summary = await lease.CommitAsync(transactional: true);
+
+        summary.Updated.Should().Be(2);
+        summary.Failures.Should().BeEmpty();
+        (await sut.GetOneAsync(a.Id)).Data.Should().Be("a-updated");
+        (await sut.GetOneAsync(b.Id)).Data.Should().Be("b-updated");
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    [Trait("Category", "RequiresReplicaSet")]
+    public async Task LockManyAsync_TransactionalCommit_ReusesBoundSession()
+    {
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var a = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "a" };
+        await sut.AddAsync(a);
+
+        // Outer transaction binds the session; inner transactional commit should reuse it (no nested transaction).
+        await _mongoDbServiceFactory.WithTransactionAsync(async (session, ct) =>
+        {
+            await using var lease = await sut.LockManyAsync(new[] { a.Id }, session: session);
+            lease.MarkForUpdate(lease.Documents.Single() with { Data = "a-outer" });
+            // transactional: true is a no-op when an outer session is bound (uses _boundSession path).
+            var summary = await lease.CommitAsync(transactional: true, ct);
+            summary.Updated.Should().Be(1);
+        });
+
+        (await sut.GetOneAsync(a.Id)).Data.Should().Be("a-outer");
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    [Trait("Category", "RequiresReplicaSet")]
+    public async Task WithTransactionAsync_MixedDiskAndRenewable_BothCommitOrAbortTogether()
+    {
+        var lockable = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "x" };
+        await lockable.AddAsync(entity);
+
+        // First transaction: commit both
+        await _mongoDbServiceFactory.WithTransactionAsync(async (session, ct) =>
+        {
+            await using var scope = await lockable.LockAsync(entity.Id, session: session);
+            await scope.CommitAsync(CommitMode.Update, scope.Entity with { Data = "x-commit" });
+            await lockable.AddAsync(new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "extra" }, session);
+        });
+
+        (await lockable.GetOneAsync(entity.Id)).Data.Should().Be("x-commit");
+        (await lockable.CountAsync(_ => true)).Should().Be(2);
+
+        // Second transaction: abort by exception
+        Func<Task> act = async () => await _mongoDbServiceFactory.WithTransactionAsync(async (session, ct) =>
+        {
+            await using var scope = await lockable.LockAsync(entity.Id, session: session);
+            await scope.CommitAsync(CommitMode.Update, scope.Entity with { Data = "x-rollback" });
+            await lockable.AddAsync(new LockableTestEntity { Id = ObjectId.GenerateNewId(), Data = "should-rollback" }, session);
+            throw new InvalidOperationException("abort");
+        });
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        (await lockable.GetOneAsync(entity.Id)).Data.Should().Be("x-commit"); // unchanged
+        (await lockable.CountAsync(_ => true)).Should().Be(2); // no new doc
+    }
+}

--- a/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableWaitForDeleteTests.cs
+++ b/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableWaitForDeleteTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Bson;
+using Tharga.MongoDB.Tests.Lockable.Renewable.Base;
+using Tharga.MongoDB.Tests.Support;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests.Lockable.Renewable;
+
+[Collection("Sequential")]
+[CollectionDefinition("Sequential", DisableParallelization = true)]
+public class RenewableWaitForDeleteTests : RenewableLockableTestBase
+{
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task WaitForDelete()
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(entity);
+
+        //Act
+        await using var result = await sut.WaitForDeleteAsync(entity.Id);
+
+        //Assert
+        result.Entity.Should().NotBeNull();
+        result.Entity.Should().Be(entity);
+        var item = await sut.GetOneAsync(entity.Id);
+        item.Should().NotBeNull();
+        item.Lock.Should().NotBeNull();
+        item.Lock.ExceptionInfo.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task WaitForLockedEntityThatIsNotReleased()
+    {
+        //Arrange
+        var firstActor = "some actor";
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(entity);
+        await sut.PickForUpdateAsync(entity.Id, actor: firstActor);
+
+        //Act
+        var act = () => sut.WaitForDeleteAsync(entity.Id, TimeSpan.FromSeconds(1), default, "test actor");
+
+        //Assert
+        await act.Should()
+            .ThrowAsync<TimeoutException>()
+            .WithMessage("No valid entity has been released for update.");
+        var item = await sut.GetOneAsync(entity.Id);
+        item.Should().NotBeNull();
+        item.Lock.Should().NotBeNull();
+        item.Lock.ExceptionInfo.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task WaitForLockedEntityThatIsReleased()
+    {
+        //Arrange
+        var firstActor = "some actor";
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(entity);
+        await sut.PickForUpdateAsync(entity.Id, actor: firstActor, timeout: TimeSpan.FromSeconds(1));
+
+        //Act
+        await using var result = await sut.WaitForDeleteAsync(entity.Id, TimeSpan.FromSeconds(2));
+
+        //Assert
+        result.Entity.Should().NotBeNull();
+        var item = await sut.GetOneAsync(entity.Id);
+        item.Should().NotBeNull();
+        item.Lock.Should().NotBeNull();
+        item.Lock.ExceptionInfo.Should().BeNull();
+    }
+}

--- a/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableWaitForUpdateTests.cs
+++ b/Tharga.MongoDB.Tests/Lockable/Renewable/RenewableWaitForUpdateTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Bson;
+using Tharga.MongoDB.Lockable;
+using Tharga.MongoDB.Tests.Lockable.Renewable.Base;
+using Tharga.MongoDB.Tests.Support;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests.Lockable.Renewable;
+
+[Collection("Sequential")]
+[CollectionDefinition("Sequential", DisableParallelization = true)]
+public class RenewableWaitForUpdateTests : RenewableLockableTestBase
+{
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task WaitForEntity()
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(entity);
+
+        //Act
+        await using var result = await sut.WaitForUpdateAsync(entity.Id);
+
+        //Assert
+        result.Entity.Should().NotBeNull();
+        result.Entity.Should().Be(entity);
+        var item = await sut.GetOneAsync(entity.Id);
+        item.Should().NotBeNull();
+        item.Lock.Should().NotBeNull();
+        item.Lock.ExceptionInfo.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task WaitForLockedEntityThatIsNotReleased()
+    {
+        //Arrange
+        var firstActor = "some actor";
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(entity);
+        await sut.PickForUpdateAsync(entity.Id, actor: firstActor);
+
+        //Act
+        var act = () => sut.WaitForUpdateAsync(entity.Id, TimeSpan.FromSeconds(1), default, "test actor");
+
+        //Assert
+        await act.Should()
+            .ThrowAsync<TimeoutException>()
+            .WithMessage("No valid entity has been released for update.");
+        var item = await sut.GetOneAsync(entity.Id);
+        item.Should().NotBeNull();
+        item.Lock.Should().NotBeNull();
+        item.Lock.ExceptionInfo.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task WaitForLockedEntityThatIsReleased()
+    {
+        //Arrange
+        var firstActor = "some actor";
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(entity);
+        await sut.PickForUpdateAsync(entity.Id, actor: firstActor, timeout: TimeSpan.FromSeconds(1));
+
+        //Act
+        await using var result = await sut.WaitForUpdateAsync(entity.Id, TimeSpan.FromSeconds(2));
+
+        //Assert
+        result.Entity.Should().NotBeNull();
+        var item = await sut.GetOneAsync(entity.Id);
+        item.Should().NotBeNull();
+        item.Lock.Should().NotBeNull();
+        item.Lock.ExceptionInfo.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task WaitForEntityWithException()
+    {
+        //Arrange
+        var firstActor = "some actor";
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(entity);
+        var scope = await sut.PickForUpdateAsync(entity.Id, actor: firstActor);
+        await scope.SetErrorStateAsync(new Exception("Some issue"));
+
+        //Act
+        var act = () => sut.WaitForUpdateAsync(entity.Id);
+
+        //Assert
+        await act.Should()
+            .ThrowAsync<LockErrorException>()
+            .WithMessage($"Entity with id '{entity.Id}' has an exception attached.");
+        var item = await sut.GetOneAsync(entity.Id);
+        item.Should().NotBeNull();
+        item.Lock.Should().NotBeNull();
+        item.Lock.ExceptionInfo.Should().NotBeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task WaitForEntityThatDoesNotExist()
+    {
+        //Arrange
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+
+        //Act
+        await using var result = await sut.WaitForUpdateAsync(ObjectId.GenerateNewId());
+
+        //Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task WaitForEntityWithExpiredLock()
+    {
+        //Arrange
+        var firstActor = "some actor";
+        var sut = new RenewableLockableTestRepositoryCollection(_mongoDbServiceFactory);
+        var entity = new LockableTestEntity { Id = ObjectId.GenerateNewId() };
+        await sut.AddAsync(entity);
+        await sut.PickForUpdateAsync(entity.Id, actor: firstActor, timeout: TimeSpan.Zero);
+
+        //Act
+        await using var result = await sut.WaitForUpdateAsync(entity.Id);
+
+        //Assert
+        result.Entity.Should().NotBeNull();
+        result.Entity.Count.Should().Be(entity.Count);
+        var item = await sut.GetOneAsync(entity.Id);
+        item.Should().NotBeNull();
+        item.Lock.Should().NotBeNull();
+        item.Lock.ExceptionInfo.Should().BeNull();
+    }
+}

--- a/Tharga.MongoDB/Lockable/Renewable/IRenewableLockRepositoryCollection.cs
+++ b/Tharga.MongoDB/Lockable/Renewable/IRenewableLockRepositoryCollection.cs
@@ -1,0 +1,93 @@
+using MongoDB.Bson;
+using MongoDB.Driver;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tharga.MongoDB.Lockable.Renewable;
+
+public interface IRenewableLockRepositoryCollection<TEntity, TKey> : IRepositoryCollection<TEntity, TKey>
+    where TEntity : LockableEntityBase<TKey>
+{
+    event EventHandler<LockEventArgs<TEntity>> LockEvent;
+
+    //Update
+    Task<long> UpdateUnlockedAsync(Expression<Func<TEntity, bool>> predicate, UpdateDefinition<TEntity> update);
+    Task<long> UpdateUnlockedAsync(FilterDefinition<TEntity> filter, UpdateDefinition<TEntity> update);
+
+    //Delete
+    Task<TEntity> DeleteOneUnlockedAsync(Expression<Func<TEntity, bool>> predicate, OneOption<TEntity> options = null);
+    Task<TEntity> DeleteOneUnlockedAsync(FilterDefinition<TEntity> filter, OneOption<TEntity> options = null);
+
+    Task<long> DeleteManyUnlockedAsync(Expression<Func<TEntity, bool>> predicate = null);
+    Task<long> DeleteManyUnlockedAsync(FilterDefinition<TEntity> filter);
+    Task<long> DeleteManyAsync(DeleteMode deleteMode, Expression<Func<TEntity, bool>> predicate = null);
+
+    //Lock
+    Expression<Func<TEntity, bool>> UnlockedOrExpiredFilter { get; }
+    Expression<Func<TEntity, bool>> LockedOrExceptionFilter { get; }
+    Expression<Func<TEntity, bool>> ExceptionFilter { get; }
+    Expression<Func<TEntity, bool>> LockedFilter { get; }
+
+    IAsyncEnumerable<TEntity> GetUnlockedAsync(Expression<Func<TEntity, bool>> predicate = null, Options<TEntity> options = null, CancellationToken cancellationToken = default);
+    IAsyncEnumerable<TEntity> GetUnlockedAsync(FilterDefinition<TEntity> filter, Options<TEntity> options = null, CancellationToken cancellationToken = default);
+
+    Task<RenewableEntityScope<TEntity, TKey>> PickForUpdateAsync(TKey id, TimeSpan? timeout = null, string actor = null, Func<CallbackResult<TEntity>, Task> completeAction = null, IClientSessionHandle session = null);
+    Task<RenewableEntityScope<TEntity, TKey>> PickForUpdateAsync(FilterDefinition<TEntity> filter, TimeSpan? timeout = null, string actor = null, Func<CallbackResult<TEntity>, Task> completeAction = null, IClientSessionHandle session = null);
+    Task<RenewableEntityScope<TEntity, TKey>> PickForUpdateAsync(Expression<Func<TEntity, bool>> predicate = null, TimeSpan? timeout = null, string actor = null, Func<CallbackResult<TEntity>, Task> completeAction = null, IClientSessionHandle session = null);
+    Task<RenewableEntityScope<TEntity, TKey>> PickForDeleteAsync(TKey id, TimeSpan? timeout = null, string actor = null, Func<CallbackResult<TEntity>, Task> completeAction = null, IClientSessionHandle session = null);
+    Task<RenewableEntityScope<TEntity, TKey>> PickForDeleteAsync(FilterDefinition<TEntity> filter, TimeSpan? timeout = null, string actor = null, Func<CallbackResult<TEntity>, Task> completeAction = null, IClientSessionHandle session = null);
+    Task<RenewableEntityScope<TEntity, TKey>> PickForDeleteAsync(Expression<Func<TEntity, bool>> predicate = null, TimeSpan? timeout = null, string actor = null, Func<CallbackResult<TEntity>, Task> completeAction = null, IClientSessionHandle session = null);
+
+    Task<RenewableEntityScope<TEntity, TKey>> WaitForUpdateAsync(TKey id, TimeSpan? lockTimeout = null, TimeSpan? waitTimeout = null, string actor = null, Func<CallbackResult<TEntity>, Task> completeAction = null, CancellationToken cancellationToken = default);
+    Task<RenewableEntityScope<TEntity, TKey>> WaitForDeleteAsync(TKey id, TimeSpan? lockTimeout = null, TimeSpan? waitTimeout = null, string actor = null, Func<CallbackResult<TEntity>, Task> completeAction = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Locks a single document without pre-committing to update-vs-delete. The decision is taken at commit time
+    /// via <c>RenewableLockScope&lt;TEntity, TKey&gt;.CommitAsync(CommitMode, TEntity)</c>.
+    /// </summary>
+    Task<RenewableLockScope<TEntity, TKey>> LockAsync(TKey id, TimeSpan? timeout = null, string actor = null, Func<CallbackResult<TEntity>, Task> completeAction = null, IClientSessionHandle session = null);
+
+    /// <summary>
+    /// Locks a single document matched by <paramref name="filter"/> without pre-committing to update-vs-delete.
+    /// </summary>
+    Task<RenewableLockScope<TEntity, TKey>> LockAsync(FilterDefinition<TEntity> filter, TimeSpan? timeout = null, string actor = null, Func<CallbackResult<TEntity>, Task> completeAction = null, IClientSessionHandle session = null);
+
+    /// <summary>
+    /// Locks a single document matched by <paramref name="predicate"/> without pre-committing to update-vs-delete.
+    /// </summary>
+    Task<RenewableLockScope<TEntity, TKey>> LockAsync(Expression<Func<TEntity, bool>> predicate = null, TimeSpan? timeout = null, string actor = null, Func<CallbackResult<TEntity>, Task> completeAction = null, IClientSessionHandle session = null);
+
+    /// <summary>
+    /// Locks multiple documents identified by <paramref name="ids"/>. Acquisition is sequential and ordered by key
+    /// to avoid AB / BA deadlocks; if any acquisition fails, locks acquired so far are released and the failure
+    /// is propagated (the lease never returns half-acquired). Per-document commit decisions are staged on the
+    /// returned <see cref="DocumentLease{TEntity, TKey}"/>.
+    /// </summary>
+    Task<DocumentLease<TEntity, TKey>> LockManyAsync(IEnumerable<TKey> ids, TimeSpan? timeout = null, string actor = null, CancellationToken cancellationToken = default, IClientSessionHandle session = null);
+
+    /// <summary>
+    /// Locks all documents matched by <paramref name="filter"/>. The filter is resolved to an id list at acquire time;
+    /// documents added later are not locked. Otherwise behaves like <see cref="LockManyAsync(IEnumerable{TKey}, TimeSpan?, string, CancellationToken, IClientSessionHandle)"/>.
+    /// </summary>
+    Task<DocumentLease<TEntity, TKey>> LockManyAsync(FilterDefinition<TEntity> filter, TimeSpan? timeout = null, string actor = null, CancellationToken cancellationToken = default, IClientSessionHandle session = null);
+
+    /// <summary>
+    /// Locks all documents matched by <paramref name="predicate"/>. The predicate is resolved to an id list at acquire time.
+    /// </summary>
+    Task<DocumentLease<TEntity, TKey>> LockManyAsync(Expression<Func<TEntity, bool>> predicate, TimeSpan? timeout = null, string actor = null, CancellationToken cancellationToken = default, IClientSessionHandle session = null);
+
+    IAsyncEnumerable<EntityLock<TEntity, TKey>> GetWithLockInfoAsync(FilterDefinition<TEntity> filter = null, Options<TEntity> options = null, CancellationToken cancellationToken = default);
+    IAsyncEnumerable<EntityLock<TEntity, TKey>> GetLockedAsync(LockMode lockMode, FilterDefinition<TEntity> filter = null, Options<TEntity> options = null, CancellationToken cancellationToken = default);
+    IAsyncEnumerable<EntityLock<TEntity, TKey>> GetExpiredAsync(FilterDefinition<TEntity> filter = null, Options<TEntity> options = null, CancellationToken cancellationToken = default);
+
+    Task<EntityChangeResult<TEntity>> ReleaseOneAsync(TKey id, ReleaseMode mode);
+    Task<long> ReleaseManyAsync(ReleaseMode mode);
+}
+
+public interface IRenewableLockRepositoryCollection<TEntity> : IRenewableLockRepositoryCollection<TEntity, ObjectId>
+    where TEntity : LockableEntityBase<ObjectId>
+{
+}

--- a/Tharga.MongoDB/Lockable/Renewable/LockKeepAliveOptions.cs
+++ b/Tharga.MongoDB/Lockable/Renewable/LockKeepAliveOptions.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace Tharga.MongoDB.Lockable.Renewable;
+
+/// <summary>
+/// Tuning for <c>StartKeepAlive</c>. A background loop periodically extends the lease so a short
+/// lease survives long-running work without pinning the document forever if the owner dies.
+/// </summary>
+public record LockKeepAliveOptions
+{
+    /// <summary>
+    /// How often the keep-alive loop attempts an extension. When <c>null</c>, defaults to one third
+    /// of the lease's original timeout, so each lease has three chances to renew before it expires.
+    /// </summary>
+    public TimeSpan? Interval { get; init; }
+
+    /// <summary>
+    /// How far into the future each renewal pushes <c>ExpireTime</c>. When <c>null</c>, defaults to
+    /// the lease's original timeout.
+    /// </summary>
+    public TimeSpan? Extension { get; init; }
+
+    /// <summary>
+    /// Anti-zombie cap. Once the keep-alive loop has been running this long, it stops renewing and
+    /// lets the lease expire — protects against a stuck owner that never releases. Defaults to 4 hours.
+    /// </summary>
+    public TimeSpan MaxTotalDuration { get; init; } = TimeSpan.FromHours(4);
+
+    /// <summary>
+    /// Invoked when a renewal attempt fails. For transient failures the loop continues; for terminal
+    /// failures (lock lost, strict-TTL expiry) the loop stops after invoking this callback.
+    /// </summary>
+    public Action<Exception> OnRenewalFailure { get; init; }
+}

--- a/Tharga.MongoDB/Lockable/Renewable/LockLostException.cs
+++ b/Tharga.MongoDB/Lockable/Renewable/LockLostException.cs
@@ -1,0 +1,16 @@
+namespace Tharga.MongoDB.Lockable.Renewable;
+
+/// <summary>
+/// Thrown when a renewal (extend / keep-alive) finds the lock is no longer owned by this lease —
+/// the document no longer exists, or its <c>LockKey</c> no longer matches because another writer
+/// has since acquired the lock (the expiry recovery path picked it up). Distinct from
+/// <see cref="LockExpiredException"/>, which signals a strict-TTL collection refusing an expired
+/// renewal even though the <c>LockKey</c> still matches.
+/// </summary>
+public class LockLostException : LockException
+{
+    public LockLostException(string message)
+        : base(message)
+    {
+    }
+}

--- a/Tharga.MongoDB/Lockable/Renewable/LockState.cs
+++ b/Tharga.MongoDB/Lockable/Renewable/LockState.cs
@@ -1,0 +1,22 @@
+namespace Tharga.MongoDB.Lockable.Renewable;
+
+/// <summary>
+/// Mutable holder of the current <see cref="Lock"/> reference for a single lease. <see cref="Lock"/>
+/// is immutable; a successful renewal swaps the reference here so that the release path reads the
+/// renewed <c>ExpireTime</c>/<c>LockKey</c> rather than the original lock.
+/// </summary>
+internal sealed class LockState
+{
+    private volatile Lock _current;
+
+    public LockState(Lock current)
+    {
+        _current = current;
+    }
+
+    public Lock Current
+    {
+        get => _current;
+        set => _current = value;
+    }
+}

--- a/Tharga.MongoDB/Lockable/Renewable/RenewableEntityScope.cs
+++ b/Tharga.MongoDB/Lockable/Renewable/RenewableEntityScope.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+
+namespace Tharga.MongoDB.Lockable.Renewable;
+
+/// <summary>
+/// Renewable variant of <see cref="EntityScope{T}"/>. Behaves identically for commit / abandon /
+/// error-state, but additionally exposes lease-renewal: <c>ExtendAsync</c> for an explicit
+/// keep-alive, <c>StartKeepAlive</c> for an automatic background loop, and <c>LockLost</c>
+/// which is cancelled if a renewal discovers the lock has been lost.
+/// </summary>
+public record RenewableEntityScope<T> : RenewableEntityScope<T, ObjectId>
+    where T : LockableEntityBase<ObjectId>
+{
+    internal RenewableEntityScope(T entity, Func<T, bool, Exception, Task> releaseAction, RenewalController controller)
+        : base(entity, releaseAction, controller)
+    {
+    }
+}
+
+/// <summary>
+/// Renewable variant of <see cref="EntityScope{T, TKey}"/>. Behaves identically for commit / abandon /
+/// error-state, but additionally exposes lease-renewal: <c>ExtendAsync</c> for an explicit
+/// keep-alive, <c>StartKeepAlive</c> for an automatic background loop, and <c>LockLost</c>
+/// which is cancelled if a renewal discovers the lock has been lost.
+/// </summary>
+public record RenewableEntityScope<T, TKey> : EntityScope<T, TKey>
+    where T : LockableEntityBase<TKey>
+{
+    private readonly RenewalController _controller;
+
+    internal RenewableEntityScope(T entity, Func<T, bool, Exception, Task> releaseAction, RenewalController controller)
+        : base(entity, releaseAction)
+    {
+        _controller = controller;
+    }
+
+    /// <summary>
+    /// Cancelled when a renewal attempt discovers the lock has been lost (document deleted or
+    /// re-locked by another writer). Long-running work can observe this token to abort early.
+    /// </summary>
+    public CancellationToken LockLost => _controller.LockLost;
+
+    /// <summary>
+    /// Extends the lease, pushing <c>ExpireTime</c> further into the future. Returns the new <c>ExpireTime</c>.
+    /// </summary>
+    /// <param name="extension">How far to extend. When <c>null</c>, reuses the lease's current span.</param>
+    public Task<DateTime> ExtendAsync(TimeSpan? extension = null) => _controller.ExtendAsync(extension);
+
+    /// <summary>
+    /// Starts a background loop that periodically extends the lease until the returned handle is
+    /// disposed or the lease is released. Dispose the handle (or release the scope) to stop it.
+    /// </summary>
+    public IAsyncDisposable StartKeepAlive(LockKeepAliveOptions options = null) => _controller.StartKeepAlive(options);
+}

--- a/Tharga.MongoDB/Lockable/Renewable/RenewableLockRepositoryCollectionBase.cs
+++ b/Tharga.MongoDB/Lockable/Renewable/RenewableLockRepositoryCollectionBase.cs
@@ -1,0 +1,1107 @@
+using Microsoft.Extensions.Logging;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Tharga.MongoDB.Disk;
+using Tharga.MongoDB.Internals;
+
+namespace Tharga.MongoDB.Lockable.Renewable;
+
+public class RenewableLockRepositoryCollectionBase<TEntity, TKey> : RepositoryCollectionBase<TEntity, TKey>, IRenewableLockRepositoryCollection<TEntity, TKey>, IDocumentLeaseTransactionRunner
+    where TEntity : LockableEntityBase<TKey>
+{
+    private DiskRepositoryCollectionBase<TEntity, TKey> _disk;
+    // ReSharper disable once StaticMemberInGenericType
+    private static readonly AutoResetEvent _releaseEvent = new(false);
+
+    protected RenewableLockRepositoryCollectionBase(IMongoDbServiceFactory mongoDbServiceFactory, ILogger logger = null, DatabaseContext databaseContext = null)
+        : base(mongoDbServiceFactory, logger, databaseContext)
+    {
+    }
+
+    public event EventHandler<LockEventArgs<TEntity>> LockEvent;
+
+    internal override IRepositoryCollection<TEntity, TKey> BaseCollection => Disk;
+    private DiskRepositoryCollectionBase<TEntity, TKey> Disk => _disk ??= new GenericDiskRepositoryCollection<TEntity, TKey>(_mongoDbServiceFactory, _databaseContext ?? new DatabaseContext { CollectionName = CollectionName, DatabasePart = DatabasePart, ConfigurationName = ConfigurationName }, _logger, this);
+    public override IEnumerable<CreateIndexModel<TEntity>> CoreIndices =>
+    [
+        new(Builders<TEntity>.IndexKeys.Ascending(x => x.Lock), new CreateIndexOptions { Name = nameof(LockableEntityBase.Lock) }),
+        new(
+            Builders<TEntity>.IndexKeys
+                .Ascending(x => x.Lock.ExceptionInfo)
+                .Ascending(x => x.Lock.ExpireTime)
+                .Ascending(x => x.Lock.LockTime),
+            new CreateIndexOptions { Name = "LockStatus" }
+        )
+    ];
+
+    protected virtual TimeSpan DefaultTimeout { get; init; } = TimeSpan.FromSeconds(30);
+    protected virtual bool RequireActor => true;
+
+    /// <summary>
+    /// When <c>true</c> (default — resolved from <see cref="Configuration.DatabaseOptions.AllowDelayedCommit"/>),
+    /// a successful <c>CommitAsync</c> is permitted even when the lease's lock has expired,
+    /// provided no other writer has touched the document (<c>LockKey</c> still matches). The
+    /// <c>LockKey</c> atomicity check still drives the safety guarantee.
+    /// Override to <c>false</c> to pin a specific collection to strict-TTL semantics regardless
+    /// of the global option — <c>CommitAsync</c> will throw <see cref="LockExpiredException"/>
+    /// for any expired lease as it did before this feature.
+    /// </summary>
+    protected virtual bool AllowDelayedCommit => _mongoDbServiceFactory.AllowDelayedCommit;
+
+    //Read
+    public override IAsyncEnumerable<TEntity> GetAsync(Expression<Func<TEntity, bool>> predicate = null, Options<TEntity> options = null, CancellationToken cancellationToken = default)
+    {
+        return Disk.GetAsync(predicate, options, cancellationToken);
+    }
+
+    public override IAsyncEnumerable<TEntity> GetAsync(FilterDefinition<TEntity> filter, Options<TEntity> options = null, CancellationToken cancellationToken = default)
+    {
+        return Disk.GetAsync(filter, options, cancellationToken);
+    }
+
+    public override IAsyncEnumerable<T> GetProjectionAsync<T>(Expression<Func<TEntity, bool>> predicate = null, Options<TEntity> options = null, CancellationToken cancellationToken = default)
+    {
+        return Disk.GetProjectionAsync<T>(predicate, options, cancellationToken);
+    }
+
+    public override IAsyncEnumerable<T> GetProjectionAsync<T>(FilterDefinition<TEntity> filter, Options<TEntity> options = null, CancellationToken cancellationToken = default)
+    {
+        return Disk.GetProjectionAsync<T>(filter, options, cancellationToken);
+    }
+
+    public override Task<Result<TEntity, TKey>> GetManyAsync(Expression<Func<TEntity, bool>> predicate = null, Options<TEntity> options = null, CancellationToken cancellationToken = default)
+    {
+        return Disk.GetManyAsync(predicate, options, cancellationToken);
+    }
+
+    public override Task<Result<TEntity, TKey>> GetManyAsync(FilterDefinition<TEntity> filter, Options<TEntity> options = null, CancellationToken cancellationToken = default)
+    {
+        return Disk.GetManyAsync(filter, options, cancellationToken);
+    }
+
+    public override Task<Result<T>> GetManyProjectionAsync<T>(Expression<Func<TEntity, bool>> predicate = null, Options<TEntity> options = null, CancellationToken cancellationToken = default)
+    {
+        return Disk.GetManyProjectionAsync<T>(predicate, options, cancellationToken);
+    }
+
+    public override Task<Result<T>> GetManyProjectionAsync<T>(FilterDefinition<TEntity> filter, Options<TEntity> options = null, CancellationToken cancellationToken = default)
+    {
+        return Disk.GetManyProjectionAsync<T>(filter, options, cancellationToken);
+    }
+
+    public override Task<TEntity> GetOneAsync(TKey id, CancellationToken cancellationToken = default)
+    {
+        return Disk.GetOneAsync(id, cancellationToken);
+    }
+
+    public override Task<TEntity> GetOneAsync(Expression<Func<TEntity, bool>> predicate, OneOption<TEntity> options = null, CancellationToken cancellationToken = default)
+    {
+        return Disk.GetOneAsync(predicate, options, cancellationToken);
+    }
+
+    public override Task<TEntity> GetOneAsync(FilterDefinition<TEntity> filter, OneOption<TEntity> options = null, CancellationToken cancellationToken = default)
+    {
+        return Disk.GetOneAsync(filter, options, cancellationToken);
+    }
+
+    public override Task<long> CountAsync(Expression<Func<TEntity, bool>> predicate, CancellationToken cancellationToken = default)
+    {
+        return Disk.CountAsync(predicate, cancellationToken);
+    }
+
+    public override Task<long> CountAsync(FilterDefinition<TEntity> filter, CancellationToken cancellationToken = default)
+    {
+        return Disk.CountAsync(filter, cancellationToken);
+    }
+
+    public override Task<long> EstimatedCountAsync(CancellationToken cancellationToken = default)
+    {
+        return Disk.EstimatedCountAsync(cancellationToken);
+    }
+
+    public override Task<decimal> SumAsync(Expression<Func<TEntity, decimal>> field, Expression<Func<TEntity, bool>> predicate = null, CancellationToken cancellationToken = default)
+    {
+        return Disk.SumAsync(field, predicate, cancellationToken);
+    }
+
+    public override Task<decimal> AvgAsync(Expression<Func<TEntity, decimal>> field, Expression<Func<TEntity, bool>> predicate = null, CancellationToken cancellationToken = default)
+    {
+        return Disk.AvgAsync(field, predicate, cancellationToken);
+    }
+
+    public override Task<TField> MinAsync<TField>(Expression<Func<TEntity, TField>> field, Expression<Func<TEntity, bool>> predicate = null, CancellationToken cancellationToken = default)
+    {
+        return Disk.MinAsync(field, predicate, cancellationToken);
+    }
+
+    public override Task<TField> MaxAsync<TField>(Expression<Func<TEntity, TField>> field, Expression<Func<TEntity, bool>> predicate = null, CancellationToken cancellationToken = default)
+    {
+        return Disk.MaxAsync(field, predicate, cancellationToken);
+    }
+
+    public override Task<long> GetSizeAsync(CancellationToken cancellationToken = default)
+    {
+        return Disk.GetSizeAsync(cancellationToken);
+    }
+
+    public override Task<Paging.CursorPage<TEntity>> GetPageAsync(
+        int pageSize,
+        Paging.PagePosition position,
+        Expression<Func<TEntity, bool>> predicate = null,
+        Expression<Func<TEntity, object>> sortBy = null,
+        bool ascending = true,
+        CancellationToken cancellationToken = default)
+        => Disk.GetPageAsync(pageSize, position, predicate, sortBy, ascending, cancellationToken);
+
+    public override Task<Paging.CursorPage<T>> GetPageProjectionAsync<T>(
+        int pageSize,
+        Paging.PagePosition position,
+        Expression<Func<TEntity, T>> projection,
+        Expression<Func<TEntity, bool>> predicate = null,
+        Expression<Func<TEntity, object>> sortBy = null,
+        bool ascending = true,
+        CancellationToken cancellationToken = default)
+        => Disk.GetPageProjectionAsync(pageSize, position, projection, predicate, sortBy, ascending, cancellationToken);
+
+    //Create
+    public override Task AddAsync(TEntity entity, IClientSessionHandle session = null)
+    {
+        return Disk.AddAsync(entity, session);
+    }
+
+    public override Task<bool> TryAddAsync(TEntity entity, IClientSessionHandle session = null)
+    {
+        return Disk.TryAddAsync(entity, session);
+    }
+
+    public override Task AddManyAsync(IEnumerable<TEntity> entities, IClientSessionHandle session = null)
+    {
+        return Disk.AddManyAsync(entities, session);
+    }
+
+    //Update
+    public Task<long> UpdateUnlockedAsync(Expression<Func<TEntity, bool>> predicate, UpdateDefinition<TEntity> update)
+    {
+        var filter = Builders<TEntity>.Filter.Where(predicate);
+        return UpdateUnlockedAsync(filter, update);
+    }
+
+    public async Task<long> UpdateUnlockedAsync(FilterDefinition<TEntity> filter, UpdateDefinition<TEntity> update)
+    {
+        var filters = new FilterDefinitionBuilder<TEntity>().And(UnlockedOrExpiredFilter, filter);
+        return await Disk.UpdateManyAsync(filters, update);
+    }
+
+    //Delete
+    public override async Task<TEntity> DeleteOneAsync(TKey id, IClientSessionHandle session = null)
+    {
+        var scope = await PickForDeleteAsync(id, session: session);
+        var item = await scope.CommitAsync();
+        return item;
+    }
+
+    public Task<TEntity> DeleteOneUnlockedAsync(Expression<Func<TEntity, bool>> predicate, OneOption<TEntity> options = null)
+    {
+        return Disk.DeleteOneAsync(UnlockedOrExpiredFilter.AndAlso(predicate), options);
+    }
+
+    public Task<TEntity> DeleteOneUnlockedAsync(FilterDefinition<TEntity> filter, OneOption<TEntity> options = null)
+    {
+        var unlockedOrExpired = Builders<TEntity>.Filter.Where(UnlockedOrExpiredFilter);
+
+        if (filter == null) return Disk.DeleteOneAsync(unlockedOrExpired, options);
+
+        var combined = Builders<TEntity>.Filter.And(unlockedOrExpired, filter);
+        return Disk.DeleteOneAsync(combined, options);
+    }
+
+    public Task<long> DeleteManyUnlockedAsync(Expression<Func<TEntity, bool>> predicate)
+    {
+        return Disk.DeleteManyAsync(UnlockedOrExpiredFilter.AndAlso(predicate ?? (_ => true)));
+    }
+
+    public Task<long> DeleteManyUnlockedAsync(FilterDefinition<TEntity> filter)
+    {
+        var unlockedOrExpired = Builders<TEntity>.Filter.Where(UnlockedOrExpiredFilter);
+
+        if (filter == null || filter == FilterDefinition<TEntity>.Empty) return Disk.DeleteManyAsync(unlockedOrExpired);
+
+        var combined = Builders<TEntity>.Filter.And(unlockedOrExpired, filter);
+        return Disk.DeleteManyAsync(combined);
+    }
+
+    public async Task<long> DeleteManyAsync(DeleteMode deleteMode, Expression<Func<TEntity, bool>> predicate = null)
+    {
+        switch (deleteMode)
+        {
+            case DeleteMode.Unlocked:
+                return await Disk.DeleteManyAsync(UnlockedOrExpiredFilter.AndAlso(predicate ?? (_ => true)));
+            case DeleteMode.ExceptionOnly:
+                return await Disk.DeleteManyAsync(ExceptionFilter.AndAlso(predicate ?? (_ => true)));
+            case DeleteMode.LockedOnly:
+                return await Disk.DeleteManyAsync(LockedFilter.AndAlso(predicate ?? (_ => true)));
+            case DeleteMode.Any:
+                return await Disk.DeleteManyAsync(predicate ?? (_ => true));
+            default:
+                throw new ArgumentOutOfRangeException(nameof(deleteMode), deleteMode, null);
+        }
+    }
+
+    //Other
+    public override Task DropCollectionAsync()
+    {
+        return Disk.DropCollectionAsync();
+    }
+
+    public override Task<T> ExecuteAsync<T>(Func<IMongoCollection<TEntity>, Task<T>> execute, Operation operation)
+    {
+        if (operation != Operation.Read && operation != Operation.Create) throw new InvalidOperationException($"Only operations {nameof(Operation.Read)} and {nameof(Operation.Create)} are allowed for lockable repository collections. {nameof(Operation.Update)} and {nameof(Operation.Delete)} must go through the lock-acquire/commit cycle.");
+        return Disk.ExecuteAsync(execute, operation);
+    }
+
+    public override Task<T> ExecuteAsync<T>(Func<IMongoCollection<TEntity>, CancellationToken, Task<T>> execute, Operation operation, CancellationToken cancellationToken)
+    {
+        if (operation != Operation.Read && operation != Operation.Create) throw new InvalidOperationException($"Only operations {nameof(Operation.Read)} and {nameof(Operation.Create)} are allowed for lockable repository collections. {nameof(Operation.Update)} and {nameof(Operation.Delete)} must go through the lock-acquire/commit cycle.");
+        return Disk.ExecuteAsync(execute, operation, cancellationToken);
+    }
+
+    public override IAsyncEnumerable<T> ExecuteManyAsync<T>(Func<IMongoCollection<TEntity>, CancellationToken, Task<IAsyncCursor<T>>> queryFactory, CancellationToken cancellationToken = default)
+    {
+        return Disk.ExecuteManyAsync(queryFactory, cancellationToken);
+    }
+
+    public override IAsyncEnumerable<TEntity> GetDirtyAsync()
+    {
+        return Disk.GetDirtyAsync();
+    }
+
+    public override IReadOnlyList<IndexFailure> GetFailedIndices()
+    {
+        return Disk.GetFailedIndices();
+    }
+
+    internal override Task<StepResponse<IMongoCollection<TEntity>>> FetchCollectionAsync(bool initiate = true)
+    {
+        return Disk.FetchCollectionAsync(initiate);
+    }
+
+    internal override Task<bool> AssureIndex(IMongoCollection<TEntity> collection, bool forceAssure = false, bool throwOnException = false)
+    {
+        return Disk.AssureIndex(collection, forceAssure, throwOnException);
+    }
+
+    internal override Task<(int Before, int After)> DropIndex(IMongoCollection<TEntity> collection)
+    {
+        return Disk.DropIndex(collection);
+    }
+
+    internal override Task CleanAsync(IMongoCollection<TEntity> collection)
+    {
+        return Disk.CleanAsync(collection);
+    }
+
+    internal override Task<CleanInfo> CleanCollectionAsync(IMongoCollection<TEntity> collection, bool cleanGuids)
+    {
+        return Disk.CleanCollectionAsync(collection, cleanGuids);
+    }
+
+    internal override Task<CleanInfo> GetCleanInfoAsync()
+    {
+        return Disk.GetCleanInfoAsync();
+    }
+
+    //Lock
+    public Expression<Func<TEntity, bool>> UnlockedOrExpiredFilter
+    {
+        get
+        {
+            var now = DateTime.UtcNow;
+            Expression<Func<TEntity, bool>> expression = x =>
+                x.Lock == null
+                || (x.Lock.ExceptionInfo == null && x.Lock.ExpireTime < now);
+
+            return expression;
+        }
+    }
+
+    public Expression<Func<TEntity, bool>> LockedOrExceptionFilter
+    {
+        get
+        {
+            var now = DateTime.UtcNow;
+            Expression<Func<TEntity, bool>> expression = x =>
+                x.Lock != null
+                && (x.Lock.ExceptionInfo != null || x.Lock.ExpireTime >= now);
+
+            return expression;
+        }
+    }
+
+    public Expression<Func<TEntity, bool>> ExceptionFilter
+    {
+        get
+        {
+            Expression<Func<TEntity, bool>> expression = x =>
+                x.Lock != null
+                && x.Lock.ExceptionInfo != null;
+
+            return expression;
+        }
+    }
+
+    public Expression<Func<TEntity, bool>> LockedFilter
+    {
+        get
+        {
+            var now = DateTime.UtcNow;
+            Expression<Func<TEntity, bool>> expression = x =>
+                x.Lock != null
+                && x.Lock.ExpireTime >= now;
+
+            return expression;
+        }
+    }
+
+    public async IAsyncEnumerable<TEntity> GetUnlockedAsync(Expression<Func<TEntity, bool>> predicate = null, Options<TEntity> options = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await foreach (var item in Disk.GetAsync(UnlockedOrExpiredFilter.AndAlso(predicate ?? (x => true)), options, cancellationToken))
+        {
+            yield return item;
+        }
+    }
+
+    public IAsyncEnumerable<TEntity> GetUnlockedAsync(FilterDefinition<TEntity> filter, Options<TEntity> options = null, CancellationToken cancellationToken = default)
+    {
+        var baseFilter = Builders<TEntity>.Filter.Where(UnlockedOrExpiredFilter);
+        var combinedFilter = Builders<TEntity>.Filter.And(baseFilter, filter);
+
+        return Disk.GetAsync(combinedFilter, options, cancellationToken);
+    }
+
+    public async Task<RenewableEntityScope<TEntity, TKey>> PickForUpdateAsync(TKey id, TimeSpan? timeout = null, string actor = null, Func<CallbackResult<TEntity>, Task> completeAction = null, IClientSessionHandle session = null)
+    {
+        var result = await CreateLockAsync(Builders<TEntity>.Filter.Eq(x => x.Id, id), timeout, actor, CommitMode.Update, completeAction, true, session);
+        ThrowException(result);
+        return result.EntityScope;
+    }
+
+    public async Task<RenewableEntityScope<TEntity, TKey>> PickForUpdateAsync(FilterDefinition<TEntity> filter, TimeSpan? timeout = null, string actor = null, Func<CallbackResult<TEntity>, Task> completeAction = null, IClientSessionHandle session = null)
+    {
+        var result = await CreateLockAsync(filter, timeout, actor, CommitMode.Update, completeAction, false, session);
+        ThrowException(result);
+        return result.EntityScope;
+    }
+
+    public async Task<RenewableEntityScope<TEntity, TKey>> PickForUpdateAsync(Expression<Func<TEntity, bool>> predicate = null, TimeSpan? timeout = null, string actor = null, Func<CallbackResult<TEntity>, Task> completeAction = null, IClientSessionHandle session = null)
+    {
+        var result = await CreateLockAsync(predicate ?? (x => true), timeout, actor, CommitMode.Update, completeAction, false, session);
+        ThrowException(result);
+        return result.EntityScope;
+    }
+
+    public async Task<RenewableEntityScope<TEntity, TKey>> PickForDeleteAsync(TKey id, TimeSpan? timeout = null, string actor = null, Func<CallbackResult<TEntity>, Task> completeAction = null, IClientSessionHandle session = null)
+    {
+        var result = await CreateLockAsync(Builders<TEntity>.Filter.Eq(x => x.Id, id), timeout, actor, CommitMode.Delete, completeAction, true, session);
+        ThrowException(result);
+        return result.EntityScope;
+    }
+
+    public async Task<RenewableEntityScope<TEntity, TKey>> PickForDeleteAsync(FilterDefinition<TEntity> filter, TimeSpan? timeout = null, string actor = null, Func<CallbackResult<TEntity>, Task> completeAction = null, IClientSessionHandle session = null)
+    {
+        var result = await CreateLockAsync(filter, timeout, actor, CommitMode.Delete, completeAction, false, session);
+        ThrowException(result);
+        return result.EntityScope;
+    }
+
+    public async Task<RenewableEntityScope<TEntity, TKey>> PickForDeleteAsync(Expression<Func<TEntity, bool>> predicate = null, TimeSpan? timeout = null, string actor = null, Func<CallbackResult<TEntity>, Task> completeAction = null, IClientSessionHandle session = null)
+    {
+        var result = await CreateLockAsync(predicate ?? (x => true), timeout, actor, CommitMode.Delete, completeAction, false, session);
+        ThrowException(result);
+        return result.EntityScope;
+    }
+
+    public async Task<RenewableEntityScope<TEntity, TKey>> WaitForUpdateAsync(TKey id, TimeSpan? lockTimeout = null, TimeSpan? waitTimeout = null, string actor = null, Func<CallbackResult<TEntity>, Task> completeAction = default, CancellationToken cancellationToken = default)
+    {
+        return await WaitForLock(id, lockTimeout, waitTimeout, actor, cancellationToken, CommitMode.Update, completeAction);
+    }
+
+    public async Task<RenewableEntityScope<TEntity, TKey>> WaitForDeleteAsync(TKey id, TimeSpan? lockTimeout = null, TimeSpan? waitTimeout = null, string actor = null, Func<CallbackResult<TEntity>, Task> completeAction = null, CancellationToken cancellationToken = default)
+    {
+        return await WaitForLock(id, lockTimeout, waitTimeout, actor, cancellationToken, CommitMode.Delete, completeAction);
+    }
+
+    public async Task<RenewableLockScope<TEntity, TKey>> LockAsync(TKey id, TimeSpan? timeout = null, string actor = null, Func<CallbackResult<TEntity>, Task> completeAction = null, IClientSessionHandle session = null)
+    {
+        var result = await AcquireLockAsync(Builders<TEntity>.Filter.Eq(x => x.Id, id), timeout, actor, failIfLocked: true, session: session);
+        ThrowException(result.ErrorInfo);
+        return BuildLockScope(result.Entity, result.EntityLock, completeAction, session);
+    }
+
+    public async Task<RenewableLockScope<TEntity, TKey>> LockAsync(FilterDefinition<TEntity> filter, TimeSpan? timeout = null, string actor = null, Func<CallbackResult<TEntity>, Task> completeAction = null, IClientSessionHandle session = null)
+    {
+        var result = await AcquireLockAsync(filter, timeout, actor, failIfLocked: false, session: session);
+        ThrowException(result.ErrorInfo);
+        return BuildLockScope(result.Entity, result.EntityLock, completeAction, session);
+    }
+
+    public async Task<RenewableLockScope<TEntity, TKey>> LockAsync(Expression<Func<TEntity, bool>> predicate = null, TimeSpan? timeout = null, string actor = null, Func<CallbackResult<TEntity>, Task> completeAction = null, IClientSessionHandle session = null)
+    {
+        var result = await AcquireLockAsync(predicate ?? (x => true), timeout, actor, failIfLocked: false, session: session);
+        ThrowException(result.ErrorInfo);
+        return BuildLockScope(result.Entity, result.EntityLock, completeAction, session);
+    }
+
+    public async Task<DocumentLease<TEntity, TKey>> LockManyAsync(IEnumerable<TKey> ids, TimeSpan? timeout = null, string actor = null, CancellationToken cancellationToken = default, IClientSessionHandle session = null)
+    {
+        if (ids == null) throw new ArgumentNullException(nameof(ids));
+
+        var sortedIds = ids.Distinct().OrderBy(id => id, Comparer<TKey>.Default).ToList();
+
+        if (sortedIds.Count == 0)
+        {
+            return new DocumentLease<TEntity, TKey>(Array.Empty<DocumentLeaseEntry<TEntity, TKey>>(), session, this);
+        }
+
+        var entries = new List<DocumentLeaseEntry<TEntity, TKey>>();
+        try
+        {
+            foreach (var id in sortedIds)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var result = await AcquireLockAsync(Builders<TEntity>.Filter.Eq(x => x.Id, id), timeout, actor, failIfLocked: true, session: session);
+                ThrowException(result.ErrorInfo);
+
+                if (result.Entity == null)
+                {
+                    throw new InvalidOperationException($"No document with id '{id}' was found.");
+                }
+
+                var entityLock = result.EntityLock;
+                Func<TEntity, CommitMode?, Exception, IClientSessionHandle, Task> releaseAction = (e, mode, exception, sess) =>
+                {
+                    switch (mode)
+                    {
+                        case CommitMode.Update:
+                            return ReleaseAsync(e, entityLock, commit: true, exception, completeAction: null, PrepareCommitForUpdateAsync, sess);
+                        case CommitMode.Delete:
+                            return ReleaseAsync(e, entityLock, commit: true, exception, completeAction: null, PerformCommitForDeleteAsync, sess);
+                        case null:
+                            return ReleaseAsync(e, entityLock, commit: false, exception, completeAction: null, null, sess);
+                        default:
+                            throw new ArgumentOutOfRangeException(nameof(mode), mode, null);
+                    }
+                };
+
+                entries.Add(new DocumentLeaseEntry<TEntity, TKey>(result.Entity, releaseAction));
+                _releaseEvent.Set();
+            }
+
+            return new DocumentLease<TEntity, TKey>(entries, session, this);
+        }
+        catch
+        {
+            await ReleaseAcquiredAsync(entries, session);
+            throw;
+        }
+    }
+
+    public async Task<DocumentLease<TEntity, TKey>> LockManyAsync(FilterDefinition<TEntity> filter, TimeSpan? timeout = null, string actor = null, CancellationToken cancellationToken = default, IClientSessionHandle session = null)
+    {
+        if (filter == null) throw new ArgumentNullException(nameof(filter));
+
+        var ids = await GetAsync(filter).Select(e => e.Id).ToArrayAsync(cancellationToken);
+        return await LockManyAsync(ids, timeout, actor, cancellationToken, session);
+    }
+
+    public Task<DocumentLease<TEntity, TKey>> LockManyAsync(Expression<Func<TEntity, bool>> predicate, TimeSpan? timeout = null, string actor = null, CancellationToken cancellationToken = default, IClientSessionHandle session = null)
+    {
+        if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+        return LockManyAsync(Builders<TEntity>.Filter.Where(predicate), timeout, actor, cancellationToken, session);
+    }
+
+    Task IDocumentLeaseTransactionRunner.RunInTransactionAsync(Func<IClientSessionHandle, CancellationToken, Task> body, CancellationToken cancellationToken)
+    {
+        return _mongoDbServiceFactory.WithTransactionAsync(body, configurationName: ConfigurationName, cancellationToken: cancellationToken);
+    }
+
+    private static async Task ReleaseAcquiredAsync(IEnumerable<DocumentLeaseEntry<TEntity, TKey>> entries, IClientSessionHandle session = null)
+    {
+        foreach (var entry in entries)
+        {
+            try
+            {
+                await entry.ReleaseAction.Invoke(entry.Entity, null, null, session);
+            }
+            catch
+            {
+                // Best-effort rollback — swallow to avoid hiding the original failure.
+            }
+        }
+    }
+
+    private RenewableLockScope<TEntity, TKey> BuildLockScope(TEntity entity, Lock entityLock, Func<CallbackResult<TEntity>, Task> completeAction, IClientSessionHandle session = null)
+    {
+        if (entity == null) return null;
+
+        var lockState = new LockState(entityLock);
+        var controller = new RenewalController(lockState, (current, extension) => ExtendLockAsync(entity.Id, current, extension), entityLock.ExpireTime - entityLock.LockTime, _logger);
+
+        Func<TEntity, CommitMode?, Exception, Task> releaseAction = async (e, mode, exception) =>
+        {
+            await controller.StopAsync();
+            var currentLock = lockState.Current;
+            switch (mode)
+            {
+                case CommitMode.Update:
+                    await ReleaseAsync(e, currentLock, commit: true, exception, completeAction, PrepareCommitForUpdateAsync, session);
+                    break;
+                case CommitMode.Delete:
+                    await ReleaseAsync(e, currentLock, commit: true, exception, completeAction, PerformCommitForDeleteAsync, session);
+                    break;
+                case null:
+                    await ReleaseAsync(e, currentLock, commit: false, exception, completeAction, null, session);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(mode), mode, null);
+            }
+        };
+
+        _releaseEvent.Set();
+        return new RenewableLockScope<TEntity, TKey>(entity, releaseAction, controller);
+    }
+
+    public IAsyncEnumerable<EntityLock<TEntity, TKey>> GetWithLockInfoAsync(FilterDefinition<TEntity> filter = null, Options<TEntity> options = null, CancellationToken cancellationToken = default)
+    {
+        return Disk.GetAsync(filter, options, cancellationToken)
+            .Select(x => new EntityLock<TEntity, TKey>(x, x.Lock));
+    }
+
+    public IAsyncEnumerable<EntityLock<TEntity, TKey>> GetLockedAsync(LockMode lockMode, FilterDefinition<TEntity> filter = null, Options<TEntity> options = null, CancellationToken cancellationToken = default)
+    {
+        var now = DateTime.UtcNow;
+
+        var builder = Builders<TEntity>.Filter;
+        var filters = new List<FilterDefinition<TEntity>>
+        {
+            new FilterDefinitionBuilder<TEntity>().Ne(x => x.Lock, null)
+        };
+        if (filter != null) filters.Add(filter);
+
+        if (lockMode.HasFlag(LockMode.Locked) && lockMode.HasFlag(LockMode.Exception))
+        {
+            filters.Add(
+                Builders<TEntity>.Filter.Or(
+                    new FilterDefinitionBuilder<TEntity>().Ne(x => x.Lock.ExceptionInfo, null),
+                    Builders<TEntity>.Filter.And(
+                        new FilterDefinitionBuilder<TEntity>().Eq(x => x.Lock.ExceptionInfo, null),
+                        new FilterDefinitionBuilder<TEntity>().Gte(x => x.Lock.ExpireTime, now)
+                    )
+                )
+            );
+        }
+        else if (lockMode.HasFlag(LockMode.Locked))
+        {
+            filters.Add(new FilterDefinitionBuilder<TEntity>().Eq(x => x.Lock.ExceptionInfo, null));
+            filters.Add(new FilterDefinitionBuilder<TEntity>().Gte(x => x.Lock.ExpireTime, now));
+        }
+        else if (lockMode.HasFlag(LockMode.Exception))
+        {
+            filters.Add(new FilterDefinitionBuilder<TEntity>().Ne(x => x.Lock.ExceptionInfo, null));
+        }
+
+        return Disk.GetAsync(builder.And(filters), options, cancellationToken)
+            .Select(x => new EntityLock<TEntity, TKey>(x, x.Lock));
+    }
+
+    public IAsyncEnumerable<EntityLock<TEntity, TKey>> GetExpiredAsync(FilterDefinition<TEntity> filter = null, Options<TEntity> options = null, CancellationToken cancellationToken = default)
+    {
+        var now = DateTime.UtcNow;
+
+        var builder = Builders<TEntity>.Filter;
+        var filters = new List<FilterDefinition<TEntity>>
+        {
+            new FilterDefinitionBuilder<TEntity>().Ne(x => x.Lock, null),
+            new FilterDefinitionBuilder<TEntity>().Eq(x => x.Lock.ExceptionInfo, null),
+            new FilterDefinitionBuilder<TEntity>().Lt(x => x.Lock.ExpireTime, now)
+        };
+
+        if (filter != null) filters.Add(filter);
+
+        return Disk.GetAsync(builder.And(filters), options, cancellationToken)
+            .Select(x => new EntityLock<TEntity, TKey>(x, x.Lock));
+    }
+
+    public async Task<EntityChangeResult<TEntity>> ReleaseOneAsync(TKey id, ReleaseMode mode)
+    {
+        var filter = Builders<TEntity>.Filter.And(Builders<TEntity>.Filter.Eq(x => x.Id, id), BuildReleaseFilter(mode));
+        var update = new UpdateDefinitionBuilder<TEntity>().Set(x => x.Lock, null);
+        var result = await Disk.UpdateOneAsync(filter, update, OneOption<TEntity>.FirstOrDefault); //Use FirstOrDefault since it is atomic safe.
+        return result;
+    }
+
+    public async Task<long> ReleaseManyAsync(ReleaseMode mode)
+    {
+        var filter = BuildReleaseFilter(mode);
+        var update = new UpdateDefinitionBuilder<TEntity>().Set(x => x.Lock, null);
+        var result = await Disk.UpdateManyAsync(filter, update);
+        return result;
+    }
+
+    private static FilterDefinition<TEntity> BuildReleaseFilter(ReleaseMode mode)
+    {
+        FilterDefinition<TEntity> filter;
+        switch (mode)
+        {
+            case ReleaseMode.ExceptionOnly:
+                filter = Builders<TEntity>.Filter.And(
+                    Builders<TEntity>.Filter.Ne(x => x.Lock, null),
+                    Builders<TEntity>.Filter.Ne(x => x.Lock.ExceptionInfo, null)
+                );
+                break;
+            case ReleaseMode.LockedOnly:
+                filter = Builders<TEntity>.Filter.And(
+                    Builders<TEntity>.Filter.Ne(x => x.Lock, null),
+                    Builders<TEntity>.Filter.Eq(x => x.Lock.ExceptionInfo, null)
+                );
+                break;
+            case ReleaseMode.Any:
+                filter = Builders<TEntity>.Filter.And(
+                    Builders<TEntity>.Filter.Ne(x => x.Lock, null)
+                );
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(mode), mode, null);
+        }
+
+        return filter;
+    }
+
+    private async Task<RenewableEntityScope<TEntity, TKey>> WaitForLock(TKey id, TimeSpan? lockTimeout, TimeSpan? waitTimeout, string actor, CancellationToken cancellationToken, CommitMode commitMode, Func<CallbackResult<TEntity>, Task> completeAction)
+    {
+        var actualTimeout = lockTimeout ?? waitTimeout ?? DefaultTimeout;
+        var recheckTimeInterval = actualTimeout / 5;
+        using var timeoutCts = new CancellationTokenSource(actualTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+        var waitHandles = new[] { _releaseEvent, linkedCts.Token.WaitHandle };
+
+        while (!linkedCts.Token.IsCancellationRequested)
+        {
+            var result = await CreateLockAsync(Builders<TEntity>.Filter.Eq(x => x.Id, id), lockTimeout ?? DefaultTimeout, actor, commitMode, completeAction, true);
+            if (!result.ShouldWait) return HandleFinalResult(result);
+            WaitHandle.WaitAny(waitHandles, recheckTimeInterval);
+        }
+
+        if (cancellationToken.IsCancellationRequested) throw new OperationCanceledException("The operation was canceled.");
+
+        var finalCheckResult = await CreateLockAsync(Builders<TEntity>.Filter.Eq(x => x.Id, id), lockTimeout ?? DefaultTimeout, actor, commitMode, completeAction, true);
+        if (!finalCheckResult.ShouldWait)
+        {
+            return HandleFinalResult(finalCheckResult);
+        }
+
+        throw new TimeoutException("No valid entity has been released for update.");
+
+        RenewableEntityScope<TEntity, TKey> HandleFinalResult((RenewableEntityScope<TEntity, TKey> EntityScope, ErrorInfo errorInfo, bool ShouldWait) result)
+        {
+            ThrowException(result);
+            return result.EntityScope;
+        }
+    }
+
+    /// <summary>
+    /// Pure lock-acquisition primitive. Atomically attempts to set the <see cref="LockableEntityBase{TKey}.Lock"/>
+    /// field on a document matching <paramref name="filter"/>. Returns the locked entity + the lock details on success.
+    /// On failure, returns either <c>(null, null, null, false)</c> when the filter matches no documents
+    /// (and <paramref name="failIfLocked"/> is <c>false</c>), or <c>(null, null, errorInfo, shouldWait)</c> when the
+    /// document exists but cannot be locked. Used by <see cref="CreateLockAsync"/> (legacy <c>Pick*</c> path)
+    /// and by <c>LockAsync</c> (commit-mode-at-commit-time path).
+    /// </summary>
+    private async Task<(TEntity Entity, Lock EntityLock, ErrorInfo ErrorInfo, bool ShouldWait)> AcquireLockAsync(FilterDefinition<TEntity> filter, TimeSpan? timeout, string actor, bool failIfLocked, IClientSessionHandle session = null)
+    {
+        var timeoutTotUse = timeout ?? DefaultTimeout;
+        if (timeoutTotUse.Ticks < 0) throw new ArgumentException($"{nameof(timeout)} cannot be less than zero. Provided or default value is {timeoutTotUse}.");
+        if (RequireActor && actor.IsNullOrEmpty()) throw new ArgumentNullException(nameof(actor), $"No {nameof(actor)} provided. Set {nameof(RequireActor)} to false or provide {nameof(actor)}.");
+
+        var now = DateTime.UtcNow;
+        var lockKey = Guid.NewGuid();
+        actor = actor.NullIfEmpty();
+
+        var unlockedFilter = Builders<TEntity>.Filter.And(
+            filter,
+            Builders<TEntity>.Filter.Eq(x => x.Lock, null)
+        );
+        var expiredLockFilter = Builders<TEntity>.Filter.And(
+            filter,
+            Builders<TEntity>.Filter.Ne(x => x.Lock, null),
+            Builders<TEntity>.Filter.Eq(x => x.Lock.ExceptionInfo, null),
+            Builders<TEntity>.Filter.Lt(x => x.Lock.ExpireTime, now)
+        );
+        var matchFilter = Builders<TEntity>.Filter.Or(unlockedFilter, expiredLockFilter);
+
+        var entityLock = new Lock
+        {
+            LockKey = lockKey,
+            LockTime = now,
+            ExpireTime = now.Add(timeoutTotUse),
+            Actor = actor,
+            ExceptionInfo = null,
+        };
+
+        var update = new UpdateDefinitionBuilder<TEntity>().Set(x => x.Lock, entityLock);
+
+        var result = await Disk.UpdateOneAsync(matchFilter, update, OneOption<TEntity>.FirstOrDefault, session); //Use FirstOrDefault since it is atomic safe.
+        if (result.Before == null) //Document is missing or is already locked
+        {
+            if (!failIfLocked) return (null, null, null, false); //No document matches the filter.
+
+            var docs = await GetAsync(filter).ToArrayAsync();
+
+            if (!docs.Any()) return (null, null, null, false); //No document matches the filter.
+
+            if (docs.Length == 1)
+            {
+                var doc = docs.Single();
+                if (doc.Lock?.ExceptionInfo == null)
+                {
+                    var timeString = doc.Lock == null ? null : $" for {doc.Lock.ExpireTime - now}";
+                    var actorString = doc.Lock?.Actor == null ? null : $" by '{doc.Lock.Actor}'";
+
+                    return (null, null, new ErrorInfo
+                    {
+                        Message = $"Entity with id '{doc.Id}' is locked{actorString}{timeString}.",
+                        Type = ErrorInfoType.Locked
+                    }, true);
+                }
+
+                if (doc.Lock.ExceptionInfo != null)
+                {
+                    return (null, null, new ErrorInfo
+                    {
+                        Message = $"Entity with id '{doc.Id}' has an exception attached.",
+                        Type = ErrorInfoType.Error
+                    }, false);
+                }
+
+                return (null, null, new ErrorInfo
+                {
+                    Message = $"Entity with id '{doc.Id}' has an unknown state.",
+                    Type = ErrorInfoType.Unknown
+                }, false);
+            }
+
+            return (null, null, new ErrorInfo
+            {
+                Message = $"Matched with {docs.Length} documents but no unlocked",
+                Type = ErrorInfoType.Unknown
+            }, false);
+        }
+        else
+        {
+            FireAndForgetEvent(() => Task.FromResult(result.Before), LockAction.Locked); //NOTE: using before here would be same as after, since we are not getting the lock information.
+        }
+
+        if (result.Before.Lock != null)
+        {
+            if (now <= result.Before.Lock.ExpireTime)
+            {
+                throw new NotSupportedException($"The entity that was picked had a lock that has not yet expired. [ExpireTime: {result.Before.Lock.ExpireTime}, LockTime: {result.Before.Lock.LockTime}, BeforeActor: {result.Before.Lock.Actor}, Actor: {actor}, Now: {now}]");
+            }
+
+            if (result.Before.Lock.ExceptionInfo != null)
+            {
+                throw new NotSupportedException($"The entity that was picked had an exception attached. [ExpireTime: {result.Before.Lock.ExpireTime}, LockTime: {result.Before.Lock.LockTime}, Exception: {result.Before.Lock.ExceptionInfo.Message}, BeforeActor: {result.Before.Lock.Actor}, Actor: {actor}, Now: {now}]");
+            }
+
+            _logger?.LogInformation("{Actor} picked an entity from {BeforeActor} that expired {Expired} ago.", actor, result.Before.Lock.Actor, result.Before.Lock.ExpireTime - now);
+        }
+
+        return (result.Before, entityLock, null, false);
+    }
+
+    /// <summary>
+    /// The renewal primitive. Atomically pushes the lease's <c>ExpireTime</c> further into the future
+    /// while the same <c>LockKey</c> is still on the document. On a non-strict collection an
+    /// already-expired-but-not-stolen lock can still be extended — the <c>LockKey</c> match is the
+    /// safety authority, exactly as for delayed commit. On a strict collection an expired lease throws
+    /// <see cref="LockExpiredException"/>. When the <c>LockKey</c> no longer matches (document gone or
+    /// re-locked elsewhere) it throws <see cref="LockLostException"/>.
+    /// </summary>
+    internal async Task<Lock> ExtendLockAsync(TKey id, Lock current, TimeSpan? extension)
+    {
+        var extensionToUse = extension ?? (current.ExpireTime - current.LockTime);
+        if (extensionToUse <= TimeSpan.Zero) throw new ArgumentException($"{nameof(extension)} must be greater than zero. Provided or default value is {extensionToUse}.", nameof(extension));
+
+        var now = DateTime.UtcNow;
+        if (now > current.ExpireTime && !AllowDelayedCommit)
+        {
+            var timeout = current.ExpireTime - current.LockTime;
+            var lockTime = now - current.LockTime;
+            throw new LockExpiredException($"Too late to extend entity of type {typeof(TEntity).Name} locked by {current.Actor}.", timeout, lockTime);
+        }
+
+        var renewed = current with
+        {
+            ExpireTime = now.Add(extensionToUse)
+        };
+
+        //NOTE: This filter assures that the correct lock still exists on the entity.
+        var filter = Builders<TEntity>.Filter.And(
+            Builders<TEntity>.Filter.Eq(x => x.Id, id),
+            Builders<TEntity>.Filter.Ne(x => x.Lock, null),
+            Builders<TEntity>.Filter.Eq(x => x.Lock.LockKey, current.LockKey)
+        );
+        var update = new UpdateDefinitionBuilder<TEntity>().Set(x => x.Lock, renewed);
+        var result = await Disk.UpdateOneAsync(filter, update, OneOption<TEntity>.FirstOrDefault); //Use FirstOrDefault since it is atomic safe.
+
+        if (result.Before == null)
+        {
+            var item = await Disk.GetOneAsync(id);
+            if (item == null) throw new LockLostException($"Entity of type {typeof(TEntity).Name} with id '{id}' could not be extended, it does not exist. [EntityActor: {current.Actor}, EntityLockTime: {current.LockTime}, EntityExpireTime: {current.ExpireTime}, Now: {now}]");
+            throw new LockLostException($"Entity of type {typeof(TEntity).Name} with id '{id}' could not be extended, lock key missmatch. [EntityActor: {current.Actor}, EntityLockTime: {current.LockTime}, EntityExpireTime: {current.ExpireTime}, CurrentActor: {item.Lock?.Actor}, CurrentLockTime: {item.Lock?.LockTime}, CurrentExpireTime: {item.Lock?.ExpireTime}, CurrentException: {item.Lock?.ExceptionInfo?.Message}, Now: {now}]");
+        }
+
+        return renewed;
+    }
+
+    /// <summary>
+    /// Legacy <c>Pick*</c> entry point: acquires the lock via <see cref="AcquireLockAsync"/>, then constructs a
+    /// <see cref="RenewableEntityScope{TEntity, TKey}"/> whose release action is bound to <paramref name="commitMode"/>.
+    /// </summary>
+    private async Task<(RenewableEntityScope<TEntity, TKey> EntityScope, ErrorInfo errorInfo, bool ShouldWait)> CreateLockAsync(FilterDefinition<TEntity> filter, TimeSpan? timeout, string actor, CommitMode commitMode, Func<CallbackResult<TEntity>, Task> completeAction, bool failIfLocked, IClientSessionHandle session = null)
+    {
+        var (entity, entityLock, errorInfo, shouldWait) = await AcquireLockAsync(filter, timeout, actor, failIfLocked, session);
+        if (entity == null) return (null, errorInfo, shouldWait);
+
+        var lockState = new LockState(entityLock);
+        var controller = new RenewalController(lockState, (current, extension) => ExtendLockAsync(entity.Id, current, extension), entityLock.ExpireTime - entityLock.LockTime, _logger);
+
+        Func<TEntity, bool, Exception, Task> releaseAction;
+        try
+        {
+            switch (commitMode)
+            {
+                case CommitMode.Update:
+                    releaseAction = async (e, commit, exception) =>
+                    {
+                        await controller.StopAsync();
+                        await ReleaseAsync(e, lockState.Current, commit, exception, completeAction, PrepareCommitForUpdateAsync, session);
+                    };
+                    break;
+                case CommitMode.Delete:
+                    releaseAction = async (e, commit, exception) =>
+                    {
+                        await controller.StopAsync();
+                        await ReleaseAsync(e, lockState.Current, commit, exception, completeAction, PerformCommitForDeleteAsync, session);
+                    };
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(commitMode), commitMode, null);
+            }
+        }
+        finally
+        {
+            _releaseEvent.Set();
+        }
+
+        return (new RenewableEntityScope<TEntity, TKey>(entity, releaseAction, controller), null, false);
+    }
+
+    private async Task<bool> ReleaseAsync(TEntity entity, Lock entityLock, bool commit, Exception exception, Func<CallbackResult<TEntity>, Task> completeAction, Func<TEntity, Lock, Func<CallbackResult<TEntity>, Task>, Lock, IClientSessionHandle, Task<(EntityChangeResult<TEntity>, LockAction)>> releaseAction, IClientSessionHandle session = null)
+    {
+        if (commit && exception != null) throw new ArgumentException("Cannot commit entity when there is an exception.");
+
+        var lockTime = DateTime.UtcNow - entityLock.LockTime;
+        var timeout = entityLock.ExpireTime - entityLock.LockTime;
+        var lockInfo = BuildLockInfo(entityLock, exception);
+        var expired = lockTime > timeout;
+        var delayedCommit = expired && commit && exception == null && AllowDelayedCommit;
+
+        // Strict-TTL gate: throw on expired commit / expired exception-release unless this is
+        // a delayed-commit path explicitly enabled by the AllowDelayedCommit option. The
+        // exception-release branch always remains strict — a delayed exception-record on a
+        // lock that may have been picked elsewhere has no clean semantics.
+        if (expired && (exception != null || (commit && !AllowDelayedCommit)))
+        {
+            throw new LockExpiredException($"Too late to release entity of type {typeof(TEntity).Name} locked by {entityLock.Actor}.", timeout, lockTime);
+        }
+
+        if (delayedCommit)
+        {
+            _logger?.LogInformation(
+                "Lockable entity {entityId} in collection {collection} committed {expiredBy} after lock expiry — no other writer had modified it.",
+                entity.Id, ProtectedCollectionName, lockTime - timeout);
+        }
+
+        EntityChangeResult<TEntity> result;
+        TEntity after = null;
+        LockAction lockAction;
+        if (commit)
+        {
+            var r = await releaseAction.Invoke(entity, entityLock, completeAction, lockInfo, session);
+            result = r.Item1;
+            lockAction = r.Item2;
+            if (result == null) return true;
+        }
+        else
+        {
+            // Renewable abandon is scoped to our own LockKey so we only ever touch the lock we still own.
+            // A renewed lease can be lost between renewal cycles (anti-zombie cap, natural expiry, or a
+            // steal by another actor); releasing such a lost lock is a silent no-op rather than a fault.
+            var abandonFilter = Builders<TEntity>.Filter.And(
+                Builders<TEntity>.Filter.Eq(x => x.Id, entity.Id),
+                Builders<TEntity>.Filter.Ne(x => x.Lock, null),
+                Builders<TEntity>.Filter.Eq(x => x.Lock.LockKey, entityLock.LockKey)
+            );
+            var update = new UpdateDefinitionBuilder<TEntity>()
+                .Set(x => x.Lock, lockInfo);
+            result = await Disk.UpdateOneAsync(abandonFilter, update, OneOption<TEntity>.FirstOrDefault, session); //Use FirstOrDefault since it is atomic safe.
+
+            lockAction = lockInfo?.ExceptionInfo != null ? LockAction.Exception : LockAction.Abandoned;
+
+            if (result.Before == null) return true;
+
+            if (LockEvent != null)
+            {
+                after = await result.GetAfterAsync();
+                var afterCopy = after;
+                FireAndForgetEvent(() => Task.FromResult(afterCopy), lockAction);
+            }
+        }
+
+        if (result.Before == null) throw new InvalidOperationException("Cannot find entity before release.");
+        if (result.Before.Lock == null) throw new InvalidOperationException("No lock information for document before release.");
+
+        after ??= await result.GetAfterAsync();
+        if (after == null && Debugger.IsAttached) throw new InvalidOperationException($"Entity {typeof(TEntity).Name} with id '{entity.Id}' does not exist after release.");
+
+        // Fire the post-release callback when the lease produced a real write — either within
+        // the TTL window, or via the new delayed-commit path (commit happened, no other writer
+        // had touched the document). Skip when the lock was past expiry AND the consumer chose
+        // not to commit (abandon-after-expiry).
+        if (completeAction != null && (!expired || commit))
+        {
+            await completeAction.Invoke(new CallbackResult<TEntity> { LockAction = lockAction, Before = result.Before, After = after });
+        }
+
+        return after?.Lock == null;
+    }
+
+    private async Task<(EntityChangeResult<TEntity>, LockAction)> PrepareCommitForUpdateAsync(TEntity entity, Lock entityLock, Func<CallbackResult<TEntity>, Task> completeAction, Lock lockInfo, IClientSessionHandle session)
+    {
+        var updatedEntity = entity with
+        {
+            Lock = lockInfo
+        };
+
+        //NOTE: This filter assures that the correct lock still exists on the entity.
+        var filter = Builders<TEntity>.Filter.And(
+            Builders<TEntity>.Filter.Eq(x => x.Id, entity.Id),
+            Builders<TEntity>.Filter.Ne(x => x.Lock, null),
+            Builders<TEntity>.Filter.Eq(x => x.Lock.LockKey, entityLock.LockKey)
+        );
+        var result = await Disk.ReplaceOneAsync(updatedEntity, filter, OneOption<TEntity>.FirstOrDefault, session); //Use FirstOrDefault since it is atomic safe.
+
+        FireAndForgetEvent(async () => await result.GetAfterAsync(), LockAction.CommitUpdated);
+
+        return (result, LockAction.CommitUpdated);
+    }
+
+    private async Task<(EntityChangeResult<TEntity>, LockAction)> PerformCommitForDeleteAsync(TEntity entity, Lock entityLock, Func<CallbackResult<TEntity>, Task> completeAction, Lock lockInfo, IClientSessionHandle session)
+    {
+        var before = await Disk.DeleteOneAsync(x => x.Id.Equals(entity.Id) && x.Lock != null && x.Lock.LockKey == entityLock.LockKey, session: session);
+        if (before == null)
+        {
+            var item = await Disk.GetOneAsync(entity.Id);
+            if (item == null) throw new InvalidOperationException($"Entity of type {typeof(TEntity).Name} with id '{entity.Id}' was not deleted on commit, it did not exist. [EntityActor: {entity.Lock?.Actor}, EntityLockTime: {entity.Lock?.LockTime}, EntityExpireTime: {entity.Lock?.ExpireTime}, EntityException: {entity.Lock?.ExceptionInfo?.Message}, Now: {DateTime.UtcNow}]");
+            throw new InvalidOperationException($"Entity of type {typeof(TEntity).Name} with id '{entity.Id}' was not deleted on commit, lock key missmatch. [EntityActor: {entity.Lock?.Actor}, EntityLockTime: {entity.Lock?.LockTime}, EntityExpireTime: {entity.Lock?.ExpireTime}, EntityException: {entity.Lock?.ExceptionInfo?.Message}, CurrentActor: {item.Lock?.Actor}, CurrentLockTime: {item.Lock?.LockTime}, CurrentExpireTime: {item.Lock?.ExpireTime}, CurrentException: {item.Lock?.ExceptionInfo?.Message}, Now: {DateTime.UtcNow}]");
+        }
+
+        FireAndForgetEvent(() => Task.FromResult(before), LockAction.CommitDeleted);
+
+        if (completeAction != null)
+        {
+            await completeAction.Invoke(new CallbackResult<TEntity> { LockAction = LockAction.CommitDeleted, Before = before, After = null });
+        }
+
+        return (null, LockAction.CommitDeleted);
+    }
+
+    private void FireAndForgetEvent(Func<Task<TEntity>> entityLoader, LockAction lockAction)
+    {
+        if (LockEvent == null) return;
+
+        Task.Run(async () =>
+        {
+            try
+            {
+                var entity = await entityLoader.Invoke();
+                LockEvent?.Invoke(this, new LockEventArgs<TEntity>(entity, lockAction));
+            }
+            catch (Exception e)
+            {
+                _logger?.LogWarning(e, e.Message);
+            }
+        });
+    }
+
+    private Lock BuildLockInfo(Lock entityLock, Exception exception)
+    {
+        if (exception != null)
+        {
+            return (entityLock with
+            {
+                ExceptionInfo = new ExceptionInfo
+                {
+                    Type = exception.GetType().Name,
+                    Message = exception.Message,
+                    StackTrace = exception.StackTrace
+                }
+            });
+        }
+
+        return null;
+    }
+
+    private static void ThrowException((RenewableEntityScope<TEntity, TKey> EntityScope, ErrorInfo errorInfo, bool ShouldWait) result)
+    {
+        ThrowException(result.errorInfo);
+    }
+
+    private static void ThrowException(ErrorInfo errorInfo)
+    {
+        if (errorInfo != null)
+        {
+            switch (errorInfo.Type)
+            {
+                case ErrorInfoType.Locked:
+                    throw new LockException(errorInfo.Message);
+                case ErrorInfoType.Error:
+                    throw new LockErrorException(errorInfo.Message);
+                case ErrorInfoType.Unknown:
+                    throw new UnknownException(errorInfo.Message);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(errorInfo.Type), $"Unknown type {nameof(errorInfo.Type)} {errorInfo.Type}");
+            }
+        }
+    }
+}
+
+public class RenewableLockRepositoryCollectionBase<TEntity> : RenewableLockRepositoryCollectionBase<TEntity, ObjectId>
+    where TEntity : LockableEntityBase
+{
+    protected RenewableLockRepositoryCollectionBase(IMongoDbServiceFactory mongoDbServiceFactory, ILogger logger = null, DatabaseContext databaseContext = null)
+        : base(mongoDbServiceFactory, logger, databaseContext)
+    {
+    }
+}

--- a/Tharga.MongoDB/Lockable/Renewable/RenewableLockScope.cs
+++ b/Tharga.MongoDB/Lockable/Renewable/RenewableLockScope.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+
+namespace Tharga.MongoDB.Lockable.Renewable;
+
+/// <summary>
+/// Renewable variant of <see cref="LockScope{T}"/>. The commit decision (<see cref="CommitMode.Update"/>
+/// vs <see cref="CommitMode.Delete"/>) is still taken at commit time; in addition the lease can be
+/// renewed via <c>ExtendAsync</c> / <c>StartKeepAlive</c>, and <c>LockLost</c> is
+/// cancelled if a renewal discovers the lock has been lost.
+/// </summary>
+public record RenewableLockScope<T> : RenewableLockScope<T, ObjectId>
+    where T : LockableEntityBase<ObjectId>
+{
+    internal RenewableLockScope(T entity, Func<T, CommitMode?, Exception, Task> releaseAction, RenewalController controller)
+        : base(entity, releaseAction, controller)
+    {
+    }
+}
+
+/// <summary>
+/// Renewable variant of <see cref="LockScope{T, TKey}"/>. The commit decision (<see cref="CommitMode.Update"/>
+/// vs <see cref="CommitMode.Delete"/>) is still taken at commit time; in addition the lease can be
+/// renewed via <c>ExtendAsync</c> / <c>StartKeepAlive</c>, and <c>LockLost</c> is
+/// cancelled if a renewal discovers the lock has been lost.
+/// </summary>
+public record RenewableLockScope<T, TKey> : LockScope<T, TKey>
+    where T : LockableEntityBase<TKey>
+{
+    private readonly RenewalController _controller;
+
+    internal RenewableLockScope(T entity, Func<T, CommitMode?, Exception, Task> releaseAction, RenewalController controller)
+        : base(entity, releaseAction)
+    {
+        _controller = controller;
+    }
+
+    /// <summary>
+    /// Cancelled when a renewal attempt discovers the lock has been lost (document deleted or
+    /// re-locked by another writer). Long-running work can observe this token to abort early.
+    /// </summary>
+    public CancellationToken LockLost => _controller.LockLost;
+
+    /// <summary>
+    /// Extends the lease, pushing <c>ExpireTime</c> further into the future. Returns the new <c>ExpireTime</c>.
+    /// </summary>
+    /// <param name="extension">How far to extend. When <c>null</c>, reuses the lease's current span.</param>
+    public Task<DateTime> ExtendAsync(TimeSpan? extension = null) => _controller.ExtendAsync(extension);
+
+    /// <summary>
+    /// Starts a background loop that periodically extends the lease until the returned handle is
+    /// disposed or the lease is released. Dispose the handle (or release the scope) to stop it.
+    /// </summary>
+    public IAsyncDisposable StartKeepAlive(LockKeepAliveOptions options = null) => _controller.StartKeepAlive(options);
+}

--- a/Tharga.MongoDB/Lockable/Renewable/RenewalController.cs
+++ b/Tharga.MongoDB/Lockable/Renewable/RenewalController.cs
@@ -1,0 +1,176 @@
+using Microsoft.Extensions.Logging;
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tharga.MongoDB.Lockable.Renewable;
+
+/// <summary>
+/// Owns the renewal lifecycle for a single lease: the current lock reference (<see cref="LockState"/>),
+/// the extend delegate, the keep-alive background loop, and the <see cref="LockLost"/> cancellation
+/// signal raised when a renewal discovers the lock has been lost. All extension attempts are
+/// serialized through a single gate so the keep-alive loop and an explicit <see cref="ExtendAsync"/>
+/// never race on the lock reference.
+/// </summary>
+internal sealed class RenewalController
+{
+    private readonly LockState _lockState;
+    private readonly Func<Lock, TimeSpan?, Task<Lock>> _extend;
+    private readonly TimeSpan _originalTimeout;
+    private readonly ILogger _logger;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly CancellationTokenSource _lockLostCts = new();
+
+    private CancellationTokenSource _loopCts;
+    private Task _loopTask;
+    private bool _keepAliveStarted;
+    private bool _stopped;
+
+    public RenewalController(LockState lockState, Func<Lock, TimeSpan?, Task<Lock>> extend, TimeSpan originalTimeout, ILogger logger)
+    {
+        _lockState = lockState;
+        _extend = extend;
+        _originalTimeout = originalTimeout;
+        _logger = logger;
+    }
+
+    public CancellationToken LockLost => _lockLostCts.Token;
+
+    public async Task<DateTime> ExtendAsync(TimeSpan? extension = null)
+    {
+        await _gate.WaitAsync();
+        try
+        {
+            if (_stopped) throw new LockAlreadyReleasedException("Cannot extend a lock that has already been released.");
+
+            var current = _lockState.Current;
+            try
+            {
+                var renewed = await _extend.Invoke(current, extension);
+                _lockState.Current = renewed;
+                return renewed.ExpireTime;
+            }
+            catch (LockLostException)
+            {
+                if (!_lockLostCts.IsCancellationRequested) _lockLostCts.Cancel();
+                throw;
+            }
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public IAsyncDisposable StartKeepAlive(LockKeepAliveOptions options = null)
+    {
+        if (_keepAliveStarted) throw new InvalidOperationException("Keep-alive has already been started for this lease.");
+        if (_stopped) throw new InvalidOperationException("Cannot start keep-alive on a lease that has already been released.");
+
+        _keepAliveStarted = true;
+        _loopCts = new CancellationTokenSource();
+        _loopTask = Task.Run(() => KeepAliveLoopAsync(options, _loopCts.Token));
+
+        return new KeepAliveHandle(this);
+    }
+
+    private async Task KeepAliveLoopAsync(LockKeepAliveOptions options, CancellationToken loopCt)
+    {
+        var interval = options?.Interval ?? TimeSpan.FromTicks(_originalTimeout.Ticks / 3);
+        if (interval <= TimeSpan.Zero) interval = TimeSpan.FromMilliseconds(1);
+        var extensionSpan = options?.Extension ?? _originalTimeout;
+        var maxTotalDuration = options?.MaxTotalDuration ?? TimeSpan.FromHours(4);
+        var onRenewalFailure = options?.OnRenewalFailure;
+
+        var elapsed = Stopwatch.StartNew();
+
+        while (!loopCt.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(interval, loopCt);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+
+            if (elapsed.Elapsed >= maxTotalDuration)
+            {
+                _logger?.LogWarning("Keep-alive for lease stopped: anti-zombie cap of {MaxTotalDuration} reached without release.", maxTotalDuration);
+                return;
+            }
+
+            try
+            {
+                await ExtendAsync(extensionSpan);
+            }
+            catch (LockLostException e)
+            {
+                onRenewalFailure?.Invoke(e);
+                return;
+            }
+            catch (LockExpiredException e)
+            {
+                onRenewalFailure?.Invoke(e);
+                return;
+            }
+            catch (LockAlreadyReleasedException)
+            {
+                return;
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+            catch (Exception e)
+            {
+                onRenewalFailure?.Invoke(e);
+                _logger?.LogWarning(e, "Keep-alive renewal failed transiently; will retry next tick. {Message}", e.Message);
+            }
+        }
+    }
+
+    public async Task StopAsync()
+    {
+        if (_stopped) return;
+        _stopped = true;
+
+        _loopCts?.Cancel();
+
+        if (_loopTask != null)
+        {
+            try
+            {
+                await _loopTask.WaitAsync(TimeSpan.FromSeconds(5));
+            }
+            catch (TimeoutException)
+            {
+                _logger?.LogWarning("Keep-alive loop did not stop within the timeout during release.");
+            }
+            catch (Exception e)
+            {
+                _logger?.LogWarning(e, "Keep-alive loop faulted while stopping during release. {Message}", e.Message);
+            }
+        }
+    }
+
+    private sealed class KeepAliveHandle : IAsyncDisposable
+    {
+        private readonly RenewalController _controller;
+        private bool _disposed;
+
+        public KeepAliveHandle(RenewalController controller)
+        {
+            _controller = controller;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            await _controller.StopAsync();
+        }
+    }
+}

--- a/docs/articles/renewable-lockable-collections.md
+++ b/docs/articles/renewable-lockable-collections.md
@@ -1,0 +1,83 @@
+# Renewable lockable collections
+
+`IRenewableLockRepositoryCollection<TEntity, TKey>` (namespace `Tharga.MongoDB.Lockable.Renewable`) is a standalone variant of the [lockable collection](lockable-collections.md) built for work whose duration is unpredictable: the lease can be set **short**, and the lock owner **extends it until finished**. A lock always expires after its lease — unless the owner asks for more time.
+
+It is a parallel implementation, not a change to the existing one. `LockableRepositoryCollectionBase` and its scopes are untouched, the on-disk `Lock` subdocument and pickup filters are identical, and both implementations interoperate on the same collections — so a consumer can swap per collection by changing the repository collection's base class, and swap back at any time.
+
+## Why
+
+With a fixed lease you must choose between two failure modes: a lease shorter than the work (the lock expires mid-run, another worker re-picks the document, and the original commit fails with a lock-key mismatch) or a lease long enough for the worst case (a crashed worker blocks the document for the entire lease). Renewal removes the trade-off: a 5-minute lease recovers from a crash within 5 minutes, while a healthy 6-hour job just keeps renewing.
+
+## Swap in
+
+```csharp
+// before
+internal class MyJobCollection : LockableRepositoryCollectionBase<MyJob, ObjectId> { ... }
+
+// after — same entity, same collection, same data
+internal class MyJobCollection : RenewableLockRepositoryCollectionBase<MyJob, ObjectId> { ... }
+```
+
+The API mirrors `ILockableRepositoryCollection<TEntity, TKey>` one to one — `PickForUpdateAsync` / `PickForDeleteAsync` / `WaitFor*` / `LockAsync` / `LockManyAsync` / `ReleaseOneAsync` and the rest — returning `RenewableEntityScope` / `RenewableLockScope`, which inherit the ordinary scopes (so `CommitAsync`, `AbandonAsync`, `SetErrorStateAsync`, `ExecuteAsync` and disposal behave exactly the same) and add three members.
+
+## Manual extension
+
+```csharp
+await using var scope = await collection.PickForUpdateAsync(id, TimeSpan.FromMinutes(5), actor);
+
+foreach (var item in workItems)
+{
+    await Process(item);
+    await scope.ExtendAsync();      // push ExpireTime forward another lease
+}
+
+await scope.CommitAsync(scope.Entity);
+```
+
+`ExtendAsync(TimeSpan? extension = null)` atomically moves `Lock.ExpireTime` to `now + extension` (default: the original lease), fenced on the scope's own `LockKey` — it can never extend a lock that another actor has re-picked. It returns the new expiry, and throws:
+
+- `LockLostException` — the lock was stolen (expired and re-picked) or the document was deleted. The scope's `LockLost` token is cancelled **before** the exception propagates.
+- `LockExpiredException` — the lease expired and the collection is strict (`AllowDelayedCommit` overridden to `false`). On a default collection an expired-but-not-stolen lock extends successfully — the `LockKey` match, not the wall clock, is the safety authority, consistent with delayed commit.
+- `LockAlreadyReleasedException` — the scope was already committed/abandoned.
+
+## Keep-alive
+
+For jobs without natural renewal points, start an automatic renewer:
+
+```csharp
+await using var scope = await collection.PickForDeleteAsync(id, TimeSpan.FromMinutes(5), actor);
+await using var keepAlive = scope.StartKeepAlive(new LockKeepAliveOptions
+{
+    MaxTotalDuration = TimeSpan.FromHours(2)    // anti-zombie cap — set this deliberately
+});
+
+using var cts = CancellationTokenSource.CreateLinkedTokenSource(scope.LockLost, jobToken);
+await RunLongJobAsync(scope.Entity, cts.Token);
+
+await scope.CommitAsync();
+```
+
+The loop renews at `Interval` (default: lease ÷ 3) by `Extension` (default: the original lease) and stops automatically when the scope commits, abandons, errors, or disposes — always before the release write. Failure handling:
+
+- Transient errors (network, MongoDB hiccup): logged, `OnRenewalFailure` invoked, retried next tick. If the lease lapses meanwhile and nobody re-picked, the next renewal resurrects it.
+- `LockLostException`: the `LockLost` token is cancelled and the loop stops — link the token into the job's `CancellationToken` so the work aborts within roughly one interval instead of running to a doomed commit.
+- `MaxTotalDuration` reached: renewals stop with a warning and the lock expires at its last `ExpireTime`. Recovery from that point is exactly the ordinary expired-lock pickup — a hung-but-alive process cannot hold a lock forever.
+
+## Crash recovery and mixed versions
+
+A crashed owner simply stops renewing: the lock expires at most one lease after the last renewal and any worker can pick it up, exactly as with the fixed-lease implementation — just bounded by the short lease instead of a worst-case one.
+
+Because renewal only rewrites `Lock.ExpireTime` inside the existing subdocument, processes running older package versions read and honor the extended expiry through their unchanged filters. Only the lock **owner** needs the new implementation; readers and competing pickers need nothing.
+
+## Concurrency and cost
+
+Renewal is one small `_id`-targeted, `LockKey`-fenced update per held scope per interval — for a 5-minute lease, one tiny write every ~100 seconds per *currently held lock*, independent of collection size. Each scope owns its own renewal state (a per-scope semaphore serializes its extends); there is no cross-scope or cross-collection coordination, no new indexes, and no change to the pickup path. Races resolve by MongoDB document-level atomicity: a renewal landing first makes the stealer's expired-pickup filter miss; a steal landing first makes the renewal's key fence miss and surface as `LockLost`. No interleaving yields two owners.
+
+## Divergence from the fixed-lease implementation
+
+One deliberate difference: the **abandon** path releases the lock fenced on the owner's `LockKey` and treats an already-lost lock as a successful no-op. With renewal, a lease may legitimately expire (e.g. at the `MaxTotalDuration` cap), be re-picked and committed by another actor before the original scope disposes — that disposal must not throw, and must never clear the new owner's lock.
+
+## See also
+
+- [Lockable collections](lockable-collections.md) — the fixed-lease implementation this mirrors
+- [API: IRenewableLockRepositoryCollection&lt;TEntity, TKey&gt;](xref:Tharga.MongoDB.Lockable.Renewable.IRenewableLockRepositoryCollection`2)

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -4,6 +4,8 @@
   href: getting-started.md
 - name: Lockable collections
   href: lockable-collections.md
+- name: Renewable lockable collections
+  href: renewable-lockable-collections.md
 - name: Transactions
   href: transactions.md
 - name: Keyset pagination


### PR DESCRIPTION
Closes #120.

## What

A standalone **renewable-lease** variant of the Lockable mechanism, in a new parallel namespace `Tharga.MongoDB.Lockable.Renewable`. The lease can be set short (crash recovery within minutes) and the lock owner extends it until finished — *a lock always expires unless the owner asks for more time*.

**Zero shipped files are modified** — the diff is purely additive (8 source types, 19 ported parity test files, 2 new test files, docs). Consumers opt in per collection by changing their repository collection's base class, and can swap back at any time: the on-disk `Lock` subdocument and pickup filters are identical, so both implementations interoperate on the same collections, including mixed package versions mid-rollout (only the lock *owner* needs the new type; older readers honor the extended `ExpireTime` through their unchanged filters).

## API

- `RenewableLockRepositoryCollectionBase<TEntity, TKey>` / `IRenewableLockRepositoryCollection<TEntity, TKey>` — 1:1 mirror of the existing interface (same member names, parameters, defaults; same `AllowDelayedCommit` / `DefaultTimeout` / `RequireActor` virtuals; identical message strings), returning renewable scopes.
- `RenewableEntityScope` / `RenewableLockScope` — inherit `EntityScope` / `LockScope` (so commit/abandon/error/dispose and the `ExecuteAsync` extension behave identically) and add:
  - `Task<DateTime> ExtendAsync(TimeSpan? extension = null)` — atomic `UpdateOne` fenced on `Id + Lock.LockKey`, moving only `ExpireTime`. A stolen/deleted lock throws the new `LockLostException`; on a strict collection (`AllowDelayedCommit == false`) extending an expired lease throws `LockExpiredException`; on a default collection an expired-but-not-stolen lock extends successfully (the `LockKey` match is the safety authority — consistent with delayed commit).
  - `IAsyncDisposable StartKeepAlive(LockKeepAliveOptions)` — auto-renew at lease/3 (configurable) with a `MaxTotalDuration` anti-zombie cap; stopped automatically before any release write; transient errors retry, lost-lock and strict-expiry are terminal.
  - `CancellationToken LockLost` — cancelled (before the exception propagates) when any renewal discovers the lock was stolen, letting long jobs abort within one interval instead of running to a doomed commit.
- The release path reads the *current* lock at invocation, so a renewed lease legitimately passes the strict-TTL gate at commit time.

## Deliberate divergence (documented)

The **abandon** path is fenced on the owner's `LockKey` and treats an already-lost lock as a successful no-op release. With renewal, a lease may legitimately expire (e.g. at the `MaxTotalDuration` cap), be re-picked and committed by another actor before the original scope disposes; that disposal must not throw and must never clear the new owner's lock. (The fixed-lease implementation clears by id only — see issue #120, "related observations".)

## Tests

- The existing Lockable test suite ported 1:1 against the new collection (19 files) as a functional-parity proof.
- `ExtendLockTests` + `KeepAliveTests` — 16 renewal-specific cases (strict-commit-after-extension, steal → `LockLost`, expired-but-not-stolen, extension-prevents-pickup, anti-zombie cap, release-racing-renewal, …).
- Local results (standalone mongod, full suite): all green except the transaction tests, which require a replica set — same as the existing suite. No new failures in the original Lockable tests.

## Version

New public API — suggests bumping `MAJOR_MINOR` `2.10` → `2.11` in `build.yml`, but that is your call as maintainer, so this PR deliberately leaves `build.yml` untouched. Happy to add the bump (or anything else — naming, defaults like `MaxTotalDuration = 4h`, the `LockLostException : LockException` family choice) per your preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
