### PR TITLE
feat: resilient startup connectivity — observable fail-fast + degrade (#123)

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,6 +643,59 @@ The heartbeat is driven by a background service registered automatically by `Add
 
 401/403 from the proxy surfaces as `Quilt4NetFirewallAuthorizationException` and the affected entry is dropped from the heartbeat loop — a misconfigured key won't burn cycles retrying. Transient HTTP failures keep the entry so the next tick retries.
 
+## Resilient startup connectivity
+
+When a configured connection is unreachable at startup (e.g. the egress IP is not yet in the Atlas access list), `UseMongoDB` runs a **connectivity pre-check** — one non-throwing probe per configured connection, built on the same check as `IMongoDbService.GetInfoAsync()` / `DatabaseInfo.CanConnect`. Unreachable connections are retried with exponential backoff.
+
+If any connection is still unreachable after the retries, the failure is **logged (`LogCritical`) and the `StartupFailureCallback` is awaited** (so telemetry can be flushed) before the configured reaction takes effect:
+
+- **`FailFast`** (default) — a `MongoStartupConnectivityException` is thrown. The process still exits as before, but the failure is now observable in your telemetry backend instead of an unhandled, untelemetered abort.
+- **`Degrade`** — the host starts anyway. `IMongoDbConnectivityState` reports the connection as unhealthy (and a registered health check reports unhealthy) until connectivity is restored, while the rest of the app keeps running and telemetry keeps flowing.
+
+The pre-check is skipped when `DatabaseOptions.ReadyCallback` is configured (connection strings arrive later), mirroring the firewall-open skip.
+
+```csharp
+app.UseMongoDB(o =>
+{
+    o.StartupConnectivity = StartupConnectivityMode.Degrade;     // default is FailFast
+    o.StartupConnectivityRetryCount = 3;                          // attempts per connection
+    o.StartupConnectivityRetryDelay = TimeSpan.FromSeconds(2);    // initial backoff, doubled per retry
+
+    // Awaited before rethrow (FailFast) or continue (Degrade). Flush your telemetry here so the
+    // failure reaches Application Insights / OpenTelemetry even on a fail-fast exit.
+    o.StartupFailureCallback = async (failure, sp) =>
+    {
+        // Application Insights:
+        sp.GetService<TelemetryClient>()?.Flush();
+        await Task.Delay(TimeSpan.FromSeconds(5));   // give the async channel time to drain
+        // OpenTelemetry:
+        // sp.GetService<TracerProvider>()?.ForceFlush();
+    };
+});
+```
+
+> The library never references App Insights / OTel itself — the `StartupFailureCallback` is where you flush your own pipeline. It also logs `LogCritical` regardless, so the failure reaches any `ILogger` provider you have wired.
+
+### Health / readiness endpoint
+
+`IMongoDbConnectivityState` (registered by `AddMongoDB`) exposes per-connection reachability and an aggregate `IsHealthy`, and re-evaluates live via `CheckAsync()`. Wire it into ASP.NET Core health checks with the opt-in helper:
+
+```csharp
+builder.Services.AddHealthChecks()
+    .AddMongoDb(name: "mongodb", tags: ["ready"]);   // live = true re-probes per call and auto-recovers
+```
+
+Or read it directly:
+
+```csharp
+var state = app.Services.GetRequiredService<IMongoDbConnectivityState>();
+if (!state.IsHealthy)
+    foreach (var c in state.Connections.Where(x => !x.CanConnect))
+        logger.LogWarning("MongoDB connection {Config} is down: {Message}", c.ConfigurationName, c.Message);
+```
+
+The `_monitor` cache load and its "drop and start fresh" recovery are also hardened — an unreachable server there is logged and skipped (the monitor starts with an empty cache and repopulates on first access) rather than aborting the process.
+
 ## Tracking external collections
 
 When an external NuGet package registers its own collection types via DI (e.g. `services.AddTransient<IMyCollection, MyCollection>()`), the database monitor may show them as "NotInCode" because they were not discovered by the auto-registration scan.

--- a/Tharga.MongoDB.Tests/StartupConnectivityTests.cs
+++ b/Tharga.MongoDB.Tests/StartupConnectivityTests.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Tharga.MongoDB.Configuration;
+using Tharga.MongoDB.HealthChecks;
+using Tharga.MongoDB.Internals;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests;
+
+/// <summary>
+/// Covers the resilient-startup-connectivity feature (issue #123): option defaults, the
+/// <see cref="MongoDbConnectivityState"/> probe (aggregation, retry, never-throws), the
+/// failure/exception types, and the <see cref="MongoDbHealthCheck"/>.
+/// </summary>
+public class StartupConnectivityTests
+{
+    // --- UseMongoOptions defaults ---
+
+    [Fact]
+    public void StartupConnectivity_DefaultsToFailFast()
+    {
+        new UseMongoOptions().StartupConnectivity.Should().Be(StartupConnectivityMode.FailFast);
+    }
+
+    [Fact]
+    public void StartupConnectivityRetryCount_DefaultsToThree()
+    {
+        new UseMongoOptions().StartupConnectivityRetryCount.Should().Be(3);
+    }
+
+    [Fact]
+    public void StartupConnectivityRetryDelay_DefaultsToTwoSeconds()
+    {
+        new UseMongoOptions().StartupConnectivityRetryDelay.Should().Be(TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public void StartupFailureCallback_DefaultsToNull()
+    {
+        new UseMongoOptions().StartupFailureCallback.Should().BeNull();
+    }
+
+    // --- MongoDbConnectivityState ---
+
+    [Fact]
+    public async Task CheckAsync_AllReachable_IsHealthy()
+    {
+        var state = CreateState(new()
+        {
+            ["Default"] = Service(Info(true, "ok-default")),
+            ["Integration"] = Service(Info(true, "ok-integration")),
+        });
+
+        var results = await state.CheckAsync();
+
+        state.IsHealthy.Should().BeTrue();
+        results.Should().HaveCount(2);
+        results.Should().OnlyContain(r => r.CanConnect);
+        state.Connections.Single(c => c.ConfigurationName == "Default").Message.Should().Be("ok-default");
+    }
+
+    [Fact]
+    public async Task CheckAsync_OneUnreachable_IsNotHealthy_AndCarriesMessage()
+    {
+        var state = CreateState(new()
+        {
+            ["Default"] = Service(Info(true, "ok")),
+            ["Integration"] = Service(Info(false, "server selection timed out")),
+        });
+
+        await state.CheckAsync();
+
+        state.IsHealthy.Should().BeFalse();
+        var failing = state.Connections.Single(c => !c.CanConnect);
+        failing.ConfigurationName.Should().Be("Integration");
+        failing.Message.Should().Be("server selection timed out");
+    }
+
+    [Fact]
+    public async Task CheckWithRetry_TransientFailureThenSuccess_EndsHealthy()
+    {
+        // First probe fails, second succeeds — with 3 attempts and a tiny delay it should recover.
+        var state = CreateState(new()
+        {
+            ["Default"] = Service(Info(false, "blip"), Info(true, "recovered")),
+        });
+
+        var results = await state.CheckWithRetryAsync(attempts: 3, initialDelay: TimeSpan.FromMilliseconds(1), assureFirewall: false);
+
+        state.IsHealthy.Should().BeTrue();
+        results.Single().Message.Should().Be("recovered");
+    }
+
+    [Fact]
+    public async Task CheckWithRetry_HealthyConnectionIsNotReprobed()
+    {
+        var service = new Mock<IMongoDbService>();
+        service.Setup(s => s.GetInfoAsync(It.IsAny<bool>())).ReturnsAsync(Info(true, "ok"));
+        var state = CreateState(new() { ["Default"] = service.Object });
+
+        await state.CheckWithRetryAsync(attempts: 3, initialDelay: TimeSpan.FromMilliseconds(1), assureFirewall: false);
+
+        // A reachable connection must be probed exactly once even though 3 attempts were allowed.
+        service.Verify(s => s.GetInfoAsync(It.IsAny<bool>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CheckAsync_ProbeThrows_ReportedAsUnreachable_NeverThrows()
+    {
+        var service = new Mock<IMongoDbService>();
+        service.Setup(s => s.GetInfoAsync(It.IsAny<bool>())).ThrowsAsync(new Exception("resolution blew up"));
+        var state = CreateState(new() { ["Default"] = service.Object });
+
+        var results = await state.CheckAsync();
+
+        results.Single().CanConnect.Should().BeFalse();
+        results.Single().Message.Should().Be("resolution blew up");
+        state.IsHealthy.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsHealthy_BeforeAnyCheck_IsTrue()
+    {
+        // Nothing has been observed as unreachable yet.
+        var state = CreateState(new() { ["Default"] = Service(Info(true, "ok")) });
+
+        state.IsHealthy.Should().BeTrue();
+        state.Connections.Should().BeEmpty();
+    }
+
+    // --- MongoStartupFailure / MongoStartupConnectivityException ---
+
+    [Fact]
+    public void MongoStartupFailure_Summary_ListsConfigsAndMessages()
+    {
+        var failure = new MongoStartupFailure(new[]
+        {
+            Conn("Default", false, "timeout-a"),
+            Conn("Integration", false, "timeout-b"),
+        });
+
+        failure.UnreachableConnections.Should().HaveCount(2);
+        failure.Summary.Should().Contain("Default: timeout-a");
+        failure.Summary.Should().Contain("Integration: timeout-b");
+    }
+
+    [Fact]
+    public void MongoStartupConnectivityException_CarriesFailure_AndDescribesIt()
+    {
+        var failure = new MongoStartupFailure(new[] { Conn("Default", false, "timeout") });
+
+        var ex = new MongoStartupConnectivityException(failure);
+
+        ex.Failure.Should().BeSameAs(failure);
+        ex.Message.Should().Contain("Default: timeout");
+        ex.Message.Should().Contain("1 configuration");
+    }
+
+    // --- MongoDbHealthCheck ---
+
+    [Fact]
+    public async Task HealthCheck_AllReachable_ReportsHealthy()
+    {
+        var connections = new[] { Conn("Default", true, "reachable") };
+        var check = new MongoDbHealthCheck(StubState(connections), live: false);
+
+        var result = await check.CheckHealthAsync(Context());
+
+        result.Status.Should().Be(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task HealthCheck_OneUnreachable_ReportsFailureStatus()
+    {
+        var connections = new[] { Conn("Default", true, "reachable"), Conn("Integration", false, "down") };
+        var check = new MongoDbHealthCheck(StubState(connections), live: false);
+
+        var result = await check.CheckHealthAsync(Context());
+
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+        result.Description.Should().Contain("Integration: down");
+        result.Data.Should().ContainKey("Integration");
+    }
+
+    [Fact]
+    public async Task HealthCheck_Live_ReprobesViaCheckAsync()
+    {
+        var connections = new[] { Conn("Default", true, "reachable") };
+        var state = new Mock<IMongoDbConnectivityState>();
+        state.Setup(s => s.CheckAsync(It.IsAny<CancellationToken>())).ReturnsAsync(connections);
+        var check = new MongoDbHealthCheck(state.Object, live: true);
+
+        await check.CheckHealthAsync(Context());
+
+        state.Verify(s => s.CheckAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // --- helpers ---
+
+    private static DatabaseInfo Info(bool canConnect, string message)
+        => new() { CanConnect = canConnect, Message = message };
+
+    private static ConnectionConnectivity Conn(string config, bool canConnect, string message)
+        => new() { ConfigurationName = config, CanConnect = canConnect, Message = message, CheckedAt = DateTime.UtcNow };
+
+    private static IMongoDbService Service(params DatabaseInfo[] sequence)
+    {
+        var mock = new Mock<IMongoDbService>();
+        var setup = mock.SetupSequence(s => s.GetInfoAsync(It.IsAny<bool>()));
+        foreach (var info in sequence)
+            setup = setup.ReturnsAsync(info);
+        return mock.Object;
+    }
+
+    private static MongoDbConnectivityState CreateState(Dictionary<string, IMongoDbService> servicesByConfig)
+    {
+        var factory = new Mock<IMongoDbServiceFactory>();
+        factory.Setup(f => f.GetMongoDbService(It.IsAny<Func<DatabaseContext>>()))
+            .Returns((Func<DatabaseContext> loader) => servicesByConfig[loader().ConfigurationName.Value]);
+
+        var config = new Mock<IRepositoryConfiguration>();
+        config.Setup(c => c.GetDatabaseConfigurationNames()).Returns(servicesByConfig.Keys.ToArray());
+
+        return new MongoDbConnectivityState(factory.Object, config.Object, NullLogger<MongoDbConnectivityState>.Instance);
+    }
+
+    private static IMongoDbConnectivityState StubState(IReadOnlyList<ConnectionConnectivity> connections)
+    {
+        var state = new Mock<IMongoDbConnectivityState>();
+        state.SetupGet(s => s.Connections).Returns(connections);
+        state.Setup(s => s.CheckAsync(It.IsAny<CancellationToken>())).ReturnsAsync(connections);
+        return state.Object;
+    }
+
+    private static HealthCheckContext Context()
+        => new() { Registration = new HealthCheckRegistration("mongodb", Mock.Of<IHealthCheck>(), HealthStatus.Unhealthy, tags: null) };
+}

--- a/Tharga.MongoDB/Configuration/StartupConnectivityMode.cs
+++ b/Tharga.MongoDB/Configuration/StartupConnectivityMode.cs
@@ -1,0 +1,26 @@
+namespace Tharga.MongoDB.Configuration;
+
+/// <summary>
+/// Controls how <see cref="MongoDbRegistrationExtensions.UseMongoDB"/> reacts when a configured
+/// connection is unreachable during the startup connectivity pre-check.
+/// </summary>
+public enum StartupConnectivityMode
+{
+    /// <summary>
+    /// Default. If any configured connection is unreachable at startup, the failure is logged
+    /// (<c>LogCritical</c>), the <see cref="UseMongoOptions.StartupFailureCallback"/> is awaited
+    /// (so telemetry can be flushed), and a <see cref="MongoStartupConnectivityException"/> is
+    /// thrown — the process still exits, but the failure is observable. Back-compatible with the
+    /// previous fail-fast behaviour, minus the unhandled, untelemetered abort.
+    /// </summary>
+    FailFast,
+
+    /// <summary>
+    /// Start the host even when a configured connection is unreachable. The failure is logged and
+    /// the <see cref="UseMongoOptions.StartupFailureCallback"/> is awaited, but startup continues.
+    /// <see cref="IMongoDbConnectivityState"/> reports the connection as unhealthy until
+    /// connectivity is restored, so a readiness/health endpoint can surface the degradation while
+    /// the rest of the app keeps running and telemetry keeps flowing.
+    /// </summary>
+    Degrade
+}

--- a/Tharga.MongoDB/Configuration/UseMongoOptions.cs
+++ b/Tharga.MongoDB/Configuration/UseMongoOptions.cs
@@ -1,9 +1,48 @@
 ﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
 
 namespace Tharga.MongoDB.Configuration;
 
 public record UseMongoOptions
 {
+    /// <summary>
+    /// Controls behaviour when a configured connection is unreachable during the startup
+    /// connectivity pre-check. Default <see cref="StartupConnectivityMode.FailFast"/> — the
+    /// process still exits on an unreachable database (back-compatible), but the failure is now
+    /// logged (<c>LogCritical</c>), flushed via <see cref="StartupFailureCallback"/>, and thrown
+    /// as a <see cref="MongoStartupConnectivityException"/> rather than an unhandled, untelemetered
+    /// abort. Set to <see cref="StartupConnectivityMode.Degrade"/> to start degraded instead and
+    /// surface the failure through <see cref="IMongoDbConnectivityState"/> / a health endpoint.
+    /// <para>The pre-check is skipped when <c>DatabaseOptions.ReadyCallback</c> is configured
+    /// (connection strings arrive later), mirroring the firewall-open skip.</para>
+    /// </summary>
+    public StartupConnectivityMode StartupConnectivity { get; set; } = StartupConnectivityMode.FailFast;
+
+    /// <summary>
+    /// Total number of attempts per connection during the startup connectivity pre-check.
+    /// Unreachable connections are retried with exponential backoff (see
+    /// <see cref="StartupConnectivityRetryDelay"/>); reachable ones are not re-probed. Default 3.
+    /// Set to 1 to disable retrying.
+    /// </summary>
+    public int StartupConnectivityRetryCount { get; set; } = 3;
+
+    /// <summary>
+    /// Initial delay before the first retry of the startup connectivity pre-check, doubled on each
+    /// subsequent retry (capped at one minute). Default 2 seconds.
+    /// </summary>
+    public TimeSpan StartupConnectivityRetryDelay { get; set; } = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// Invoked (and awaited) when the startup connectivity pre-check finds one or more unreachable
+    /// connections — before a <see cref="StartupConnectivityMode.FailFast"/> rethrow or a
+    /// <see cref="StartupConnectivityMode.Degrade"/> continuation. The library logs the failure via
+    /// <c>ILogger</c> itself; use this hook to flush your telemetry pipeline so the failure is not
+    /// lost on exit, e.g. <c>telemetryClient.Flush(); await Task.Delay(TimeSpan.FromSeconds(5));</c>
+    /// for Application Insights, or <c>tracerProvider.ForceFlush()</c> for OpenTelemetry. Optional.
+    /// </summary>
+    public Func<MongoStartupFailure, IServiceProvider, Task> StartupFailureCallback { get; set; }
+
     /// <summary>
     /// Wait for the UseMongoDB-method to complete before continuing.
     /// By default, this is false.

--- a/Tharga.MongoDB/ConnectionConnectivity.cs
+++ b/Tharga.MongoDB/ConnectionConnectivity.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace Tharga.MongoDB;
+
+/// <summary>
+/// The connectivity result for a single configured connection, as produced by
+/// <see cref="IMongoDbConnectivityState"/>. Built on the same non-throwing probe as
+/// <see cref="IMongoDbService.GetInfoAsync"/> / <see cref="DatabaseInfo.CanConnect"/>.
+/// </summary>
+public record ConnectionConnectivity
+{
+    internal ConnectionConnectivity()
+    {
+    }
+
+    /// <summary>
+    /// The configuration name this result belongs to.
+    /// </summary>
+    public string ConfigurationName { get; init; }
+
+    /// <summary>
+    /// True when the connection could be reached (after assuring the firewall, when requested).
+    /// </summary>
+    public bool CanConnect { get; init; }
+
+    /// <summary>
+    /// A human-readable database description when reachable, or the failure message when not.
+    /// </summary>
+    public string Message { get; init; }
+
+    /// <summary>
+    /// The firewall-assurance message produced while probing, when available.
+    /// </summary>
+    public string Firewall { get; init; }
+
+    /// <summary>
+    /// When (UTC) this result was produced.
+    /// </summary>
+    public DateTime CheckedAt { get; init; }
+}

--- a/Tharga.MongoDB/DatabaseMonitor.cs
+++ b/Tharga.MongoDB/DatabaseMonitor.cs
@@ -78,7 +78,18 @@ internal class DatabaseMonitor : IDatabaseMonitor
         }
         else
         {
-            _cache.LoadAsync().GetAwaiter().GetResult();
+            // A connectivity failure while loading the persisted cache must not abort process
+            // startup — the monitor starts degraded (empty cache, repopulated live on first
+            // access). Connectivity-fail-fast, when requested, is enforced earlier by the
+            // startup pre-check in UseMongoDB; reaching here means we are starting regardless.
+            try
+            {
+                _cache.LoadAsync().GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to load DatabaseMonitor cache at startup. Starting monitor with an empty cache; it will repopulate as collections are accessed.");
+            }
         }
 
         try

--- a/Tharga.MongoDB/HealthChecks/MongoDbHealthCheck.cs
+++ b/Tharga.MongoDB/HealthChecks/MongoDbHealthCheck.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tharga.MongoDB.HealthChecks;
+
+/// <summary>
+/// An <see cref="IHealthCheck"/> that reports the reachability of every configured MongoDB
+/// connection, built on <see cref="IMongoDbConnectivityState"/>. Register via
+/// <c>services.AddHealthChecks().AddMongoDb()</c>. Reports unhealthy while any connection is
+/// unreachable and recovers automatically once connectivity is restored.
+/// </summary>
+public sealed class MongoDbHealthCheck : IHealthCheck
+{
+    private readonly IMongoDbConnectivityState _state;
+    private readonly bool _live;
+
+    /// <param name="state">The connectivity state surface.</param>
+    /// <param name="live">
+    /// When true (default for the helper), the check re-probes connectivity on each call so it
+    /// recovers as soon as the database becomes reachable. When false, it reports the last known
+    /// state captured by the startup pre-check (cheaper, but only refreshed by other probes).
+    /// </param>
+    public MongoDbHealthCheck(IMongoDbConnectivityState state, bool live = true)
+    {
+        _state = state;
+        _live = live;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        var connections = _live
+            ? await _state.CheckAsync(cancellationToken)
+            : _state.Connections;
+
+        var data = connections.ToDictionary(
+            c => c.ConfigurationName,
+            c => (object)(c.CanConnect ? "reachable" : c.Message ?? "unreachable"));
+
+        var unreachable = connections.Where(c => !c.CanConnect).ToArray();
+        if (unreachable.Length == 0)
+            return HealthCheckResult.Healthy("All configured MongoDB connections are reachable.", data);
+
+        var description = $"{unreachable.Length} MongoDB connection(s) unreachable: " +
+            string.Join("; ", unreachable.Select(c => $"{c.ConfigurationName}: {c.Message}"));
+
+        return new HealthCheckResult(context.Registration.FailureStatus, description, exception: null, data: data);
+    }
+}

--- a/Tharga.MongoDB/HealthChecks/MongoDbHealthCheckExtensions.cs
+++ b/Tharga.MongoDB/HealthChecks/MongoDbHealthCheckExtensions.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System.Collections.Generic;
+using Tharga.MongoDB;
+using Tharga.MongoDB.HealthChecks;
+
+// ReSharper disable once CheckNamespace -- placed in the DI namespace so AddMongoDb() surfaces
+// next to AddHealthChecks()/AddCheck() without an extra using.
+namespace Microsoft.Extensions.DependencyInjection;
+
+public static class MongoDbHealthCheckExtensions
+{
+    /// <summary>
+    /// Adds a health check that reports the reachability of every configured MongoDB connection,
+    /// built on <see cref="IMongoDbConnectivityState"/>. Opt-in:
+    /// <c>services.AddHealthChecks().AddMongoDb()</c>. Requires that <c>AddMongoDB</c> has been
+    /// called so the connectivity state is registered.
+    /// </summary>
+    /// <param name="builder">The health-checks builder.</param>
+    /// <param name="name">The health-check registration name. Default <c>"mongodb"</c>.</param>
+    /// <param name="live">
+    /// When true (default), the check re-probes connectivity on each call so a degraded app
+    /// recovers as soon as the database is reachable again. When false, reports the last known
+    /// state from the startup pre-check without re-probing.
+    /// </param>
+    /// <param name="failureStatus">
+    /// The status reported when a connection is unreachable. Default (null) is
+    /// <see cref="HealthStatus.Unhealthy"/>.
+    /// </param>
+    /// <param name="tags">Optional tags for filtering (e.g. <c>"ready"</c> for readiness probes).</param>
+    public static IHealthChecksBuilder AddMongoDb(
+        this IHealthChecksBuilder builder,
+        string name = "mongodb",
+        bool live = true,
+        HealthStatus? failureStatus = null,
+        IEnumerable<string> tags = null)
+    {
+        return builder.Add(new HealthCheckRegistration(
+            name,
+            sp => new MongoDbHealthCheck(sp.GetRequiredService<IMongoDbConnectivityState>(), live),
+            failureStatus,
+            tags));
+    }
+}

--- a/Tharga.MongoDB/IMongoDbConnectivityState.cs
+++ b/Tharga.MongoDB/IMongoDbConnectivityState.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tharga.MongoDB;
+
+/// <summary>
+/// Tracks per-connection reachability for all configured connections. Populated by the startup
+/// connectivity pre-check in <see cref="MongoDbRegistrationExtensions.UseMongoDB"/> and
+/// re-evaluable live via <see cref="CheckAsync"/>. Registered as a singleton by
+/// <c>AddMongoDB</c>.
+/// <para>
+/// Built on the existing non-throwing <see cref="IMongoDbService.GetInfoAsync"/> /
+/// <see cref="DatabaseInfo.CanConnect"/> probe. Use it to drive a readiness/health endpoint; it
+/// recovers automatically once connectivity is restored (e.g. once an IP is allow-listed).
+/// </para>
+/// </summary>
+public interface IMongoDbConnectivityState
+{
+    /// <summary>
+    /// True when every configured connection was reachable as of the last check. When no check
+    /// has run yet, this is true (nothing has been observed as unreachable).
+    /// </summary>
+    bool IsHealthy { get; }
+
+    /// <summary>
+    /// The most recent per-connection results. Empty until the first check runs.
+    /// </summary>
+    IReadOnlyList<ConnectionConnectivity> Connections { get; }
+
+    /// <summary>
+    /// Re-evaluates connectivity for every configured connection and updates
+    /// <see cref="Connections"/> / <see cref="IsHealthy"/>. Never throws — an unreachable
+    /// connection is reported as <see cref="ConnectionConnectivity.CanConnect"/> false.
+    /// </summary>
+    Task<IReadOnlyList<ConnectionConnectivity>> CheckAsync(CancellationToken cancellationToken = default);
+}

--- a/Tharga.MongoDB/Internals/MongoDbCollectionCache.cs
+++ b/Tharga.MongoDB/Internals/MongoDbCollectionCache.cs
@@ -59,7 +59,7 @@ internal class MongoDbCollectionCache : ICollectionCache
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Failed to read _monitor collection for config '{ConfigName}'. Dropping and starting fresh.", configName);
-                await col.Database.DropCollectionAsync("_monitor");
+                await TryDropMonitorAsync(col, configName);
                 continue;
             }
 
@@ -81,10 +81,32 @@ internal class MongoDbCollectionCache : ICollectionCache
             if (hadDeserializationError)
             {
                 _logger.LogWarning("One or more _monitor documents failed to deserialize for config '{ConfigName}'. Dropping collection and starting fresh.", configName);
-                await col.Database.DropCollectionAsync("_monitor");
-                foreach (var key in loadedKeys)
-                    _dict.TryRemove(key, out _);
+                if (await TryDropMonitorAsync(col, configName))
+                {
+                    foreach (var key in loadedKeys)
+                        _dict.TryRemove(key, out _);
+                }
             }
+        }
+    }
+
+    /// <summary>
+    /// Drops the _monitor collection as part of the "start fresh" recovery. The drop is itself a
+    /// write against a database that may be unreachable (the very reason we are recovering), so a
+    /// failure here must never propagate — it would abort process startup. Returns true when the
+    /// drop succeeded.
+    /// </summary>
+    private async Task<bool> TryDropMonitorAsync(IMongoCollection<BsonDocument> col, string configName)
+    {
+        try
+        {
+            await col.Database.DropCollectionAsync("_monitor");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to drop _monitor collection for config '{ConfigName}' during recovery. Continuing without the persisted cache for this configuration.", configName);
+            return false;
         }
     }
 

--- a/Tharga.MongoDB/Internals/MongoDbConnectivityState.cs
+++ b/Tharga.MongoDB/Internals/MongoDbConnectivityState.cs
@@ -1,0 +1,108 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Tharga.MongoDB.Configuration;
+
+namespace Tharga.MongoDB.Internals;
+
+internal class MongoDbConnectivityState : IMongoDbConnectivityState
+{
+    private static readonly TimeSpan MaxBackoff = TimeSpan.FromMinutes(1);
+
+    private readonly IMongoDbServiceFactory _factory;
+    private readonly IRepositoryConfiguration _repositoryConfiguration;
+    private readonly ILogger<MongoDbConnectivityState> _logger;
+    private volatile IReadOnlyList<ConnectionConnectivity> _connections = Array.Empty<ConnectionConnectivity>();
+
+    public MongoDbConnectivityState(IMongoDbServiceFactory factory, IRepositoryConfiguration repositoryConfiguration, ILogger<MongoDbConnectivityState> logger)
+    {
+        _factory = factory;
+        _repositoryConfiguration = repositoryConfiguration;
+        _logger = logger;
+    }
+
+    public bool IsHealthy => _connections.All(c => c.CanConnect);
+
+    public IReadOnlyList<ConnectionConnectivity> Connections => _connections;
+
+    public Task<IReadOnlyList<ConnectionConnectivity>> CheckAsync(CancellationToken cancellationToken = default)
+        => CheckWithRetryAsync(attempts: 1, initialDelay: TimeSpan.Zero, assureFirewall: true, cancellationToken);
+
+    /// <summary>
+    /// Probes every configured connection, retrying the still-unreachable ones up to
+    /// <paramref name="attempts"/> times with exponential backoff starting at
+    /// <paramref name="initialDelay"/>. Healthy connections are not re-probed. Used by the
+    /// startup pre-check; never throws.
+    /// </summary>
+    internal async Task<IReadOnlyList<ConnectionConnectivity>> CheckWithRetryAsync(int attempts, TimeSpan initialDelay, bool assureFirewall, CancellationToken cancellationToken = default)
+    {
+        if (attempts < 1) attempts = 1;
+
+        var configNames = _repositoryConfiguration.GetDatabaseConfigurationNames().ToArray();
+        var results = new Dictionary<string, ConnectionConnectivity>();
+        var delay = initialDelay;
+
+        for (var attempt = 1; attempt <= attempts; attempt++)
+        {
+            if (attempt > 1 && delay > TimeSpan.Zero)
+            {
+                try
+                {
+                    await Task.Delay(delay, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                delay = TimeSpan.FromTicks(Math.Min(delay.Ticks * 2, MaxBackoff.Ticks));
+            }
+
+            foreach (var configName in configNames)
+            {
+                if (results.TryGetValue(configName, out var existing) && existing.CanConnect) continue;
+                results[configName] = await ProbeAsync(configName, assureFirewall);
+            }
+
+            if (configNames.All(c => results.TryGetValue(c, out var r) && r.CanConnect)) break;
+            if (cancellationToken.IsCancellationRequested) break;
+        }
+
+        var ordered = configNames.Select(c => results[c]).ToArray();
+        _connections = ordered;
+        return ordered;
+    }
+
+    private async Task<ConnectionConnectivity> ProbeAsync(string configName, bool assureFirewall)
+    {
+        try
+        {
+            var svc = _factory.GetMongoDbService(() => new DatabaseContext { ConfigurationName = configName });
+            var info = await svc.GetInfoAsync(assureFirewall);
+            return new ConnectionConnectivity
+            {
+                ConfigurationName = configName,
+                CanConnect = info.CanConnect,
+                Message = info.Message,
+                Firewall = info.Firewall,
+                CheckedAt = DateTime.UtcNow,
+            };
+        }
+        catch (Exception ex)
+        {
+            // GetInfoAsync is non-throwing, but resolving the service / assuring the firewall can
+            // still throw. A probe must never propagate — that is the whole point of this type.
+            _logger.LogWarning(ex, "Connectivity probe for configuration '{ConfigName}' threw.", configName);
+            return new ConnectionConnectivity
+            {
+                ConfigurationName = configName,
+                CanConnect = false,
+                Message = ex.Message,
+                CheckedAt = DateTime.UtcNow,
+            };
+        }
+    }
+}

--- a/Tharga.MongoDB/MongoDbRegistrationExtensions.cs
+++ b/Tharga.MongoDB/MongoDbRegistrationExtensions.cs
@@ -208,6 +208,12 @@ public static class MongoDbRegistrationExtensions
         services.AddTransient<ICollectionTypeService, CollectionTypeService>();
         services.AddSingleton<IMongoDbInstance>(mongoDbInstance);
 
+        // Per-connection reachability surface, independent of the monitor. Populated by the
+        // startup connectivity pre-check in UseMongoDB and re-checkable live (e.g. from a
+        // readiness/health endpoint). Built on the non-throwing IMongoDbService.GetInfoAsync probe.
+        services.AddSingleton<MongoDbConnectivityState>();
+        services.AddSingleton<IMongoDbConnectivityState>(sp => sp.GetRequiredService<MongoDbConnectivityState>());
+
         if (o.Monitor?.Enabled ?? false)
         {
             if (o.Monitor.StorageMode == MonitorStorageMode.Database)
@@ -380,6 +386,48 @@ public static class MongoDbRegistrationExtensions
             });
 
             if (mustWait) Task.WaitAll(task);
+        }
+
+        //NOTE: Connectivity pre-check. Verifies each configured connection is reachable (built on
+        //      the non-throwing IMongoDbService.GetInfoAsync probe) BEFORE the monitor starts, so
+        //      an unreachable database produces an observable, logged, telemetered outcome instead
+        //      of an unhandled abort. On failure: log Critical -> await StartupFailureCallback
+        //      (flush) -> fail-fast (throw) or degrade (continue). Skipped when connection strings
+        //      arrive later (ReadyCallback), mirroring the firewall-open skip above.
+        if (!lateConnectionStrins)
+        {
+            var connectivityState = app.Services.GetService<MongoDbConnectivityState>();
+            if (connectivityState != null)
+            {
+                var results = connectivityState
+                    .CheckWithRetryAsync(o.StartupConnectivityRetryCount, o.StartupConnectivityRetryDelay, assureFirewall: true)
+                    .GetAwaiter().GetResult();
+
+                var unreachable = results.Where(r => !r.CanConnect).ToArray();
+                if (unreachable.Length > 0)
+                {
+                    var failure = new MongoStartupFailure(unreachable);
+                    o.Logger?.LogCritical("MongoDB startup connectivity check failed for {count} configuration(s): {summary}", unreachable.Length, failure.Summary);
+                    _actionEvent?.Invoke(new ActionEventArgs(new ActionEventArgs.ActionData { Message = $"MongoDB startup connectivity check failed: {failure.Summary}", Level = LogLevel.Critical }, new ActionEventArgs.ContextData()));
+
+                    if (o.StartupFailureCallback != null)
+                    {
+                        try
+                        {
+                            o.StartupFailureCallback(failure, app.Services).GetAwaiter().GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            o.Logger?.LogError(ex, "StartupFailureCallback threw.");
+                        }
+                    }
+
+                    if (o.StartupConnectivity == StartupConnectivityMode.FailFast)
+                        throw new MongoStartupConnectivityException(failure);
+
+                    o.Logger?.LogWarning("Starting in degraded mode — {count} configuration(s) unreachable. IMongoDbConnectivityState / health checks will report unhealthy until connectivity is restored.", unreachable.Length);
+                }
+            }
         }
 
         if (databaseOptions.Value.Monitor?.Enabled ?? false)

--- a/Tharga.MongoDB/MongoStartupConnectivityException.cs
+++ b/Tharga.MongoDB/MongoStartupConnectivityException.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Tharga.MongoDB;
+
+/// <summary>
+/// Thrown by <see cref="MongoDbRegistrationExtensions.UseMongoDB"/> when one or more configured
+/// connections are unreachable at startup and <see cref="Configuration.StartupConnectivityMode.FailFast"/>
+/// is in effect. Unlike the previous unhandled <c>TimeoutException</c>, this is thrown only after
+/// the failure has been logged (<c>LogCritical</c>) and
+/// <see cref="Configuration.UseMongoOptions.StartupFailureCallback"/> has been awaited — so it is
+/// observable in telemetry before the process exits.
+/// </summary>
+public sealed class MongoStartupConnectivityException : Exception
+{
+    internal MongoStartupConnectivityException(MongoStartupFailure failure)
+        : base($"MongoDB startup connectivity check failed for {failure.UnreachableConnections.Count} configuration(s): {failure.Summary}")
+    {
+        Failure = failure;
+    }
+
+    /// <summary>
+    /// Details of the connections that could not be reached.
+    /// </summary>
+    public MongoStartupFailure Failure { get; }
+}

--- a/Tharga.MongoDB/MongoStartupFailure.cs
+++ b/Tharga.MongoDB/MongoStartupFailure.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Tharga.MongoDB;
+
+/// <summary>
+/// Describes the set of configured connections that were unreachable during the startup
+/// connectivity pre-check. Passed to <see cref="Configuration.UseMongoOptions.StartupFailureCallback"/>
+/// and carried by <see cref="MongoStartupConnectivityException"/>.
+/// </summary>
+public record MongoStartupFailure
+{
+    internal MongoStartupFailure(IEnumerable<ConnectionConnectivity> unreachableConnections)
+    {
+        UnreachableConnections = (unreachableConnections ?? Enumerable.Empty<ConnectionConnectivity>()).ToArray();
+    }
+
+    /// <summary>
+    /// The connections that could not be reached, including the failure message for each.
+    /// </summary>
+    public IReadOnlyList<ConnectionConnectivity> UnreachableConnections { get; }
+
+    /// <summary>
+    /// A single-line summary listing the unreachable configuration names and their messages.
+    /// </summary>
+    public string Summary => string.Join("; ", UnreachableConnections.Select(c => $"{c.ConfigurationName}: {c.Message}"));
+}

--- a/Tharga.MongoDB/Tharga.MongoDB.csproj
+++ b/Tharga.MongoDB/Tharga.MongoDB.csproj
@@ -35,6 +35,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <!-- Enables the opt-in AddMongoDb() health-check helper (needs IHealthChecksBuilder). Small, framework-shared; its transitive deps (Logging.Abstractions, Options, Hosting.Abstractions) are already present. -->
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Features" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />


### PR DESCRIPTION
Closes #123.

## Problem
A configured connection unreachable at startup threw an **unhandled** `TimeoutException` from the `_monitor` "drop and start fresh" recovery write — the read timeout was caught, but the recovery `DropCollectionAsync` was not, so it aborted the process (`Aborted (core dumped)`) before any telemetry flushed. The failure was therefore invisible to Application Insights / OpenTelemetry.

## Crash fix
- `MongoDbCollectionCache.LoadAsync` routes both recovery drops through `TryDropMonitorAsync` (try/catch, log + continue); the dedup cleanup runs only on a successful drop.
- `DatabaseMonitor.Start` wraps the synchronous cache load — an unreachable server starts the monitor degraded (empty cache, repopulated on first access).

## Resilient startup
- Connectivity pre-check in `UseMongoDB` (after firewall, before monitor; skipped under `ReadyCallback`), built on `IMongoDbService.GetInfoAsync` / `DatabaseInfo.CanConnect`, retrying still-unreachable connections with exponential backoff.
- On failure: `LogCritical` → `await StartupFailureCallback` (flush hook) → throw `MongoStartupConnectivityException` (**FailFast**, default — observable) or continue (**Degrade**).
- New `IMongoDbConnectivityState` singleton (per-connection reachability, re-checkable live via `CheckAsync()`) + opt-in `AddHealthChecks().AddMongoDb()` helper that auto-recovers once connectivity returns.
- New `UseMongoOptions`: `StartupConnectivity`, `StartupConnectivityRetryCount`, `StartupConnectivityRetryDelay`, `StartupFailureCallback`.

## Compatibility
- Default stays fail-fast; the process still exits on an unreachable DB, but now logged + flushed + thrown as a typed exception rather than an unhandled abort.
- The pre-check now runs even when the monitor is disabled (previously nothing touched the DB at startup in that case) — one cheap probe per connection.
- Adds `Microsoft.Extensions.Diagnostics.HealthChecks` for the opt-in health-check helper.

## Tests
15 new tests in `StartupConnectivityTests` (option defaults, state aggregation / retry / never-throws, failure + exception types, health check). Full suite: 552 passed, 8 skipped — the 6 failures are environment/flaky only (5 `TransactionsTests` need a replica set; one `RevalidationQueueTests` timing flake that passes in isolation) and unrelated to this change.
