### PR TITLE
Firewall: open Open-mode configs at startup + Atlas service-account (OAuth2) auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,6 +610,11 @@ To create a key-pair, select *Access Manager* for the *organization*. Then Selec
 The *GroupId* can be found as part of the URL on the *Atlas MongoDB* website.
 Example. `https://cloud.mongodb.com/v2/[GroupId]`
 
+### Service account (OAuth2)
+As an alternative to the API key pair, the Atlas-direct path can authenticate with an [Atlas Service Account](https://www.mongodb.com/docs/atlas/api/service-accounts/) (OAuth2 client credentials). Set `ClientId` and `ClientSecret` on `AccessInfo` instead of `PublicKey`/`PrivateKey` (the service account is used when both are set); Tharga.MongoDB exchanges them for a short-lived bearer token automatically. Works in Classic and Notify mode.
+
+> Service-account secrets **expire** and must be rotated. A failed token exchange raises `AtlasServiceAccountAuthException` (carrying `StatusCode` and a best-effort `LikelyExpired` flag — Atlas returns 401 for both invalid and expired secrets, so it can't be definitive).
+
 ### Optional Quilt4Net firewall proxy
 For deployments where you don't want individual services to hold an Atlas API key, [Quilt4Net.Server](https://www.nuget.org/packages/Quilt4Net.Toolkit) can act as a central firewall manager — it holds the Atlas Project-Owner credential and exposes a proxy API that opens the firewall on behalf of consumers, then auto-closes openings that stop being used. Tharga.MongoDB integrates with that proxy via two optional fields on `MongoDbApiAccess`:
 
@@ -625,12 +630,14 @@ o.AccessInfo = new MongoDbApiAccess
 
 The mode is **inferred** from which keys you populate:
 
-| Atlas keys (Public+Private) | Quilt4Net key | Mode | Behaviour |
+| Atlas credential\* | Quilt4Net key | Mode | Behaviour |
 |:--:|:--:|:--|:--|
 | ✔ | ✘ | **Classic** | Direct Atlas open. Today's behaviour, unchanged. |
 | ✔ | ✔ | **Notify** | Direct Atlas open + periodic Quilt4Net `ReportUsedAsync` heartbeat so the central system knows this IP is in use. |
 | ✘ | ✔ | **Open** | Quilt4Net opens the firewall via its proxy. Subsequent heartbeats reuse the same `OpenAsync` call (returns `AlreadyOpen` once the firewall is open, which serves as the usage signal — no separate `ReportUsedAsync` needed). The consumer never holds an Atlas credential. |
 | ✘ | ✘ | None | No firewall management. |
+
+\* *Atlas credential* = a Programmatic API key pair (`PublicKey`+`PrivateKey`) **or** a Service Account (`ClientId`+`ClientSecret`); either drives the Atlas-direct open.
 
 The heartbeat is driven by a background service registered automatically by `AddMongoDB`. Set `DatabaseOptions.Quilt4NetHeartbeatInterval` to tune the cadence (default 5 minutes) or `null` to disable. The service is dormant when no access is in Notify/Open mode, so consumers without `Quilt4NetApiKey` pay nothing at runtime.
 

--- a/Tharga.MongoDB.Tests/AtlasTokenServiceTests.cs
+++ b/Tharga.MongoDB.Tests/AtlasTokenServiceTests.cs
@@ -1,0 +1,102 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Tharga.MongoDB.Atlas;
+using Tharga.MongoDB.Configuration;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests;
+
+public class AtlasTokenServiceTests
+{
+    private sealed class CountingHandler : HttpMessageHandler
+    {
+        public int CallCount { get; private set; }
+        public Func<HttpRequestMessage, HttpResponseMessage> Reply { get; init; } = _ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create(new { access_token = "tok", token_type = "Bearer", expires_in = 3600 })
+        };
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            return Task.FromResult(Reply(request));
+        }
+    }
+
+    private static (AtlasTokenService sut, CountingHandler handler) Build(Func<HttpRequestMessage, HttpResponseMessage> reply = null)
+    {
+        var handler = reply == null ? new CountingHandler() : new CountingHandler { Reply = reply };
+
+        var services = new ServiceCollection();
+        services.AddHttpClient(AtlasTokenService.HttpClientName)
+                .ConfigurePrimaryHttpMessageHandler(() => handler);
+        var sp = services.BuildServiceProvider();
+
+        return (new AtlasTokenService(sp.GetRequiredService<IHttpClientFactory>()), handler);
+    }
+
+    private static MongoDbApiAccess NewAccess(string clientId = "cid") => new()
+    {
+        ClientId = clientId,
+        ClientSecret = "csecret",
+        GroupId = "g1",
+    };
+
+    [Fact]
+    public async Task GetAccessTokenAsync_Returns_Token_OnSuccess()
+    {
+        var (sut, _) = Build();
+
+        var token = await sut.GetAccessTokenAsync(NewAccess());
+
+        token.Should().Be("tok");
+    }
+
+    [Fact]
+    public async Task GetAccessTokenAsync_ServesFromCache_OnSecondCall()
+    {
+        var (sut, handler) = Build();
+        var access = NewAccess(Guid.NewGuid().ToString());
+
+        await sut.GetAccessTokenAsync(access);
+        await sut.GetAccessTokenAsync(access);
+
+        handler.CallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetAccessTokenAsync_Throws_WithLikelyExpiredTrue_When401BodyMentionsExpire()
+    {
+        var (sut, _) = Build(_ => new HttpResponseMessage(HttpStatusCode.Unauthorized)
+        {
+            Content = new StringContent("{\"error\":\"the client secret has expired\"}")
+        });
+
+        var act = () => sut.GetAccessTokenAsync(NewAccess(Guid.NewGuid().ToString()));
+
+        var ex = (await act.Should().ThrowAsync<AtlasServiceAccountAuthException>()).Which;
+        ex.LikelyExpired.Should().BeTrue();
+        ex.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetAccessTokenAsync_Throws_WithLikelyExpiredFalse_When401BodyWithoutExpire()
+    {
+        var (sut, _) = Build(_ => new HttpResponseMessage(HttpStatusCode.Unauthorized)
+        {
+            Content = new StringContent("{\"error\":\"invalid client credentials\"}")
+        });
+
+        var act = () => sut.GetAccessTokenAsync(NewAccess(Guid.NewGuid().ToString()));
+
+        var ex = (await act.Should().ThrowAsync<AtlasServiceAccountAuthException>()).Which;
+        ex.LikelyExpired.Should().BeFalse();
+        ex.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+}

--- a/Tharga.MongoDB.Tests/FirewallModeTests.cs
+++ b/Tharga.MongoDB.Tests/FirewallModeTests.cs
@@ -74,4 +74,60 @@ public class FirewallModeTests
             // No Quilt4NetApiKey — base URL alone doesn't promote to Notify.
         }.GetFirewallMode().Should().Be(FirewallMode.Classic);
     }
+
+    [Fact]
+    public void HasFirewallConfiguration_False_WhenNull()
+    {
+        MongoDbApiAccess access = null;
+        access.HasFirewallConfiguration().Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasFirewallConfiguration_False_WhenAllFieldsEmpty()
+    {
+        new MongoDbApiAccess().HasFirewallConfiguration().Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasFirewallConfiguration_True_WhenOnlyAtlasKeys()
+    {
+        new MongoDbApiAccess
+        {
+            PublicKey = "pub",
+            PrivateKey = "priv",
+            GroupId = "g1",
+        }.HasFirewallConfiguration().Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasFirewallConfiguration_True_WhenBothAtlasAndQuilt4NetKeys()
+    {
+        new MongoDbApiAccess
+        {
+            PublicKey = "pub",
+            PrivateKey = "priv",
+            GroupId = "g1",
+            Quilt4NetApiKey = "q4n",
+        }.HasFirewallConfiguration().Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasFirewallConfiguration_True_WhenOnlyQuilt4NetKey()
+    {
+        // Open mode: Quilt4Net key + GroupId, no Atlas keys. HasMongoDbApiAccess would return false here, which is why the startup firewall open used to skip Open-mode configs.
+        new MongoDbApiAccess
+        {
+            GroupId = "g1",
+            Quilt4NetApiKey = "q4n",
+        }.HasFirewallConfiguration().Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasFirewallConfiguration_False_WhenQuilt4NetKeyButNoGroupId()
+    {
+        new MongoDbApiAccess
+        {
+            Quilt4NetApiKey = "q4n",
+        }.HasFirewallConfiguration().Should().BeFalse();
+    }
 }

--- a/Tharga.MongoDB.Tests/ServiceAccountAccessTests.cs
+++ b/Tharga.MongoDB.Tests/ServiceAccountAccessTests.cs
@@ -1,0 +1,109 @@
+using FluentAssertions;
+using Tharga.MongoDB.Configuration;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests;
+
+public class ServiceAccountAccessTests
+{
+    [Fact]
+    public void GetFirewallMode_Classic_WhenOnlyServiceAccountKeys()
+    {
+        new MongoDbApiAccess
+        {
+            ClientId = "cid",
+            ClientSecret = "csecret",
+            GroupId = "g1",
+        }.GetFirewallMode().Should().Be(FirewallMode.Classic);
+    }
+
+    [Fact]
+    public void GetFirewallMode_Notify_WhenServiceAccountAndQuilt4NetKeys()
+    {
+        new MongoDbApiAccess
+        {
+            ClientId = "cid",
+            ClientSecret = "csecret",
+            GroupId = "g1",
+            Quilt4NetApiKey = "q4n",
+        }.GetFirewallMode().Should().Be(FirewallMode.Notify);
+    }
+
+    [Fact]
+    public void HasMongoDbApiAccess_True_WhenServiceAccountAndGroupId()
+    {
+        new MongoDbApiAccess
+        {
+            ClientId = "cid",
+            ClientSecret = "csecret",
+            GroupId = "g1",
+        }.HasMongoDbApiAccess().Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasMongoDbApiAccess_False_WhenServiceAccountWithoutGroupId()
+    {
+        new MongoDbApiAccess
+        {
+            ClientId = "cid",
+            ClientSecret = "csecret",
+        }.HasMongoDbApiAccess().Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasMongoDbApiAccess_True_WhenDigestAndGroupId()
+    {
+        new MongoDbApiAccess
+        {
+            PublicKey = "pub",
+            PrivateKey = "priv",
+            GroupId = "g1",
+        }.HasMongoDbApiAccess().Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasFirewallConfiguration_True_WhenServiceAccountAndGroupId()
+    {
+        new MongoDbApiAccess
+        {
+            ClientId = "cid",
+            ClientSecret = "csecret",
+            GroupId = "g1",
+        }.HasFirewallConfiguration().Should().BeTrue();
+    }
+
+    [Fact]
+    public void UsesServiceAccount_True_WhenBothFieldsSet()
+    {
+        new MongoDbApiAccess
+        {
+            ClientId = "cid",
+            ClientSecret = "csecret",
+        }.UsesServiceAccount().Should().BeTrue();
+    }
+
+    [Fact]
+    public void UsesServiceAccount_False_WhenClientSecretMissing()
+    {
+        new MongoDbApiAccess
+        {
+            ClientId = "cid",
+        }.UsesServiceAccount().Should().BeFalse();
+    }
+
+    [Fact]
+    public void UsesServiceAccount_False_WhenClientIdMissing()
+    {
+        new MongoDbApiAccess
+        {
+            ClientSecret = "csecret",
+        }.UsesServiceAccount().Should().BeFalse();
+    }
+
+    [Fact]
+    public void UsesServiceAccount_False_WhenNull()
+    {
+        MongoDbApiAccess access = null;
+        access.UsesServiceAccount().Should().BeFalse();
+    }
+}

--- a/Tharga.MongoDB/Atlas/AtlasHttpClient.cs
+++ b/Tharga.MongoDB/Atlas/AtlasHttpClient.cs
@@ -1,24 +1,41 @@
-﻿using System;
+using System;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
 using Tharga.MongoDB.Configuration;
 
 namespace Tharga.MongoDB.Atlas;
 
 internal class AtlasHttpClient : IDisposable
 {
+    private static readonly Uri BaseAddress = new("https://cloud.mongodb.com/api/atlas/v1.0/");
     private readonly HttpClient _httpClient;
     private readonly HttpClientHandler _handler;
 
-    public AtlasHttpClient(MongoDbApiAccess access)
+    private AtlasHttpClient(HttpClient client, HttpClientHandler handler)
     {
-        _handler = new HttpClientHandler();
-        _handler.Credentials = new NetworkCredential(access.PublicKey, access.PrivateKey);
-        _httpClient = new HttpClient(_handler);
-        _httpClient.BaseAddress = new Uri("https://cloud.mongodb.com/api/atlas/v1.0/");
+        _httpClient = client;
+        _handler = handler;
     }
 
     public HttpClient Client => _httpClient;
+
+    public static async Task<AtlasHttpClient> CreateAsync(MongoDbApiAccess access, IAtlasTokenService tokenService, CancellationToken cancellationToken = default)
+    {
+        var handler = new HttpClientHandler();
+        if (access.UsesServiceAccount())
+        {
+            var token = await tokenService.GetAccessTokenAsync(access, cancellationToken);
+            var client = new HttpClient(handler) { BaseAddress = BaseAddress };
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            return new AtlasHttpClient(client, handler);
+        }
+
+        handler.Credentials = new NetworkCredential(access.PublicKey, access.PrivateKey);
+        return new AtlasHttpClient(new HttpClient(handler) { BaseAddress = BaseAddress }, handler);
+    }
 
     public void Dispose()
     {

--- a/Tharga.MongoDB/Atlas/AtlasServiceAccountAuthException.cs
+++ b/Tharga.MongoDB/Atlas/AtlasServiceAccountAuthException.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Net;
+
+namespace Tharga.MongoDB.Atlas;
+
+/// <summary>
+/// Thrown when an Atlas Service Account OAuth2 token request is rejected (HTTP 401) — the client
+/// secret is invalid or expired. Atlas returns 401 for both cases, so <see cref="LikelyExpired"/>
+/// is a best-effort flag set only when the response body mentions expiry.
+/// </summary>
+public sealed class AtlasServiceAccountAuthException : Exception
+{
+    public AtlasServiceAccountAuthException(HttpStatusCode statusCode, bool likelyExpired) : base(BuildMessage(statusCode, likelyExpired))
+    {
+        StatusCode = statusCode;
+        LikelyExpired = likelyExpired;
+    }
+
+    public HttpStatusCode StatusCode { get; }
+
+    public bool LikelyExpired { get; }
+
+    private static string BuildMessage(HttpStatusCode statusCode, bool likelyExpired)
+    {
+        if (likelyExpired) return "Atlas service account authentication failed (HTTP 401): the client secret appears to be expired — rotate the service-account secret in Atlas.";
+        return $"Atlas service account authentication failed (HTTP {(int)statusCode}): the client secret may be invalid or expired.";
+    }
+}

--- a/Tharga.MongoDB/Atlas/AtlasTokenResponse.cs
+++ b/Tharga.MongoDB/Atlas/AtlasTokenResponse.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Tharga.MongoDB.Atlas;
+
+internal sealed record AtlasTokenResponse
+{
+    [JsonPropertyName("access_token")]
+    public string AccessToken { get; init; }
+
+    [JsonPropertyName("token_type")]
+    public string TokenType { get; init; }
+
+    [JsonPropertyName("expires_in")]
+    public int ExpiresIn { get; init; }
+}

--- a/Tharga.MongoDB/Atlas/AtlasTokenService.cs
+++ b/Tharga.MongoDB/Atlas/AtlasTokenService.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Tharga.MongoDB.Configuration;
+
+namespace Tharga.MongoDB.Atlas;
+
+internal sealed class AtlasTokenService : IAtlasTokenService
+{
+    internal const string HttpClientName = "Tharga.MongoDB.AtlasOAuth";
+    private static readonly Uri TokenEndpoint = new("https://cloud.mongodb.com/api/oauth/token");
+    private static readonly TimeSpan ExpiryMargin = TimeSpan.FromSeconds(60);
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<AtlasTokenService> _logger;
+    private readonly ConcurrentDictionary<string, (string Token, DateTime ExpiresUtc)> _tokenCache = new();
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new();
+
+    public AtlasTokenService(IHttpClientFactory httpClientFactory, ILogger<AtlasTokenService> logger = null)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    public async Task<string> GetAccessTokenAsync(MongoDbApiAccess access, CancellationToken cancellationToken = default)
+    {
+        if (access == null) throw new ArgumentNullException(nameof(access));
+
+        if (TryGetCached(access.ClientId, out var cached)) return cached;
+
+        var gate = _locks.GetOrAdd(access.ClientId, _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (TryGetCached(access.ClientId, out cached)) return cached;
+
+            var (token, expiresInSeconds) = await RequestTokenAsync(access, cancellationToken).ConfigureAwait(false);
+            _tokenCache[access.ClientId] = (token, DateTime.UtcNow.AddSeconds(expiresInSeconds));
+            return token;
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    private bool TryGetCached(string clientId, out string token)
+    {
+        token = null;
+        if (!_tokenCache.TryGetValue(clientId, out var entry)) return false;
+        if (DateTime.UtcNow >= entry.ExpiresUtc - ExpiryMargin) return false;
+        token = entry.Token;
+        return true;
+    }
+
+    private async Task<(string Token, int ExpiresInSeconds)> RequestTokenAsync(MongoDbApiAccess access, CancellationToken cancellationToken)
+    {
+        var httpClient = _httpClientFactory.CreateClient(HttpClientName);
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, TokenEndpoint);
+        var credentials = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{access.ClientId}:{access.ClientSecret}"));
+        request.Headers.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+        request.Content = new FormUrlEncodedContent(new[] { new KeyValuePair<string, string>("grant_type", "client_credentials") });
+
+        using var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            var likelyExpired = body != null && body.Contains("expire", StringComparison.OrdinalIgnoreCase);
+            _logger?.LogError("Atlas service account token request failed with {statusCode}. LikelyExpired={likelyExpired}.", (int)response.StatusCode, likelyExpired);
+            throw new AtlasServiceAccountAuthException(response.StatusCode, likelyExpired);
+        }
+
+        var result = await response.Content.ReadFromJsonAsync<AtlasTokenResponse>(cancellationToken: cancellationToken).ConfigureAwait(false);
+        return (result.AccessToken, result.ExpiresIn);
+    }
+}

--- a/Tharga.MongoDB/Atlas/IAtlasTokenService.cs
+++ b/Tharga.MongoDB/Atlas/IAtlasTokenService.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Tharga.MongoDB.Configuration;
+
+namespace Tharga.MongoDB.Atlas;
+
+internal interface IAtlasTokenService
+{
+    Task<string> GetAccessTokenAsync(MongoDbApiAccess access, CancellationToken cancellationToken = default);
+}

--- a/Tharga.MongoDB/Atlas/MongoDbFirewallService.cs
+++ b/Tharga.MongoDB/Atlas/MongoDbFirewallService.cs
@@ -16,11 +16,13 @@ namespace Tharga.MongoDB.Atlas;
 internal class MongoDbFirewallService : IMongoDbFirewallService
 {
     private readonly IExternalIpAddressService _externalIpAddressService;
+    private readonly IAtlasTokenService _tokenService;
     private readonly ILogger<MongoDbFirewallService> _logger;
 
-    public MongoDbFirewallService(IExternalIpAddressService externalIpAddressService, ILogger<MongoDbFirewallService> logger)
+    public MongoDbFirewallService(IExternalIpAddressService externalIpAddressService, IAtlasTokenService tokenService, ILogger<MongoDbFirewallService> logger)
     {
         _externalIpAddressService = externalIpAddressService;
+        _tokenService = tokenService;
         _logger = logger;
     }
 
@@ -84,7 +86,7 @@ internal class MongoDbFirewallService : IMongoDbFirewallService
     {
         if (access == null) throw new ArgumentNullException(nameof(access));
 
-        using var atlasHttp = new AtlasHttpClient(access);
+        using var atlasHttp = await AtlasHttpClient.CreateAsync(access, _tokenService);
 
         using var request = new HttpRequestMessage(HttpMethod.Get, $"groups/{access.GroupId}/accessList");
         using var result = await atlasHttp.Client.SendAsync(request);
@@ -103,7 +105,7 @@ internal class MongoDbFirewallService : IMongoDbFirewallService
     {
         if (access == null) throw new ArgumentNullException(nameof(access));
 
-        using var atlasHttp = new AtlasHttpClient(access);
+        using var atlasHttp = await AtlasHttpClient.CreateAsync(access, _tokenService);
 
         await foreach (var item in GetFirewallListAsync(access).Where(x => x.Comment == name))
         {
@@ -117,7 +119,7 @@ internal class MongoDbFirewallService : IMongoDbFirewallService
     {
         if (access == null) throw new ArgumentNullException(nameof(access));
 
-        using var atlasHttp = new AtlasHttpClient(access);
+        using var atlasHttp = await AtlasHttpClient.CreateAsync(access, _tokenService);
 
         var payload = new[] { new { cidrBlock = $"{ipAddress}/32", comment = name } };
         var serialized = JsonSerializer.Serialize(payload);

--- a/Tharga.MongoDB/Configuration/MongoDbApiAccess.cs
+++ b/Tharga.MongoDB/Configuration/MongoDbApiAccess.cs
@@ -13,6 +13,16 @@ public record MongoDbApiAccess
     public string PrivateKey { get; init; }
 
     /// <summary>
+    /// Atlas Service Account OAuth2 client id (alternative to <see cref="PublicKey"/>/<see cref="PrivateKey"/>).
+    /// </summary>
+    public string ClientId { get; init; }
+
+    /// <summary>
+    /// Atlas Service Account OAuth2 client secret. Service-account secrets expire and must be rotated.
+    /// </summary>
+    public string ClientSecret { get; init; }
+
+    /// <summary>
     /// Value of the GroupId in Atlas MongoDB.
     /// </summary>
     public string GroupId { get; init; }

--- a/Tharga.MongoDB/Configuration/MongoDbApiAccessExtensions.cs
+++ b/Tharga.MongoDB/Configuration/MongoDbApiAccessExtensions.cs
@@ -1,22 +1,28 @@
-﻿namespace Tharga.MongoDB.Configuration;
+namespace Tharga.MongoDB.Configuration;
 
 public static class MongoDbApiAccessExtensions
 {
     public static bool HasMongoDbApiAccess(this MongoDbApiAccess item)
     {
         if (item == null) return false;
-        if (string.IsNullOrEmpty(item.PublicKey)) return false;
-        if (string.IsNullOrEmpty(item.PrivateKey)) return false;
         if (string.IsNullOrEmpty(item.GroupId)) return false;
-        return true;
+        var hasDigest = !string.IsNullOrEmpty(item.PublicKey) && !string.IsNullOrEmpty(item.PrivateKey);
+        var hasServiceAccount = item.UsesServiceAccount();
+        return hasDigest || hasServiceAccount;
+    }
+
+    internal static bool UsesServiceAccount(this MongoDbApiAccess item)
+    {
+        if (item == null) return false;
+        return !string.IsNullOrEmpty(item.ClientId) && !string.IsNullOrEmpty(item.ClientSecret);
     }
 
     internal static FirewallMode GetFirewallMode(this MongoDbApiAccess item)
     {
         if (item == null) return FirewallMode.None;
 
-        var hasAtlas = !string.IsNullOrEmpty(item.PublicKey)
-                       && !string.IsNullOrEmpty(item.PrivateKey)
+        var hasDigest = !string.IsNullOrEmpty(item.PublicKey) && !string.IsNullOrEmpty(item.PrivateKey);
+        var hasAtlas = (hasDigest || item.UsesServiceAccount())
                        && !string.IsNullOrEmpty(item.GroupId);
         var hasQuilt4Net = !string.IsNullOrEmpty(item.Quilt4NetApiKey)
                            && !string.IsNullOrEmpty(item.GroupId);

--- a/Tharga.MongoDB/Configuration/MongoDbApiAccessExtensions.cs
+++ b/Tharga.MongoDB/Configuration/MongoDbApiAccessExtensions.cs
@@ -26,4 +26,10 @@ public static class MongoDbApiAccessExtensions
         if (hasAtlas) return FirewallMode.Classic;
         return FirewallMode.None;
     }
+
+    // True when any firewall mode is configured (Classic, Notify or Open). Unlike HasMongoDbApiAccess this also covers Quilt4Net-only (Open) configs, so the startup firewall open is attempted for them too.
+    internal static bool HasFirewallConfiguration(this MongoDbApiAccess item)
+    {
+        return item.GetFirewallMode() != FirewallMode.None;
+    }
 }

--- a/Tharga.MongoDB/MongoDbRegistrationExtensions.cs
+++ b/Tharga.MongoDB/MongoDbRegistrationExtensions.cs
@@ -70,6 +70,8 @@ public static class MongoDbRegistrationExtensions
         services.AddHttpClient();
 
         services.AddTransient<IExternalIpAddressService, ExternalIpAddressService>();
+        services.AddHttpClient(Atlas.AtlasTokenService.HttpClientName);
+        services.AddSingleton<Atlas.IAtlasTokenService, Atlas.AtlasTokenService>();
         services.AddTransient<IMongoDbFirewallService, MongoDbFirewallService>();
         if (o.Monitor?.EnableCommandMonitoring == true)
         {

--- a/Tharga.MongoDB/MongoDbRegistrationExtensions.cs
+++ b/Tharga.MongoDB/MongoDbRegistrationExtensions.cs
@@ -331,7 +331,7 @@ public static class MongoDbRegistrationExtensions
                     foreach (var configurationName in o.DatabaseUsage.FirewallConfigurationNames)
                     {
                         var configuration = repositoryConfiguration.GetConfiguration(configurationName);
-                        if (configuration.AccessInfo.HasMongoDbApiAccess())
+                        if (configuration.AccessInfo.HasFirewallConfiguration())
                         {
                             var mongoDbService = mongoDbServiceFactory.GetMongoDbService(() => new DatabaseContext { ConfigurationName = configurationName });
                             var databaseHostName = mongoDbService.GetDatabaseHostName();
@@ -363,7 +363,7 @@ public static class MongoDbRegistrationExtensions
                         else
                         {
                             skipped++;
-                            o.Logger?.LogInformation("Firewall skipped for {config}: no API access info.", configurationName);
+                            o.Logger?.LogInformation("Firewall skipped for {config}: no firewall configuration.", configurationName);
                         }
                     }
                 }

--- a/docs/articles/atlas-firewall.md
+++ b/docs/articles/atlas-firewall.md
@@ -1,6 +1,6 @@
 # Atlas firewall management
 
-When a Tharga.MongoDB-hosted service talks to an Atlas cluster (anything other than `localhost`), the consumer's egress IP must be on the cluster's IP access list. Tharga.MongoDB can manage that automatically — either by calling Atlas directly with an organisation API key, or by delegating to [Quilt4Net's firewall proxy](https://www.nuget.org/packages/Quilt4Net.Toolkit) so individual services don't need to hold an Atlas credential.
+When a Tharga.MongoDB-hosted service talks to an Atlas cluster (anything other than `localhost`), the consumer's egress IP must be on the cluster's IP access list. Tharga.MongoDB can manage that automatically — either by calling Atlas directly (with a Programmatic API key **or** an OAuth2 Service Account), or by delegating to [Quilt4Net's firewall proxy](https://www.nuget.org/packages/Quilt4Net.Toolkit) so individual services don't need to hold an Atlas credential.
 
 The mode is **inferred** from which keys you populate on `MongoDbApiAccess` — there is no explicit enum to set.
 
@@ -15,9 +15,12 @@ services.AddMongoDB(o =>
     {
         AccessInfo = new MongoDbApiAccess
         {
-            // Atlas direct (Classic / Notify):
+            // Atlas direct (Classic / Notify) — use EITHER a Programmatic API key:
             PublicKey  = "<atlas-public-key>",
             PrivateKey = "<atlas-private-key>",
+            // ...OR an OAuth2 Service Account (used when both of these are set):
+            ClientId     = "<service-account-client-id>",
+            ClientSecret = "<service-account-client-secret>",
 
             // Required for both Atlas-direct and Quilt4Net paths — it's the Atlas project ID.
             GroupId    = "<atlas-group-id>",
@@ -32,12 +35,22 @@ services.AddMongoDB(o =>
 });
 ```
 
-| Atlas keys (Public+Private) | Quilt4Net key | Mode | What happens |
+Set *either* the API key pair *or* the service account for the Atlas-direct path — not both. When `ClientId` and `ClientSecret` are both present the service account is used; otherwise the `PublicKey`/`PrivateKey` digest key is used.
+
+| Atlas credential¹ | Quilt4Net key | Mode | What happens |
 |:--:|:--:|:--|:--|
 | ✔ | ✘ | **Classic** | Direct Atlas API call adds your egress IP to the project's access list. Default and unchanged behaviour. |
 | ✔ | ✔ | **Notify** | Direct Atlas API call (same as Classic) **plus** a periodic `ReportUsedAsync` to Quilt4Net so the central system tracks that this IP is in active use. |
 | ✘ | ✔ | **Open** | Tharga.MongoDB calls Quilt4Net's proxy `OpenAsync`. Quilt4Net performs the Atlas change server-side. Subsequent heartbeats reuse the same `OpenAsync` call — when the firewall is already open Quilt4Net returns `AlreadyOpen`, which doubles as the usage signal (no separate `ReportUsedAsync` round-trip). The consumer never holds an Atlas credential. |
 | ✘ | ✘ | None | No firewall management. Used for localhost development or when something else manages the access list. |
+
+¹ An **Atlas credential** is either a Programmatic API key pair (`PublicKey`+`PrivateKey`) **or** an OAuth2 **Service Account** (`ClientId`+`ClientSecret`). Either satisfies the Atlas-direct path; the service account is used when both `ClientId` and `ClientSecret` are set. See [Service accounts](#service-accounts) for the expiry caveat. All modes — Classic, Notify and Open — open the firewall both at startup and on connect.
+
+## Service accounts
+
+[Atlas Service Accounts](https://www.mongodb.com/docs/atlas/api/service-accounts/) are the OAuth 2.0 alternative to Programmatic API keys. Set `ClientId` + `ClientSecret` (plus `GroupId`) and Tharga.MongoDB exchanges them for a short-lived (~1 h) bearer token — fetched, cached, and refreshed automatically — to make the Atlas-direct firewall calls. This works in **Classic** and **Notify** mode exactly like an API key. (Open mode is unaffected — it never holds an Atlas credential.)
+
+> **Secrets expire.** Service-account secrets have a limited lifetime and must be **rotated** before they lapse. A failed token exchange surfaces as `AtlasServiceAccountAuthException` — see [Auth failures](#auth-failures-vs-transient-failures).
 
 ## Heartbeat
 
@@ -57,15 +70,23 @@ The service is dormant when no access is in Notify/Open mode — consumers witho
 
 If the Quilt4Net proxy returns 401 or 403 the heartbeat service drops the entry and stops calling — that's `Quilt4NetFirewallAuthorizationException`, raised when the key has been revoked, lacks the required `firewall:*` scope, or targets a group it's not bound to. The exception is **public**, so callers triggering a direct `OpenAsync` (e.g. via `IMongoDbFirewallStateService.AssureFirewallAccessAsync`) can catch and react.
 
+When authenticating with a **service account**, a failed OAuth token exchange raises the public `AtlasServiceAccountAuthException`, carrying the HTTP `StatusCode` and a best-effort `LikelyExpired` flag. Atlas returns **401 for both an invalid and an expired client secret**, so `LikelyExpired` is a heuristic (set when the error body mentions "expire") rather than a guarantee — treat a persistent 401 as a signal to rotate the service-account secret.
+
 Transient HTTP errors (5xx, network blips) keep the entry in the heartbeat loop so the next tick retries.
 
-## Building Atlas keys
+## Building Atlas credentials
 
-For direct (Classic / Notify) mode you need an Atlas organisation API key pair:
+For direct (Classic / Notify) mode with an **API key** you need an Atlas organisation API key pair:
 
 1. Sign in to Atlas, open the *Access Manager* for the **organisation**.
 2. Under the *Applications* tab choose *API Keys* and create a key pair with the *Organization Project Creator* (or stricter) role and project access for the target group.
 3. The *GroupId* is in the Atlas URL: `https://cloud.mongodb.com/v2/<GroupId>`.
+
+Alternatively, use a **Service Account**:
+
+1. In *Access Manager* (organisation or project), create a *Service Account*.
+2. Note its **Client ID** and generate a **Client Secret**; set `ClientId`/`ClientSecret` on `MongoDbApiAccess` instead of the API key pair.
+3. Grant it a role that can edit the project's IP access list, and use the same `GroupId`. **Rotate the secret before it expires** — Atlas service-account secrets are time-limited.
 
 For Quilt4Net (Notify / Open) mode you need a firewall key for the right Atlas project. Open mode requires a `firewall:manage` scope key; Notify mode works with `firewall:usage`. The key is bound to one Atlas project, so the `GroupId` you set on `MongoDbApiAccess` must match the group the key was issued for.
 
@@ -73,4 +94,4 @@ For Quilt4Net (Notify / Open) mode you need a firewall key for the right Atlas p
 
 - [API: `MongoDbApiAccess`](xref:Tharga.MongoDB.Configuration.MongoDbApiAccess)
 - [API: `DatabaseOptions.Quilt4NetHeartbeatInterval`](xref:Tharga.MongoDB.Configuration.DatabaseOptions)
-- The Atlas-side IP access list reference on [mongodb.com](https://www.mongodb.com/docs/atlas/security/ip-access-list/).
+- [Atlas Service Accounts (OAuth 2.0)](https://www.mongodb.com/docs/atlas/api/service-accounts/) and the Atlas-side IP access list reference on [mongodb.com](https://www.mongodb.com/docs/atlas/security/ip-access-list/).


### PR DESCRIPTION
Two related Atlas-firewall changes (one bug fix + one feature).

## 1. Fix: Open mode never opened the firewall at startup
The startup firewall loop in `UseMongoDB` gated on `MongoDbApiAccess.HasMongoDbApiAccess()`, which is **Atlas-only** (true only when `PublicKey`+`PrivateKey`+`GroupId` are set). An **Open-mode** config (`Quilt4NetApiKey`+`GroupId`, no Atlas keys) failed that gate, so the firewall step was silently skipped ("Firewall skipped: no API access info") and never opened — even though the mode dispatcher (`GetFirewallMode` → `MongoDbFirewallStateService`) fully supports Open. The resulting unreachable DB then timed out the `_monitor` read and crashed startup.

Now the loop gates on a new `HasFirewallConfiguration()` (`GetFirewallMode() != None`), so **Classic, Notify and Open** all open at startup. The connect-time path already routed Open mode, so this was the only gap.

> Note: this makes Tharga *attempt* the Open-mode open at startup; for it to actually succeed, Quilt4Net.Server must have an `AtlasIntegration` configured for the project (a proxy key with the firewall scope).

## 2. Feature: Atlas Service Account (OAuth2) authentication
Adds MongoDB Atlas **Service Accounts** (OAuth 2.0 client-credentials) as an alternative to the Programmatic API Key (HTTP digest) auth for the firewall / IP-access-list calls.

- New `ClientId` + `ClientSecret` on `MongoDbApiAccess`. Auth is **inferred** — service account when both are set, otherwise the existing digest API key.
- `AtlasTokenService` exchanges `clientId:clientSecret` (HTTP Basic) for a ~1h bearer token at `POST /api/oauth/token` (`grant_type=client_credentials`), cached per-`ClientId` with a 60s safety margin and per-client locking. `AtlasHttpClient` sends `Authorization: Bearer` for service accounts, digest otherwise.
- `HasMongoDbApiAccess` and `GetFirewallMode` now accept **either** credential type (so Classic/Notify work with a service account; Open mode unchanged).
- A failed token request surfaces a distinct **`AtlasServiceAccountAuthException`** carrying `StatusCode` and a best-effort `LikelyExpired` flag. Atlas returns **401 for both invalid and expired** secrets, so `LikelyExpired` is best-effort (set when the response body mentions "expire"). **No** proactive pre-expiry warning — deliberately out of scope this round.

## Files
- **Config:** `MongoDbApiAccess` (+ `ClientId`/`ClientSecret`), `MongoDbApiAccessExtensions` (`UsesServiceAccount`, `HasFirewallConfiguration`, updated `HasMongoDbApiAccess`/`GetFirewallMode`).
- **Atlas:** `AtlasHttpClient` (async `CreateAsync`, Bearer vs digest), `MongoDbFirewallService` (uses the token service), new `IAtlasTokenService`/`AtlasTokenService`/`AtlasTokenResponse`/`AtlasServiceAccountAuthException`.
- **DI:** `MongoDbRegistrationExtensions` registers the OAuth named `HttpClient` + `IAtlasTokenService`.

## Tests
`FirewallModeTests` (+ `HasFirewallConfiguration` cases), `ServiceAccountAccessTests` (mode/config inference), `AtlasTokenServiceTests` (token fetch + caching + 401→`AtlasServiceAccountAuthException` with/without `LikelyExpired`). Full solution builds clean (net8/9/10); 27/27 in the firewall/service-account/token filter.
