### PR TITLE
Per-pool queue & connection metrics, in-flight call inspection, opt-in call forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,10 +733,15 @@ Set `StorageMode` to control where the monitor keeps its state.
     "Enabled": true,
     "StorageMode": "Database",
     "LastCallsToKeep": 1000,
-    "SlowCallsToKeep": 200
+    "SlowCallsToKeep": 200,
+    "ForwardCompletedCalls": false,
+    "QueueMetricInterval": "00:00:01",
+    "ClusterConnectionLimit": 3000
   }
 }
 ```
+
+`ForwardCompletedCalls` (default `false`) and `QueueMetricInterval` apply to agents forwarding to a central monitor; `ClusterConnectionLimit` is read by the central server to show open connections against a cluster's limit. See [Centralised monitoring](#centralised-monitoring) and the [monitoring docs](https://github.com/Tharga/MongoDB/blob/master/docs/articles/monitoring.md).
 
 #### Configuration by code
 ```csharp
@@ -747,7 +752,10 @@ services.AddMongoDB(o =>
         Enabled = true,
         StorageMode = MonitorStorageMode.Database,
         LastCallsToKeep = 1000,
-        SlowCallsToKeep = 200
+        SlowCallsToKeep = 200,
+        ForwardCompletedCalls = false,        // opt-in: forward every completed call to the central monitor
+        QueueMetricInterval = TimeSpan.FromSeconds(1),
+        ClusterConnectionLimit = 3000         // e.g. an Atlas tier's max connections (server-side)
     };
 });
 ```
@@ -948,7 +956,10 @@ app.MapGet("/api/monitor/pool", (IDatabaseMonitor m) => m.GetConnectionPoolState
 | `GetCallSummary()` | `CallSummaryDto[]` | Grouped by collection+function: count, avg/max/min elapsed |
 | `GetErrorSummary()` | `ErrorSummaryDto[]` | Errors grouped by type and collection |
 | `GetSlowCallsWithIndexInfoAsync()` | `SlowCallWithIndexInfoDto[]` | Slow calls with index coverage analysis |
-| `GetConnectionPoolState()` | `ConnectionPoolStateDto` | Queue depth, executing count, wait time, recent metrics |
+| `GetConnectionPoolState()` | `ConnectionPoolStateDto` | Aggregate queue depth, executing count, wait time, recent metrics |
+| `GetPerPoolQueueState()` | `IReadOnlyDictionary<string, ConnectionPoolStateDto>` | Queue/exec per connection pool (per cluster), across this process and all agents — one entry per source+pool, labelled by configuration |
+| `GetInFlightCalls()` | `InFlightCallInfo[]` | What the limiter is holding right now (queued vs executing) — for diagnosing a flood |
+| `GetClusterConnectionSummary()` | `ClusterConnectionSummary[]` | Open connections + capacity per cluster across all sources, vs the configured `ClusterConnectionLimit` |
 
 ---
 
@@ -992,7 +1003,7 @@ Each tool/resource is tagged below with its required level. Anything above the c
 |---|---|---|
 | `mongodb://collections` | Metadata | List of collections with stats, index info, and clean status |
 | `mongodb://clients` | Metadata | Connected remote monitoring agents |
-| `mongodb://monitoring` | DataRead | Recent and slow calls, summaries, error summary, connection pool state — calls embed filter values |
+| `mongodb://monitoring` | DataRead | Recent and slow calls, summaries, error summary, connection pool state, and `inFlightCalls` (queued vs executing, grouped by collection/function/filter) — calls embed filter values |
 
 ### Tools (System scope)
 | Tool | Level | Args |
@@ -1277,6 +1288,8 @@ builder.AddMongoDB(o =>
 |---|---|---|
 | `Enabled` | `true` | Enable or disable the limiter. |
 | `MaxConcurrent` | `null` (auto) | Maximum concurrent operations per connection pool. When `null`, auto-detected from `MaxConnectionPoolSize`. Capped at the pool size even if set higher — a warning is logged in that case. |
+
+The monitor surfaces the limiter **per pool** (one per cluster): queue/exec and depth/wait graphs per pool, what is queued vs executing right now (`GetInFlightCalls()` / the MCP `inFlightCalls` resource), and actual open connections per cluster vs a configured limit (`GetClusterConnectionSummary()` + `Monitor.ClusterConnectionLimit`). See the [monitoring docs](https://github.com/Tharga/MongoDB/blob/master/docs/articles/monitoring.md).
 
 ---
 

--- a/Tharga.MongoDB.Blazor/ClientsView.razor
+++ b/Tharga.MongoDB.Blazor/ClientsView.razor
@@ -50,6 +50,22 @@ else
             <RadzenDataGridColumn Title="Machine" Property="@nameof(MonitorClientDto.Machine)" />
             <RadzenDataGridColumn Title="Application" Property="@nameof(MonitorClientDto.Type)" />
             <RadzenDataGridColumn Title="Version" Property="@nameof(MonitorClientDto.Version)" Width="120px" />
+            <RadzenDataGridColumn Title="Call forwarding" Sortable="false" Width="130px">
+                <Template>
+                    @if (context.Status == null)
+                    {
+                        <RadzenText TextStyle="TextStyle.Caption" Style="color: gray;">—</RadzenText>
+                    }
+                    else if (context.Status.ForwardCompletedCalls)
+                    {
+                        <RadzenBadge BadgeStyle="BadgeStyle.Info" Text="On" />
+                    }
+                    else
+                    {
+                        <RadzenBadge BadgeStyle="BadgeStyle.Light" Text="Off" />
+                    }
+                </Template>
+            </RadzenDataGridColumn>
             <RadzenDataGridColumn Title="Connected" Property="@nameof(MonitorClientDto.ConnectTime)" SortOrder="SortOrder.Descending" Width="180px">
                 <Template>
                     <Tharga.Blazor.DateTimeView Date="@context.ConnectTime" />

--- a/Tharga.MongoDB.Blazor/MonitorClientDialog.razor
+++ b/Tharga.MongoDB.Blazor/MonitorClientDialog.razor
@@ -64,6 +64,43 @@ else
             </RadzenColumn>
         </RadzenRow>
 
+        @* --- Configuration (as reported by the agent) --- *@
+        <RadzenCard>
+            <RadzenText TextStyle="TextStyle.H6" Text="Configuration" />
+            @if (_detail.Client.Status == null)
+            {
+                <RadzenText TextStyle="TextStyle.Body2" Text="Not reported (older agent or not yet received)." Style="color: gray;" />
+            }
+            else
+            {
+                <RadzenRow>
+                    <RadzenColumn>
+                        <RadzenText TextStyle="TextStyle.Caption" Text="Call forwarding" />
+                        @if (_detail.Client.Status.ForwardCompletedCalls)
+                        {
+                            <RadzenBadge BadgeStyle="BadgeStyle.Info" Text="On" />
+                        }
+                        else
+                        {
+                            <RadzenBadge BadgeStyle="BadgeStyle.Light" Text="Off" />
+                        }
+                    </RadzenColumn>
+                    <RadzenColumn>
+                        <RadzenText TextStyle="TextStyle.Caption" Text="Queue interval" />
+                        <RadzenText Text="@($"{_detail.Client.Status.QueueMetricIntervalMs:N0} ms")" />
+                    </RadzenColumn>
+                    <RadzenColumn>
+                        <RadzenText TextStyle="TextStyle.Caption" Text="Storage mode" />
+                        <RadzenText Text="@(_detail.Client.Status.StorageMode ?? "—")" />
+                    </RadzenColumn>
+                    <RadzenColumn>
+                        <RadzenText TextStyle="TextStyle.Caption" Text="Command monitoring" />
+                        <RadzenText Text="@(_detail.Client.Status.EnableCommandMonitoring ? "On" : "Off")" />
+                    </RadzenColumn>
+                </RadzenRow>
+            }
+        </RadzenCard>
+
         @* --- Collections received --- *@
         <RadzenCard>
             <RadzenStack Orientation="Orientation.Horizontal" JustifyContent="JustifyContent.SpaceBetween" AlignItems="AlignItems.Center">

--- a/Tharga.MongoDB.Blazor/QueueView.razor
+++ b/Tharga.MongoDB.Blazor/QueueView.razor
@@ -8,7 +8,7 @@
         @foreach (var source in _sourceStates)
         {
             <RadzenColumn Size="2">
-                <RadzenText TextStyle="TextStyle.Caption" Text="@source.Key" />
+                <RadzenText TextStyle="TextStyle.Caption" Text="@(source.Value.Label ?? source.Key)" />
                 <RadzenText TextStyle="TextStyle.Subtitle1" Text="@($"Queue: {source.Value.QueueCount}  Exec: {source.Value.ExecutingCount}")" />
             </RadzenColumn>
         }
@@ -18,7 +18,7 @@
     <RadzenChart Style="height: 250px;">
         @foreach (var source in _sourceSlots)
         {
-            <RadzenLineSeries Data="@source.Value" CategoryProperty="SlotIndex" ValueProperty="QueueCount" Title="@source.Key" LineType="LineType.Solid" Smooth="true">
+            <RadzenLineSeries Data="@source.Value" CategoryProperty="SlotIndex" ValueProperty="QueueCount" Title="@LabelFor(source.Key)" LineType="LineType.Solid" Smooth="true">
                 <RadzenMarkers MarkerType="MarkerType.None" />
             </RadzenLineSeries>
         }
@@ -33,7 +33,7 @@
     <RadzenChart Style="height: 250px;">
         @foreach (var source in _sourceSlots)
         {
-            <RadzenLineSeries Data="@source.Value" CategoryProperty="SlotIndex" ValueProperty="WaitTimeSec" Title="@source.Key" LineType="LineType.Solid" Smooth="true">
+            <RadzenLineSeries Data="@source.Value" CategoryProperty="SlotIndex" ValueProperty="WaitTimeSec" Title="@LabelFor(source.Key)" LineType="LineType.Solid" Smooth="true">
                 <RadzenMarkers MarkerType="MarkerType.None" />
             </RadzenLineSeries>
         }
@@ -55,8 +55,12 @@
     private IAsyncDisposable _subscription;
 
     private readonly Dictionary<string, RingBuffer> _rings = new();
+    private readonly Dictionary<string, string> _labels = new();
     private Dictionary<string, List<Slot>> _sourceSlots = new();
     private Dictionary<string, ConnectionPoolStateDto> _sourceStates = new();
+
+    // The pool key is unique ("{source}::{serverKey}"); display the friendly label (config name(s)) instead.
+    private string LabelFor(string key) => _labels.TryGetValue(key, out var label) ? label : key;
 
     protected override async Task OnInitializedAsync()
     {
@@ -83,18 +87,20 @@
 
         try
         {
-            var perSource = DatabaseMonitor.GetPerSourceQueueState();
+            var perPool = DatabaseMonitor.GetPerPoolQueueState();
 
             await InvokeAsync(() =>
             {
-                _sourceStates = new Dictionary<string, ConnectionPoolStateDto>(perSource);
+                _sourceStates = new Dictionary<string, ConnectionPoolStateDto>(perPool);
 
-                foreach (var (source, poolState) in perSource)
+                foreach (var (poolKey, poolState) in perPool)
                 {
-                    if (!_rings.ContainsKey(source))
-                        _rings[source] = new RingBuffer(TotalSlots);
+                    _labels[poolKey] = poolState.Label ?? poolKey;
 
-                    _rings[source].Add(poolState.QueueCount, poolState.LastWaitTimeMs);
+                    if (!_rings.ContainsKey(poolKey))
+                        _rings[poolKey] = new RingBuffer(TotalSlots);
+
+                    _rings[poolKey].Add(poolState.QueueCount, poolState.LastWaitTimeMs);
                 }
 
                 BuildAllSlots();

--- a/Tharga.MongoDB.Blazor/QueueView.razor
+++ b/Tharga.MongoDB.Blazor/QueueView.razor
@@ -4,6 +4,32 @@
 @inject IServiceProvider ServiceProvider
 
 <RadzenStack Orientation="Orientation.Vertical" Gap="16px">
+
+    @if (_connectionSummaries.Count > 0)
+    {
+        <RadzenText TextStyle="TextStyle.Subtitle1" Text="Cluster connections (all sources)" />
+        <RadzenRow AlignItems="AlignItems.Start" Gap="16px">
+            @foreach (var cluster in _connectionSummaries)
+            {
+                <RadzenColumn Size="4">
+                    <RadzenText TextStyle="TextStyle.Caption" Text="@ClusterLabel(cluster)" />
+                    @if (cluster.Limit.HasValue && cluster.Limit.Value > 0)
+                    {
+                        <RadzenText TextStyle="TextStyle.Subtitle1" Text="@($"{cluster.OpenConnections:N0} / {cluster.Limit.Value:N0} open")" />
+                        <RadzenProgressBar Value="@cluster.OpenConnections" Max="@cluster.Limit.Value" ShowValue="false"
+                                           ProgressBarStyle="@ProgressStyle(cluster)" Style="height: 8px;" />
+                    }
+                    else
+                    {
+                        <RadzenText TextStyle="TextStyle.Subtitle1" Text="@($"{cluster.OpenConnections:N0} open")" />
+                    }
+                    <RadzenText TextStyle="TextStyle.Caption"
+                                Text="@($"capacity {cluster.MaxConnections:N0} · {cluster.SourceCount} source(s)")" />
+                </RadzenColumn>
+            }
+        </RadzenRow>
+    }
+
     <RadzenRow AlignItems="AlignItems.Center" Gap="16px">
         @foreach (var source in _sourceStates)
         {
@@ -58,9 +84,20 @@
     private readonly Dictionary<string, string> _labels = new();
     private Dictionary<string, List<Slot>> _sourceSlots = new();
     private Dictionary<string, ConnectionPoolStateDto> _sourceStates = new();
+    private IReadOnlyList<ClusterConnectionSummary> _connectionSummaries = [];
 
     // The pool key is unique ("{source}::{serverKey}"); display the friendly label (config name(s)) instead.
     private string LabelFor(string key) => _labels.TryGetValue(key, out var label) ? label : key;
+
+    private static string ClusterLabel(ClusterConnectionSummary c) =>
+        c.ConfigurationNames.Count > 0 ? string.Join(", ", c.ConfigurationNames) : c.ServerKey;
+
+    private static ProgressBarStyle ProgressStyle(ClusterConnectionSummary c)
+    {
+        if (!c.Limit.HasValue || c.Limit.Value <= 0) return ProgressBarStyle.Info;
+        var ratio = (double)c.OpenConnections / c.Limit.Value;
+        return ratio >= 0.9 ? ProgressBarStyle.Danger : ratio >= 0.75 ? ProgressBarStyle.Warning : ProgressBarStyle.Success;
+    }
 
     protected override async Task OnInitializedAsync()
     {
@@ -88,10 +125,12 @@
         try
         {
             var perPool = DatabaseMonitor.GetPerPoolQueueState();
+            var connectionSummaries = DatabaseMonitor.GetClusterConnectionSummary();
 
             await InvokeAsync(() =>
             {
                 _sourceStates = new Dictionary<string, ConnectionPoolStateDto>(perPool);
+                _connectionSummaries = connectionSummaries;
 
                 foreach (var (poolKey, poolState) in perPool)
                 {

--- a/Tharga.MongoDB.Blazor/README.md
+++ b/Tharga.MongoDB.Blazor/README.md
@@ -43,8 +43,8 @@ Then drop the components onto a Blazor page — they auto-discover the monitor v
 - **`<MonitorToolbar />`** — top-bar controls: configuration switcher, reset calls, reset cache.
 - **`<CollectionView />`** — table of every registered collection with status, document count, indexes, and per-collection drill-down dialog.
 - **`<CallView />`** — every database call captured by the monitor, with filter, sort, explain plan, and timing.
-- **`<ClientsView />`** — connected MongoDB clients (driver-side). Useful with `Tharga.MongoDB.Monitor.Server` when aggregating multiple agents.
-- **`<QueueView />`** — execute-limiter queue depth and throughput.
+- **`<ClientsView />`** — connected monitoring agents. Useful with `Tharga.MongoDB.Monitor.Server` when aggregating multiple agents; shows each agent's forwarding config (call-forwarding on/off, queue interval, storage mode).
+- **`<QueueView />`** — execute-limiter queue/exec and depth/wait graphs **per connection pool** (one line per cluster, labelled by configuration, across local + remote sources), plus per-cluster open-connection totals vs a configured limit (`Monitor.ClusterConnectionLimit`).
 - **`<ConfigurationsSelector />`** — switch between configured `ConnectionStrings` entries when an app talks to multiple clusters.
 
 The package is built on Radzen.Blazor — the same components and theming as the rest of your Radzen app.

--- a/Tharga.MongoDB.Mcp/MongoDbResourceProvider.cs
+++ b/Tharga.MongoDB.Mcp/MongoDbResourceProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Text.Json;
 using System.Threading;
@@ -150,6 +151,33 @@ public sealed class MongoDbResourceProvider : IMcpResourceProvider
             if (slowWithIndex.Count >= 50) break;
         }
 
+        // What the limiter is holding right now — grouped so a flood is legible. Filters render lazily here
+        // (diagnostics path), never on the execution hot path.
+        const int maxQueueGroups = 100;
+        var now = DateTime.UtcNow;
+        var inFlight = _monitor.GetInFlightCalls();
+        var queueGroups = inFlight
+            .GroupBy(c => new { c.ConfigurationName, c.DatabaseName, c.CollectionName, c.FunctionName, Operation = c.Operation.ToString(), c.Filter })
+            .Select(g => new
+            {
+                configuration = g.Key.ConfigurationName,
+                database = g.Key.DatabaseName,
+                collection = g.Key.CollectionName,
+                function = g.Key.FunctionName,
+                operation = g.Key.Operation,
+                filter = g.Key.Filter,
+                total = g.Count(),
+                queued = g.Count(x => !x.IsExecuting),
+                executing = g.Count(x => x.IsExecuting),
+                oldestQueuedSeconds = g.Where(x => !x.IsExecuting)
+                    .Select(x => (now - x.EnqueuedUtc).TotalSeconds)
+                    .DefaultIfEmpty(0)
+                    .Max(),
+            })
+            .OrderByDescending(x => x.queued)
+            .ThenByDescending(x => x.total)
+            .ToArray();
+
         var payload = new
         {
             recentCalls,
@@ -158,6 +186,14 @@ public sealed class MongoDbResourceProvider : IMcpResourceProvider
             errorSummary,
             slowCallsWithIndex = slowWithIndex,
             connectionPool = _monitor.GetConnectionPoolState(),
+            inFlightCalls = new
+            {
+                total = inFlight.Count,
+                queued = inFlight.Count(c => !c.IsExecuting),
+                executing = inFlight.Count(c => c.IsExecuting),
+                groupsTruncatedTo = queueGroups.Length > maxQueueGroups ? maxQueueGroups : (int?)null,
+                groups = queueGroups.Take(maxQueueGroups).ToArray(),
+            },
         };
 
         return new McpResourceContent

--- a/Tharga.MongoDB.Monitor.Client/MonitorClientStatusMessage.cs
+++ b/Tharga.MongoDB.Monitor.Client/MonitorClientStatusMessage.cs
@@ -1,0 +1,14 @@
+namespace Tharga.MongoDB.Monitor.Client;
+
+/// <summary>
+/// Sent once when an agent connects, reporting its forwarding-related configuration so the central
+/// monitor can show it on the Clients page. Correlated to the agent by <see cref="SourceName"/>.
+/// </summary>
+public record MonitorClientStatusMessage
+{
+    public required string SourceName { get; init; }
+    public required bool ForwardCompletedCalls { get; init; }
+    public required int QueueMetricIntervalMs { get; init; }
+    public string StorageMode { get; init; }
+    public bool EnableCommandMonitoring { get; init; }
+}

--- a/Tharga.MongoDB.Monitor.Client/MonitorForwarder.cs
+++ b/Tharga.MongoDB.Monitor.Client/MonitorForwarder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -21,6 +22,7 @@ internal sealed class MonitorForwarder : IHostedService, IDisposable
     private readonly IMongoDbServiceFactory _mongoDbServiceFactory;
     private readonly IDatabaseMonitor _databaseMonitor;
     private readonly IQueueMonitor _queueMonitor;
+    private readonly IConnectionPoolMonitor _connectionPoolMonitor;
     private readonly IClientCommunication _clientCommunication;
     private readonly MonitorOptions _monitorOptions;
     private readonly ILogger<MonitorForwarder> _logger;
@@ -32,6 +34,7 @@ internal sealed class MonitorForwarder : IHostedService, IDisposable
         IMongoDbServiceFactory mongoDbServiceFactory,
         IDatabaseMonitor databaseMonitor,
         IQueueMonitor queueMonitor,
+        IConnectionPoolMonitor connectionPoolMonitor,
         IClientCommunication clientCommunication,
         IOptions<DatabaseOptions> databaseOptions,
         ILogger<MonitorForwarder> logger = null)
@@ -39,6 +42,7 @@ internal sealed class MonitorForwarder : IHostedService, IDisposable
         _mongoDbServiceFactory = mongoDbServiceFactory;
         _databaseMonitor = databaseMonitor;
         _queueMonitor = queueMonitor;
+        _connectionPoolMonitor = connectionPoolMonitor;
         _clientCommunication = clientCommunication;
         _monitorOptions = databaseOptions.Value.Monitor;
         _logger = logger;
@@ -220,15 +224,36 @@ internal sealed class MonitorForwarder : IHostedService, IDisposable
             if (!_clientCommunication.IsConnected) return;
             if (!_clientCommunication.HasSubscribers<LiveMonitoringMarker>()) return;
 
-            var pools = _queueMonitor.GetPerPoolState();
+            // Merge the limiter's per-pool queue view with the actual connection counts, by server-key.
+            var byServer = new Dictionary<string, PoolMetricDto>();
+            foreach (var p in _queueMonitor.GetPerPoolState())
+            {
+                byServer[p.ServerKey] = new PoolMetricDto
+                {
+                    ServerKey = p.ServerKey,
+                    ConfigurationNames = p.ConfigurationNames,
+                    QueueCount = p.QueueCount,
+                    ExecutingCount = p.ExecutingCount,
+                    WaitTimeMs = p.LastWaitTimeMs > 0 ? p.LastWaitTimeMs : null,
+                };
+            }
+            foreach (var c in _connectionPoolMonitor.GetSnapshot())
+            {
+                var baseDto = byServer.TryGetValue(c.ServerKey, out var existing)
+                    ? existing
+                    : new PoolMetricDto { ServerKey = c.ServerKey, ConfigurationNames = Array.Empty<string>(), QueueCount = 0, ExecutingCount = 0 };
+                byServer[c.ServerKey] = baseDto with { OpenConnections = c.OpenConnections, MaxPoolSize = c.MaxPoolSize };
+            }
+            var pools = byServer.Values.ToList();
 
             // Aggregate scalars (back-compat for older servers + the activity guard below).
             var queueCount = pools.Sum(p => p.QueueCount);
             var executingCount = pools.Sum(p => p.ExecutingCount);
-            var lastWaitTimeMs = pools.Count == 0 ? 0 : pools.Max(p => p.LastWaitTimeMs);
+            var lastWaitTimeMs = pools.Count == 0 ? 0d : pools.Max(p => p.WaitTimeMs ?? 0);
+            var openConnections = pools.Sum(p => p.OpenConnections);
 
-            // Only send when there's activity to avoid unnecessary traffic
-            if (queueCount == 0 && executingCount == 0 && lastWaitTimeMs == 0) return;
+            // Send when there's queue activity OR open connections to report (so idle-but-open pools surface).
+            if (queueCount == 0 && executingCount == 0 && lastWaitTimeMs == 0 && openConnections == 0) return;
 
             await _clientCommunication.PostAsync(new MonitorQueueMetricMessage
             {
@@ -237,14 +262,7 @@ internal sealed class MonitorForwarder : IHostedService, IDisposable
                 QueueCount = queueCount,
                 ExecutingCount = executingCount,
                 WaitTimeMs = lastWaitTimeMs > 0 ? lastWaitTimeMs : null,
-                Pools = pools.Select(p => new PoolMetricDto
-                {
-                    ServerKey = p.ServerKey,
-                    ConfigurationNames = p.ConfigurationNames,
-                    QueueCount = p.QueueCount,
-                    ExecutingCount = p.ExecutingCount,
-                    WaitTimeMs = p.LastWaitTimeMs > 0 ? p.LastWaitTimeMs : null,
-                }).ToList(),
+                Pools = pools,
             });
         }
         catch (Exception ex)

--- a/Tharga.MongoDB.Monitor.Client/MonitorForwarder.cs
+++ b/Tharga.MongoDB.Monitor.Client/MonitorForwarder.cs
@@ -5,7 +5,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Tharga.Communication.Client.Communication;
+using Tharga.MongoDB.Configuration;
 
 namespace Tharga.MongoDB.Monitor.Client;
 
@@ -15,37 +17,51 @@ namespace Tharga.MongoDB.Monitor.Client;
 /// </summary>
 internal sealed class MonitorForwarder : IHostedService, IDisposable
 {
-    private const int QueueMetricIntervalMs = 500;
+    private const int MinQueueMetricIntervalMs = 100;
     private readonly IMongoDbServiceFactory _mongoDbServiceFactory;
     private readonly IDatabaseMonitor _databaseMonitor;
     private readonly IQueueMonitor _queueMonitor;
     private readonly IClientCommunication _clientCommunication;
+    private readonly MonitorOptions _monitorOptions;
     private readonly ILogger<MonitorForwarder> _logger;
     private readonly ConcurrentDictionary<Guid, CallStartEventArgs> _pendingCalls = new();
     private Timer _queueMetricTimer;
+    private bool _forwardCompletedCalls;
 
     public MonitorForwarder(
         IMongoDbServiceFactory mongoDbServiceFactory,
         IDatabaseMonitor databaseMonitor,
         IQueueMonitor queueMonitor,
         IClientCommunication clientCommunication,
+        IOptions<DatabaseOptions> databaseOptions,
         ILogger<MonitorForwarder> logger = null)
     {
         _mongoDbServiceFactory = mongoDbServiceFactory;
         _databaseMonitor = databaseMonitor;
         _queueMonitor = queueMonitor;
         _clientCommunication = clientCommunication;
+        _monitorOptions = databaseOptions.Value.Monitor;
         _logger = logger;
     }
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        _mongoDbServiceFactory.CallStartEvent += OnCallStart;
-        _mongoDbServiceFactory.CallEndEvent += OnCallEnd;
-        _databaseMonitor.CollectionInfoChangedEvent += OnCollectionInfoChanged;
-        _queueMetricTimer = new Timer(OnQueueMetricTick, null, QueueMetricIntervalMs, QueueMetricIntervalMs);
+        _forwardCompletedCalls = _monitorOptions.ForwardCompletedCalls;
 
-        // Send all known collections once connected
+        // Completed-call forwarding is opt-in (it can be a large, continuous stream). Only subscribe to call
+        // events when enabled — otherwise we don't even track pending calls.
+        if (_forwardCompletedCalls)
+        {
+            _mongoDbServiceFactory.CallStartEvent += OnCallStart;
+            _mongoDbServiceFactory.CallEndEvent += OnCallEnd;
+        }
+
+        _databaseMonitor.CollectionInfoChangedEvent += OnCollectionInfoChanged;
+
+        var intervalMs = Math.Max(MinQueueMetricIntervalMs, (int)_monitorOptions.QueueMetricInterval.TotalMilliseconds);
+        _queueMetricTimer = new Timer(OnQueueMetricTick, null, intervalMs, intervalMs);
+
+        // Report our config + send all known collections once connected.
         _ = SendInitialCollectionInfoAsync(cancellationToken);
 
         return Task.CompletedTask;
@@ -63,6 +79,9 @@ internal sealed class MonitorForwarder : IHostedService, IDisposable
             }
 
             if (!_clientCommunication.IsConnected) return;
+
+            // Report this agent's forwarding config so the central monitor can show it on the Clients page.
+            await SendClientStatusAsync();
 
             // Collect fingerprints first, then refresh stats for each.
             // GetInstancesAsync uses includeDetails: false so stats are null.
@@ -102,12 +121,37 @@ internal sealed class MonitorForwarder : IHostedService, IDisposable
 
     public Task StopAsync(CancellationToken cancellationToken)
     {
-        _mongoDbServiceFactory.CallStartEvent -= OnCallStart;
-        _mongoDbServiceFactory.CallEndEvent -= OnCallEnd;
+        if (_forwardCompletedCalls)
+        {
+            _mongoDbServiceFactory.CallStartEvent -= OnCallStart;
+            _mongoDbServiceFactory.CallEndEvent -= OnCallEnd;
+        }
         _databaseMonitor.CollectionInfoChangedEvent -= OnCollectionInfoChanged;
         _queueMetricTimer?.Dispose();
         _pendingCalls.Clear();
         return Task.CompletedTask;
+    }
+
+    private async Task SendClientStatusAsync()
+    {
+        try
+        {
+            if (!_clientCommunication.IsConnected) return;
+
+            var intervalMs = Math.Max(MinQueueMetricIntervalMs, (int)_monitorOptions.QueueMetricInterval.TotalMilliseconds);
+            await _clientCommunication.PostAsync(new MonitorClientStatusMessage
+            {
+                SourceName = _mongoDbServiceFactory.SourceName,
+                ForwardCompletedCalls = _forwardCompletedCalls,
+                QueueMetricIntervalMs = intervalMs,
+                StorageMode = _monitorOptions.StorageMode.ToString(),
+                EnableCommandMonitoring = _monitorOptions.EnableCommandMonitoring,
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to send client status.");
+        }
     }
 
     public void Dispose()

--- a/Tharga.MongoDB.Monitor.Client/MonitorForwarder.cs
+++ b/Tharga.MongoDB.Monitor.Client/MonitorForwarder.cs
@@ -176,7 +176,12 @@ internal sealed class MonitorForwarder : IHostedService, IDisposable
             if (!_clientCommunication.IsConnected) return;
             if (!_clientCommunication.HasSubscribers<LiveMonitoringMarker>()) return;
 
-            var (queueCount, executingCount, lastWaitTimeMs) = _queueMonitor.GetCurrentState();
+            var pools = _queueMonitor.GetPerPoolState();
+
+            // Aggregate scalars (back-compat for older servers + the activity guard below).
+            var queueCount = pools.Sum(p => p.QueueCount);
+            var executingCount = pools.Sum(p => p.ExecutingCount);
+            var lastWaitTimeMs = pools.Count == 0 ? 0 : pools.Max(p => p.LastWaitTimeMs);
 
             // Only send when there's activity to avoid unnecessary traffic
             if (queueCount == 0 && executingCount == 0 && lastWaitTimeMs == 0) return;
@@ -188,6 +193,14 @@ internal sealed class MonitorForwarder : IHostedService, IDisposable
                 QueueCount = queueCount,
                 ExecutingCount = executingCount,
                 WaitTimeMs = lastWaitTimeMs > 0 ? lastWaitTimeMs : null,
+                Pools = pools.Select(p => new PoolMetricDto
+                {
+                    ServerKey = p.ServerKey,
+                    ConfigurationNames = p.ConfigurationNames,
+                    QueueCount = p.QueueCount,
+                    ExecutingCount = p.ExecutingCount,
+                    WaitTimeMs = p.LastWaitTimeMs > 0 ? p.LastWaitTimeMs : null,
+                }).ToList(),
             });
         }
         catch (Exception ex)

--- a/Tharga.MongoDB.Monitor.Client/MonitorQueueMetricMessage.cs
+++ b/Tharga.MongoDB.Monitor.Client/MonitorQueueMetricMessage.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Tharga.MongoDB.Monitor.Client;
 
@@ -10,7 +11,13 @@ public record MonitorQueueMetricMessage
 {
     public required string SourceName { get; init; }
     public required DateTime Timestamp { get; init; }
+
+    // Aggregate (process-wide) scalars. Retained for backward/forward compatibility: an older server
+    // ignores Pools and reads these; an older agent sends only these and Pools stays null.
     public required int QueueCount { get; init; }
     public required int ExecutingCount { get; init; }
     public double? WaitTimeMs { get; init; }
+
+    /// <summary>Per-connection-pool breakdown. When present, the server prefers this over the aggregate scalars.</summary>
+    public IReadOnlyList<PoolMetricDto> Pools { get; init; }
 }

--- a/Tharga.MongoDB.Monitor.Client/README.md
+++ b/Tharga.MongoDB.Monitor.Client/README.md
@@ -28,11 +28,22 @@ If `sendTo` is null/empty the client is a no-op — convenient for local dev. Bo
 
 ## What it sends
 
-- **Calls** — every database operation captured by `IDatabaseMonitor` (filter, sort, latency, exception, explain plan).
-- **Collection info** — registered collections, document counts, index status.
-- **Queue metrics** — execute-limiter depth and throughput.
+- **Collection info** — registered collections, document counts, index status. Always forwarded (small).
+- **Queue & connection metrics** — per-pool execute-limiter depth/throughput and actual open-connection counts. Forwarded only while someone is viewing the live tab on the server, at `Monitor.QueueMetricInterval` (default 1s).
+- **Calls** — every completed database operation (filter, sort, latency, exception, explain plan). **Opt-in**, off by default — set `Monitor.ForwardCompletedCalls = true`. This is a large, continuous stream proportional to database activity, so enable it only when you want full per-call history on the central server.
 
-The agent appears as a connected client on the server side and can be inspected, addressed, and acted upon from there (e.g. "rebuild index on agent X" via remote action delegation).
+These are configured on the agent's `Monitor` options (same `MongoDB:Monitor` section as the core package):
+
+```json
+"MongoDB": {
+  "Monitor": {
+    "ForwardCompletedCalls": false,
+    "QueueMetricInterval": "00:00:01"
+  }
+}
+```
+
+The agent appears as a connected client on the server side — its forwarding configuration (call forwarding on/off, queue interval, storage mode) is shown on the server's **Clients** page — and it can be inspected, addressed, and acted upon from there (e.g. "rebuild index on agent X" via remote action delegation).
 
 ## Documentation
 

--- a/Tharga.MongoDB.Monitor.Server/MonitorClientStatusHandler.cs
+++ b/Tharga.MongoDB.Monitor.Server/MonitorClientStatusHandler.cs
@@ -1,0 +1,31 @@
+using System.Threading.Tasks;
+using Tharga.Communication.MessageHandler;
+using Tharga.MongoDB.Monitor.Client;
+
+namespace Tharga.MongoDB.Monitor.Server;
+
+/// <summary>
+/// Receives an agent's <see cref="MonitorClientStatusMessage"/> and records its reported configuration
+/// (call forwarding, queue interval, …) so it can be shown on the Clients page.
+/// </summary>
+public sealed class MonitorClientStatusHandler : PostMessageHandlerBase<MonitorClientStatusMessage>
+{
+    private readonly IDatabaseMonitor _databaseMonitor;
+
+    public MonitorClientStatusHandler(IDatabaseMonitor databaseMonitor)
+    {
+        _databaseMonitor = databaseMonitor;
+    }
+
+    public override Task Handle(MonitorClientStatusMessage message)
+    {
+        _databaseMonitor.IngestClientStatus(message.SourceName, new MonitorClientStatus
+        {
+            ForwardCompletedCalls = message.ForwardCompletedCalls,
+            QueueMetricIntervalMs = message.QueueMetricIntervalMs,
+            StorageMode = message.StorageMode,
+            EnableCommandMonitoring = message.EnableCommandMonitoring,
+        });
+        return Task.CompletedTask;
+    }
+}

--- a/Tharga.MongoDB.Monitor.Server/MonitorQueueMetricHandler.cs
+++ b/Tharga.MongoDB.Monitor.Server/MonitorQueueMetricHandler.cs
@@ -19,7 +19,10 @@ public sealed class MonitorQueueMetricHandler : PostMessageHandlerBase<MonitorQu
 
     public override Task Handle(MonitorQueueMetricMessage message)
     {
-        _databaseMonitor.IngestQueueMetric(message.SourceName, message.QueueCount, message.ExecutingCount, message.WaitTimeMs);
+        if (message.Pools is { Count: > 0 })
+            _databaseMonitor.IngestQueueMetric(message.SourceName, message.Pools);
+        else
+            _databaseMonitor.IngestQueueMetric(message.SourceName, message.QueueCount, message.ExecutingCount, message.WaitTimeMs);
         return Task.CompletedTask;
     }
 }

--- a/Tharga.MongoDB.Monitor.Server/MonitorServerRegistration.cs
+++ b/Tharga.MongoDB.Monitor.Server/MonitorServerRegistration.cs
@@ -65,6 +65,7 @@ public static class MonitorServerRegistration
         builder.Services.AddTransient<MonitorCallHandler>();
         builder.Services.AddTransient<MonitorCollectionInfoHandler>();
         builder.Services.AddTransient<MonitorQueueMetricHandler>();
+        builder.Services.AddTransient<MonitorClientStatusHandler>();
 
         // Bridge client connection events into IDatabaseMonitor
         builder.Services.AddHostedService<MonitorClientBridge>();

--- a/Tharga.MongoDB.Monitor.Server/README.md
+++ b/Tharga.MongoDB.Monitor.Server/README.md
@@ -22,8 +22,9 @@ Drop the Blazor admin components onto a page (see [`Tharga.MongoDB.Blazor`](http
 
 ## What it does
 
-- **Receives** call, collection-info, and queue-metric messages from connected agents.
-- **Tracks** each agent's connection state via `MonitorClientStateService` and `MonitorClientRepository` — the admin UI's `<ClientsView />` lists them.
+- **Receives** collection-info and per-pool queue/connection messages from connected agents (and completed calls when an agent opts in via `Monitor.ForwardCompletedCalls`).
+- **Aggregates connection usage per cluster** across the server and all agents, so the queue view can show total open connections vs a configured limit (`Monitor.ClusterConnectionLimit`).
+- **Tracks** each agent's connection state and reported config via `MonitorClientStateService` / `MonitorClientRepository` — the admin UI's `<ClientsView />` lists them with their forwarding settings.
 - **Bridges** agent connections into `IDatabaseMonitor` via `MonitorClientBridge`, so the calls/collections views render remote data alongside local data.
 - **Delegates remote actions** — admin tools can target a specific agent (e.g. *touch this collection on agent X*, *rebuild this index on agent Y*) through `IRemoteActionDispatcher`.
 - **Live monitoring subscriptions** — push live updates to subscribed clients via `ILiveMonitoringSubscription`.

--- a/Tharga.MongoDB.Tests/ConnectionSummaryTests.cs
+++ b/Tharga.MongoDB.Tests/ConnectionSummaryTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Tharga.MongoDB.Configuration;
+using Tharga.MongoDB.Internals;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests;
+
+public class ConnectionSummaryTests
+{
+    [Fact]
+    public void ConnectionPoolMonitor_CountsOpenConnections_AndGuardsAgainstNegative()
+    {
+        var monitor = new ConnectionPoolMonitor();
+        monitor.SetMaxPoolSize("cluster-A", 100);
+        monitor.OnConnectionCreated("cluster-A");
+        monitor.OnConnectionCreated("cluster-A");
+        monitor.OnConnectionCreated("cluster-A");
+        monitor.OnConnectionClosed("cluster-A");
+
+        // close-before-create on another pool must not go negative
+        monitor.OnConnectionClosed("cluster-B");
+
+        var snapshot = monitor.GetSnapshot();
+        snapshot.Single(p => p.ServerKey == "cluster-A").OpenConnections.Should().Be(2);
+        snapshot.Single(p => p.ServerKey == "cluster-A").MaxPoolSize.Should().Be(100);
+        snapshot.Single(p => p.ServerKey == "cluster-B").OpenConnections.Should().Be(0);
+    }
+
+    [Fact]
+    public void GetClusterConnectionSummary_AggregatesLocalAndRemoteByCluster_WithLimit()
+    {
+        var connectionMonitor = new ConnectionPoolMonitor();
+        connectionMonitor.SetMaxPoolSize("cluster-A", 100);
+        for (var i = 0; i < 5; i++) connectionMonitor.OnConnectionCreated("cluster-A"); // local: 5 open
+
+        var queueMonitor = new Mock<IQueueMonitor>();
+        queueMonitor.Setup(q => q.GetPerPoolState()).Returns(new[]
+        {
+            new PoolQueueState { ServerKey = "cluster-A", ConfigurationNames = new[] { "main" }, QueueCount = 0, ExecutingCount = 0, LastWaitTimeMs = 0 },
+        });
+
+        var monitor = CreateMonitor("Local/App", queueMonitor.Object, connectionMonitor, clusterConnectionLimit: 3000);
+
+        // A second source (agent) reports the same cluster + another cluster.
+        monitor.IngestQueueMetric("Agent-1", new List<PoolMetricDto>
+        {
+            new() { ServerKey = "cluster-A", ConfigurationNames = new[] { "main" }, QueueCount = 0, ExecutingCount = 0, OpenConnections = 10, MaxPoolSize = 100 },
+            new() { ServerKey = "cluster-B", ConfigurationNames = new[] { "reporting" }, QueueCount = 0, ExecutingCount = 0, OpenConnections = 3, MaxPoolSize = 50 },
+        });
+
+        var summary = monitor.GetClusterConnectionSummary();
+
+        var a = summary.Single(s => s.ServerKey == "cluster-A");
+        a.OpenConnections.Should().Be(15);  // 5 local + 10 remote
+        a.MaxConnections.Should().Be(200);   // 100 + 100 capacity
+        a.SourceCount.Should().Be(2);        // Local/App + Agent-1
+        a.Limit.Should().Be(3000);
+        a.ConfigurationNames.Should().Contain("main");
+
+        var b = summary.Single(s => s.ServerKey == "cluster-B");
+        b.OpenConnections.Should().Be(3);
+        b.SourceCount.Should().Be(1);
+        b.ConfigurationNames.Should().Contain("reporting");
+    }
+
+    private static DatabaseMonitor CreateMonitor(string sourceName, IQueueMonitor queueMonitor, IConnectionPoolMonitor connectionMonitor, int? clusterConnectionLimit)
+    {
+        var factoryMock = new Mock<IMongoDbServiceFactory>();
+        factoryMock.Setup(f => f.SourceName).Returns(sourceName);
+
+        var instanceMock = new Mock<IMongoDbInstance>();
+        instanceMock.Setup(i => i.RegisteredCollections).Returns(new ConcurrentDictionary<Type, Type>());
+
+        var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        var callLibrary = new CallLibrary(Options.Create(new DatabaseOptions { Monitor = new MonitorOptions() }));
+        var cacheMock = new Mock<ICollectionCache>();
+        cacheMock.Setup(c => c.LoadAsync()).Returns(Task.CompletedTask);
+        cacheMock.Setup(c => c.GetKeys()).Returns(Array.Empty<string>());
+        cacheMock.Setup(c => c.GetAll()).Returns(Array.Empty<CollectionInfo>());
+
+        var monitor = new DatabaseMonitor(
+            factoryMock.Object,
+            instanceMock.Object,
+            serviceProvider,
+            new Mock<IRepositoryConfiguration>().Object,
+            new Mock<ICollectionProvider>().Object,
+            callLibrary,
+            cacheMock.Object,
+            queueMonitor,
+            connectionMonitor,
+            Options.Create(new DatabaseOptions { Monitor = new MonitorOptions { ClusterConnectionLimit = clusterConnectionLimit } }),
+            NullLogger<DatabaseMonitor>.Instance);
+        monitor.Start(serviceProvider);
+        return monitor;
+    }
+}

--- a/Tharga.MongoDB.Tests/ExecuteLimiterLoggingTests.cs
+++ b/Tharga.MongoDB.Tests/ExecuteLimiterLoggingTests.cs
@@ -11,6 +11,7 @@ namespace Tharga.MongoDB.Tests;
 public class ExecuteLimiterLoggingTests
 {
     private const string ServerKey = "test-server";
+    private const string ConfigName = "test-config";
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
 
     private static ExecuteLimiter CreateLimiter(ILogger<ExecuteLimiter> logger)
@@ -40,11 +41,11 @@ public class ExecuteLimiterLoggingTests
         // Block the single concurrency slot so the next two operations pile up in the queue,
         // driving queuedCount past the > 1 threshold that emits the "Queued ..." message.
         var gate = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var blocking = limiter.ExecuteAsync(async _ => { await gate.Task; return 0; }, ServerKey, maxConnectionPoolSize: 100, CancellationToken.None);
+        var blocking = limiter.ExecuteAsync(async _ => { await gate.Task; return 0; }, ServerKey, ConfigName, maxConnectionPoolSize: 100, CancellationToken.None);
         await SpinUntil(() => limiter.GetCurrentState().ExecutingCount == 1);
 
-        var waiterA = limiter.ExecuteAsync(_ => Task.FromResult(1), ServerKey, maxConnectionPoolSize: 100, CancellationToken.None);
-        var waiterB = limiter.ExecuteAsync(_ => Task.FromResult(2), ServerKey, maxConnectionPoolSize: 100, CancellationToken.None);
+        var waiterA = limiter.ExecuteAsync(_ => Task.FromResult(1), ServerKey, ConfigName, maxConnectionPoolSize: 100, CancellationToken.None);
+        var waiterB = limiter.ExecuteAsync(_ => Task.FromResult(2), ServerKey, ConfigName, maxConnectionPoolSize: 100, CancellationToken.None);
         await SpinUntil(() => limiter.GetCurrentState().QueueCount >= 2);
 
         gate.SetResult(0);

--- a/Tharga.MongoDB.Tests/ExecuteLimiterLoggingTests.cs
+++ b/Tharga.MongoDB.Tests/ExecuteLimiterLoggingTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
+using Tharga.MongoDB.Disk;
 using Xunit;
 
 namespace Tharga.MongoDB.Tests;
@@ -13,6 +14,14 @@ public class ExecuteLimiterLoggingTests
     private const string ServerKey = "test-server";
     private const string ConfigName = "test-config";
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+
+    private static ExecuteCallContext Ctx() => new()
+    {
+        CallKey = Guid.NewGuid(),
+        ConfigurationName = ConfigName,
+        FunctionName = "test",
+        Operation = Operation.Read,
+    };
 
     private static ExecuteLimiter CreateLimiter(ILogger<ExecuteLimiter> logger)
     {
@@ -41,11 +50,11 @@ public class ExecuteLimiterLoggingTests
         // Block the single concurrency slot so the next two operations pile up in the queue,
         // driving queuedCount past the > 1 threshold that emits the "Queued ..." message.
         var gate = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var blocking = limiter.ExecuteAsync(async _ => { await gate.Task; return 0; }, ServerKey, ConfigName, maxConnectionPoolSize: 100, CancellationToken.None);
+        var blocking = limiter.ExecuteAsync(async _ => { await gate.Task; return 0; }, ServerKey, 100, Ctx(), CancellationToken.None);
         await SpinUntil(() => limiter.GetCurrentState().ExecutingCount == 1);
 
-        var waiterA = limiter.ExecuteAsync(_ => Task.FromResult(1), ServerKey, ConfigName, maxConnectionPoolSize: 100, CancellationToken.None);
-        var waiterB = limiter.ExecuteAsync(_ => Task.FromResult(2), ServerKey, ConfigName, maxConnectionPoolSize: 100, CancellationToken.None);
+        var waiterA = limiter.ExecuteAsync(_ => Task.FromResult(1), ServerKey, 100, Ctx(), CancellationToken.None);
+        var waiterB = limiter.ExecuteAsync(_ => Task.FromResult(2), ServerKey, 100, Ctx(), CancellationToken.None);
         await SpinUntil(() => limiter.GetCurrentState().QueueCount >= 2);
 
         gate.SetResult(0);

--- a/Tharga.MongoDB.Tests/InFlightCallTests.cs
+++ b/Tharga.MongoDB.Tests/InFlightCallTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Tharga.MongoDB.Configuration;
+using Tharga.MongoDB.Disk;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests;
+
+public class InFlightCallTests
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+
+    private static ExecuteLimiter CreateLimiter(int maxConcurrent) =>
+        new(Mock.Of<IOptions<ExecuteLimiterOptions>>(x =>
+                x.Value == new ExecuteLimiterOptions { Enabled = true, MaxConcurrent = maxConcurrent }),
+            NullLogger<ExecuteLimiter>.Instance);
+
+    private static ExecuteCallContext Ctx(string function, Operation operation, string filterJson = null) => new()
+    {
+        CallKey = Guid.NewGuid(),
+        ConfigurationName = "cfg",
+        DatabaseName = "db",
+        CollectionName = "Things",
+        FunctionName = function,
+        Operation = operation,
+        FilterProvider = filterJson == null ? null : () => filterJson,
+    };
+
+    [Fact]
+    public async Task GetInFlightCalls_DistinguishesQueuedFromExecuting_WithMetadataAndRenderedFilter()
+    {
+        var limiter = CreateLimiter(maxConcurrent: 1);
+        var gate = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Occupy the only slot; this one is executing.
+        var executing = limiter.ExecuteAsync(async _ => { await gate.Task; return 0; },
+            "srv", 100, Ctx("GetManyAsync", Operation.Read, "{ \"x\" : 1 }"), CancellationToken.None);
+        await SpinUntil(() => limiter.GetInFlightCalls().Any(c => c.IsExecuting));
+
+        // This one cannot acquire the slot; it stays queued.
+        var queued = limiter.ExecuteAsync(_ => Task.FromResult(1),
+            "srv", 100, Ctx("UpdateOneAsync", Operation.Update), CancellationToken.None);
+        await SpinUntil(() => limiter.GetInFlightCalls().Count(c => !c.IsExecuting) == 1);
+
+        var inFlight = limiter.GetInFlightCalls();
+        inFlight.Should().HaveCount(2);
+
+        var exec = inFlight.Single(c => c.IsExecuting);
+        exec.FunctionName.Should().Be("GetManyAsync");
+        exec.CollectionName.Should().Be("Things");
+        exec.Filter.Should().Be("{ \"x\" : 1 }"); // rendered on inspection
+
+        var wait = inFlight.Single(c => !c.IsExecuting);
+        wait.FunctionName.Should().Be("UpdateOneAsync");
+        wait.Operation.Should().Be(Operation.Update);
+
+        gate.SetResult(0);
+        await Task.WhenAll(executing, queued).WaitAsync(Timeout);
+
+        await SpinUntil(() => limiter.GetInFlightCalls().Count == 0); // drained when calls finish
+    }
+
+    [Fact]
+    public void OngoingCalls_AreNotEvicted_WhenRecentRingOverflows()
+    {
+        var library = new CallLibrary(Options.Create(new DatabaseOptions
+        {
+            Monitor = new MonitorOptions { LastCallsToKeep = 2 },
+        }));
+
+        // Three concurrent (never-finalized) calls, but the recent ring only keeps 2.
+        for (var i = 0; i < 3; i++)
+        {
+            var fingerprint = new CollectionFingerprint { ConfigurationName = "cfg", DatabaseName = "db", CollectionName = $"Coll{i}" };
+            library.StartCall(new CallStartEventArgs(Guid.NewGuid(), fingerprint, "GetManyAsync", Operation.Read, "src"));
+        }
+
+        // All three are still in flight, so all three must show as ongoing despite the ring cap of 2.
+        library.GetOngoingCalls().Count(c => !c.Final).Should().Be(3);
+    }
+
+    private static async Task SpinUntil(Func<bool> condition)
+    {
+        var deadline = DateTime.UtcNow + Timeout;
+        while (!condition())
+        {
+            if (DateTime.UtcNow > deadline) throw new TimeoutException("Condition not met within timeout.");
+            await Task.Delay(5);
+        }
+    }
+}

--- a/Tharga.MongoDB.Tests/McpProviderTests.cs
+++ b/Tharga.MongoDB.Tests/McpProviderTests.cs
@@ -84,6 +84,7 @@ public class McpProviderTests
         _monitorMock.Setup(m => m.GetCallSummary()).Returns(Array.Empty<CallSummaryDto>());
         _monitorMock.Setup(m => m.GetErrorSummary()).Returns(Array.Empty<ErrorSummaryDto>());
         _monitorMock.Setup(m => m.GetSlowCallsWithIndexInfoAsync()).Returns(EmptyAsyncEnumerable<SlowCallWithIndexInfoDto>());
+        _monitorMock.Setup(m => m.GetInFlightCalls()).Returns(Array.Empty<InFlightCallInfo>());
         _monitorMock.Setup(m => m.GetConnectionPoolState()).Returns(new ConnectionPoolStateDto
         {
             QueueCount = 0,

--- a/Tharga.MongoDB.Tests/MonitorForwarderTests.cs
+++ b/Tharga.MongoDB.Tests/MonitorForwarderTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.Extensions.Options;
 using Moq;
 using Tharga.Communication.Client.Communication;
 using Tharga.MongoDB.Configuration;
@@ -35,7 +36,9 @@ public class MonitorForwarderTests : IAsyncLifetime
         _factoryMock.SetupAdd(f => f.CallEndEvent += It.IsAny<EventHandler<CallEndEventArgs>>())
             .Callback<EventHandler<CallEndEventArgs>>(h => _callEndHandler = h);
 
-        _sut = new MonitorForwarder(_factoryMock.Object, _monitorMock.Object, _queueMonitorMock.Object, _clientMock.Object);
+        // Enable completed-call forwarding so the call-forwarding paths under test are active.
+        var options = Options.Create(new DatabaseOptions { Monitor = new MonitorOptions { ForwardCompletedCalls = true } });
+        _sut = new MonitorForwarder(_factoryMock.Object, _monitorMock.Object, _queueMonitorMock.Object, _clientMock.Object, options);
     }
 
     public async ValueTask InitializeAsync()
@@ -87,6 +90,29 @@ public class MonitorForwarderTests : IAsyncLifetime
         captured.Call.Count.Should().Be(5);
         captured.Call.Exception.Should().BeNull();
         captured.Call.Final.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task When_ForwardCompletedCalls_Off_DoesNotSubscribeToCallEvents()
+    {
+        var factory = new Mock<IMongoDbServiceFactory>();
+        var monitor = new Mock<IDatabaseMonitor>();
+        var queue = new Mock<IQueueMonitor>();
+        var client = new Mock<IClientCommunication>();
+        var options = Options.Create(new DatabaseOptions { Monitor = new MonitorOptions { ForwardCompletedCalls = false } });
+        var sut = new MonitorForwarder(factory.Object, monitor.Object, queue.Object, client.Object, options);
+
+        await sut.StartAsync(CancellationToken.None);
+        try
+        {
+            factory.VerifyAdd(f => f.CallStartEvent += It.IsAny<EventHandler<CallStartEventArgs>>(), Times.Never());
+            factory.VerifyAdd(f => f.CallEndEvent += It.IsAny<EventHandler<CallEndEventArgs>>(), Times.Never());
+        }
+        finally
+        {
+            await sut.StopAsync(CancellationToken.None);
+            sut.Dispose();
+        }
     }
 
     [Fact]

--- a/Tharga.MongoDB.Tests/MonitorForwarderTests.cs
+++ b/Tharga.MongoDB.Tests/MonitorForwarderTests.cs
@@ -38,7 +38,7 @@ public class MonitorForwarderTests : IAsyncLifetime
 
         // Enable completed-call forwarding so the call-forwarding paths under test are active.
         var options = Options.Create(new DatabaseOptions { Monitor = new MonitorOptions { ForwardCompletedCalls = true } });
-        _sut = new MonitorForwarder(_factoryMock.Object, _monitorMock.Object, _queueMonitorMock.Object, _clientMock.Object, options);
+        _sut = new MonitorForwarder(_factoryMock.Object, _monitorMock.Object, _queueMonitorMock.Object, new Mock<IConnectionPoolMonitor>().Object, _clientMock.Object, options);
     }
 
     public async ValueTask InitializeAsync()
@@ -100,7 +100,7 @@ public class MonitorForwarderTests : IAsyncLifetime
         var queue = new Mock<IQueueMonitor>();
         var client = new Mock<IClientCommunication>();
         var options = Options.Create(new DatabaseOptions { Monitor = new MonitorOptions { ForwardCompletedCalls = false } });
-        var sut = new MonitorForwarder(factory.Object, monitor.Object, queue.Object, client.Object, options);
+        var sut = new MonitorForwarder(factory.Object, monitor.Object, queue.Object, new Mock<IConnectionPoolMonitor>().Object, client.Object, options);
 
         await sut.StartAsync(CancellationToken.None);
         try

--- a/Tharga.MongoDB.Tests/MonitorServerPipelineTests.cs
+++ b/Tharga.MongoDB.Tests/MonitorServerPipelineTests.cs
@@ -214,6 +214,7 @@ public class MonitorServerPipelineTests
         public MonitorClientDetail GetMonitorClientDetail(string sourceName, int recentCallLimit = 20) => throw new NotImplementedException();
         public System.Collections.Generic.IReadOnlyList<CollectionInfo> GetCollectionsWithFailedIndices() => throw new NotImplementedException();
         public void IngestClientConnected(MonitorClientDto client) => throw new NotImplementedException();
+        public void IngestClientStatus(string sourceName, MonitorClientStatus status) => throw new NotImplementedException();
         public void IngestClientDisconnected(string connectionId) => throw new NotImplementedException();
         public void IngestCollectionInfo(RemoteCollectionInfoDto collectionInfo, string connectionId = null) => throw new NotImplementedException();
         public System.Collections.Generic.IReadOnlyCollection<string> GetCollectionSources(string fingerprintKey) => throw new NotImplementedException();

--- a/Tharga.MongoDB.Tests/MonitorServerPipelineTests.cs
+++ b/Tharga.MongoDB.Tests/MonitorServerPipelineTests.cs
@@ -222,5 +222,6 @@ public class MonitorServerPipelineTests
         public void IngestQueueMetric(string sourceName, int queueCount, int executingCount, double? waitTimeMs) { }
         public void IngestQueueMetric(string sourceName, System.Collections.Generic.IReadOnlyList<PoolMetricDto> pools) { }
         public System.Collections.Generic.IReadOnlyDictionary<string, ConnectionPoolStateDto> GetPerPoolQueueState() => new System.Collections.Generic.Dictionary<string, ConnectionPoolStateDto>();
+        public System.Collections.Generic.IReadOnlyList<InFlightCallInfo> GetInFlightCalls() => System.Array.Empty<InFlightCallInfo>();
     }
 }

--- a/Tharga.MongoDB.Tests/MonitorServerPipelineTests.cs
+++ b/Tharga.MongoDB.Tests/MonitorServerPipelineTests.cs
@@ -220,6 +220,7 @@ public class MonitorServerPipelineTests
         public string FindConnectionIdBySource(string sourceName) => null;
         public System.Collections.Generic.IReadOnlyDictionary<string, int> GetSubscriptions() => new System.Collections.Generic.Dictionary<string, int>();
         public void IngestQueueMetric(string sourceName, int queueCount, int executingCount, double? waitTimeMs) { }
-        public System.Collections.Generic.IReadOnlyDictionary<string, ConnectionPoolStateDto> GetPerSourceQueueState() => new System.Collections.Generic.Dictionary<string, ConnectionPoolStateDto>();
+        public void IngestQueueMetric(string sourceName, System.Collections.Generic.IReadOnlyList<PoolMetricDto> pools) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, ConnectionPoolStateDto> GetPerPoolQueueState() => new System.Collections.Generic.Dictionary<string, ConnectionPoolStateDto>();
     }
 }

--- a/Tharga.MongoDB.Tests/MonitorServerPipelineTests.cs
+++ b/Tharga.MongoDB.Tests/MonitorServerPipelineTests.cs
@@ -224,5 +224,6 @@ public class MonitorServerPipelineTests
         public void IngestQueueMetric(string sourceName, System.Collections.Generic.IReadOnlyList<PoolMetricDto> pools) { }
         public System.Collections.Generic.IReadOnlyDictionary<string, ConnectionPoolStateDto> GetPerPoolQueueState() => new System.Collections.Generic.Dictionary<string, ConnectionPoolStateDto>();
         public System.Collections.Generic.IReadOnlyList<InFlightCallInfo> GetInFlightCalls() => System.Array.Empty<InFlightCallInfo>();
+        public System.Collections.Generic.IReadOnlyList<ClusterConnectionSummary> GetClusterConnectionSummary() => System.Array.Empty<ClusterConnectionSummary>();
     }
 }

--- a/Tharga.MongoDB.Tests/PerPoolQueueMetricTests.cs
+++ b/Tharga.MongoDB.Tests/PerPoolQueueMetricTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using Tharga.MongoDB.Configuration;
+using Tharga.MongoDB.Disk;
 using Tharga.MongoDB.Internals;
 using Xunit;
 
@@ -24,13 +25,21 @@ public class PerPoolQueueMetricTests
         new(Mock.Of<IOptions<ExecuteLimiterOptions>>(x => x.Value == new ExecuteLimiterOptions { Enabled = true }),
             NullLogger<ExecuteLimiter>.Instance);
 
+    private static ExecuteCallContext CtxFor(string configurationName) => new()
+    {
+        CallKey = Guid.NewGuid(),
+        ConfigurationName = configurationName,
+        FunctionName = "test",
+        Operation = Operation.Read,
+    };
+
     [Fact]
     public async Task GetPerPoolState_SplitsByServerKey_AndTagsConfiguration()
     {
         var limiter = CreateLimiter();
 
-        await limiter.ExecuteAsync(_ => Task.FromResult(0), "cluster-A", "cfgA", 100, CancellationToken.None);
-        await limiter.ExecuteAsync(_ => Task.FromResult(0), "cluster-B", "cfgB", 100, CancellationToken.None);
+        await limiter.ExecuteAsync(_ => Task.FromResult(0), "cluster-A", 100, CtxFor("cfgA"), CancellationToken.None);
+        await limiter.ExecuteAsync(_ => Task.FromResult(0), "cluster-B", 100, CtxFor("cfgB"), CancellationToken.None);
 
         var pools = limiter.GetPerPoolState();
 
@@ -44,8 +53,8 @@ public class PerPoolQueueMetricTests
     {
         var limiter = CreateLimiter();
 
-        await limiter.ExecuteAsync(_ => Task.FromResult(0), "shared-cluster", "cfg1", 100, CancellationToken.None);
-        await limiter.ExecuteAsync(_ => Task.FromResult(0), "shared-cluster", "cfg2", 100, CancellationToken.None);
+        await limiter.ExecuteAsync(_ => Task.FromResult(0), "shared-cluster", 100, CtxFor("cfg1"), CancellationToken.None);
+        await limiter.ExecuteAsync(_ => Task.FromResult(0), "shared-cluster", 100, CtxFor("cfg2"), CancellationToken.None);
 
         var pools = limiter.GetPerPoolState();
 

--- a/Tharga.MongoDB.Tests/PerPoolQueueMetricTests.cs
+++ b/Tharga.MongoDB.Tests/PerPoolQueueMetricTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Tharga.MongoDB.Configuration;
+using Tharga.MongoDB.Internals;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests;
+
+public class PerPoolQueueMetricTests
+{
+    // --- ExecuteLimiter: per-pool split + configuration tagging ---
+
+    private static ExecuteLimiter CreateLimiter() =>
+        new(Mock.Of<IOptions<ExecuteLimiterOptions>>(x => x.Value == new ExecuteLimiterOptions { Enabled = true }),
+            NullLogger<ExecuteLimiter>.Instance);
+
+    [Fact]
+    public async Task GetPerPoolState_SplitsByServerKey_AndTagsConfiguration()
+    {
+        var limiter = CreateLimiter();
+
+        await limiter.ExecuteAsync(_ => Task.FromResult(0), "cluster-A", "cfgA", 100, CancellationToken.None);
+        await limiter.ExecuteAsync(_ => Task.FromResult(0), "cluster-B", "cfgB", 100, CancellationToken.None);
+
+        var pools = limiter.GetPerPoolState();
+
+        pools.Should().HaveCount(2);
+        pools.Single(p => p.ServerKey == "cluster-A").ConfigurationNames.Should().BeEquivalentTo("cfgA");
+        pools.Single(p => p.ServerKey == "cluster-B").ConfigurationNames.Should().BeEquivalentTo("cfgB");
+    }
+
+    [Fact]
+    public async Task GetPerPoolState_TwoConfigurationsOnSameCluster_CollapseToOnePoolWithBothNames()
+    {
+        var limiter = CreateLimiter();
+
+        await limiter.ExecuteAsync(_ => Task.FromResult(0), "shared-cluster", "cfg1", 100, CancellationToken.None);
+        await limiter.ExecuteAsync(_ => Task.FromResult(0), "shared-cluster", "cfg2", 100, CancellationToken.None);
+
+        var pools = limiter.GetPerPoolState();
+
+        pools.Should().ContainSingle();
+        pools[0].ServerKey.Should().Be("shared-cluster");
+        pools[0].ConfigurationNames.Should().BeEquivalentTo("cfg1", "cfg2");
+    }
+
+    // --- DatabaseMonitor: GetPerPoolQueueState labeling + remote round-trip ---
+
+    private static DatabaseMonitor CreateMonitor(string sourceName, IQueueMonitor queueMonitor)
+    {
+        var factoryMock = new Mock<IMongoDbServiceFactory>();
+        factoryMock.Setup(f => f.SourceName).Returns(sourceName);
+
+        var instanceMock = new Mock<IMongoDbInstance>();
+        instanceMock.Setup(i => i.RegisteredCollections).Returns(new ConcurrentDictionary<Type, Type>());
+
+        var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        var callLibrary = new CallLibrary(Options.Create(new DatabaseOptions { Monitor = new MonitorOptions() }));
+        var cacheMock = new Mock<ICollectionCache>();
+        cacheMock.Setup(c => c.LoadAsync()).Returns(Task.CompletedTask);
+        cacheMock.Setup(c => c.GetKeys()).Returns(Array.Empty<string>());
+        cacheMock.Setup(c => c.GetAll()).Returns(Array.Empty<CollectionInfo>());
+
+        var monitor = new DatabaseMonitor(
+            factoryMock.Object,
+            instanceMock.Object,
+            serviceProvider,
+            new Mock<IRepositoryConfiguration>().Object,
+            new Mock<ICollectionProvider>().Object,
+            callLibrary,
+            cacheMock.Object,
+            queueMonitor,
+            Options.Create(new DatabaseOptions { Monitor = new MonitorOptions() }),
+            NullLogger<DatabaseMonitor>.Instance);
+        monitor.Start(serviceProvider);
+        return monitor;
+    }
+
+    private static IQueueMonitor StubQueueMonitor(params PoolQueueState[] pools)
+    {
+        var mock = new Mock<IQueueMonitor>();
+        mock.Setup(q => q.GetPerPoolState()).Returns(pools);
+        return mock.Object;
+    }
+
+    [Fact]
+    public void GetPerPoolQueueState_SingleSource_LabelsByConfigurationName()
+    {
+        var monitor = CreateMonitor("Local/App", StubQueueMonitor(new PoolQueueState
+        {
+            ServerKey = "cluster-A",
+            ConfigurationNames = new[] { "main" },
+            QueueCount = 3,
+            ExecutingCount = 1,
+            LastWaitTimeMs = 12,
+        }));
+
+        var state = monitor.GetPerPoolQueueState();
+
+        state.Should().ContainKey("Local/App::cluster-A");
+        var pool = state["Local/App::cluster-A"];
+        pool.Label.Should().Be("main"); // single source -> no source suffix
+        pool.QueueCount.Should().Be(3);
+        pool.ExecutingCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void GetPerPoolQueueState_RemotePoolsRoundTrip_AndDisambiguateBySource()
+    {
+        var monitor = CreateMonitor("Local/App", StubQueueMonitor(new PoolQueueState
+        {
+            ServerKey = "cluster-A",
+            ConfigurationNames = new[] { "main" },
+            QueueCount = 1,
+            ExecutingCount = 0,
+            LastWaitTimeMs = 0,
+        }));
+
+        // Simulate what MonitorQueueMetricHandler does for a per-pool message from a remote agent.
+        monitor.IngestQueueMetric("Agent-1/Svc", new List<PoolMetricDto>
+        {
+            new() { ServerKey = "cluster-B", ConfigurationNames = new[] { "reporting" }, QueueCount = 5, ExecutingCount = 2, WaitTimeMs = 40 },
+        });
+
+        var state = monitor.GetPerPoolQueueState();
+
+        // Two sources now report -> labels are source-suffixed for distinctness.
+        state["Local/App::cluster-A"].Label.Should().Be("main @ Local/App");
+        var remote = state["Agent-1/Svc::cluster-B"];
+        remote.Label.Should().Be("reporting @ Agent-1/Svc");
+        remote.QueueCount.Should().Be(5);
+        remote.ExecutingCount.Should().Be(2);
+        remote.LastWaitTimeMs.Should().Be(40);
+    }
+}

--- a/Tharga.MongoDB.Tests/PerPoolQueueMetricTests.cs
+++ b/Tharga.MongoDB.Tests/PerPoolQueueMetricTests.cs
@@ -89,6 +89,7 @@ public class PerPoolQueueMetricTests
             callLibrary,
             cacheMock.Object,
             queueMonitor,
+            new ConnectionPoolMonitor(),
             Options.Create(new DatabaseOptions { Monitor = new MonitorOptions() }),
             NullLogger<DatabaseMonitor>.Instance);
         monitor.Start(serviceProvider);

--- a/Tharga.MongoDB.Tests/RemoteActionDelegationTests.cs
+++ b/Tharga.MongoDB.Tests/RemoteActionDelegationTests.cs
@@ -60,6 +60,7 @@ public class RemoteActionDelegationTests
             callLibrary,
             _cacheMock.Object,
             queueMonitorMock.Object,
+            new ConnectionPoolMonitor(),
             options,
             NullLogger<DatabaseMonitor>.Instance);
 

--- a/Tharga.MongoDB/CallLibrary.cs
+++ b/Tharga.MongoDB/CallLibrary.cs
@@ -20,6 +20,9 @@ internal class CallLibrary : ICallLibrary
     private readonly ConcurrentDictionary<string, int> _callCounts = new();
     private readonly ConcurrentDictionary<string, int> _callCountsBySuffix = new();
     private readonly ConcurrentDictionary<Guid, DateTime> _completedAt = new();
+    // In-flight (not-yet-final) calls, kept separate from the capped "recent" ring so a long-queued call is
+    // never evicted while it is still running — otherwise a flood pushes the stuck calls out of view.
+    private readonly ConcurrentDictionary<Guid, CallInfo> _inFlightCalls = new();
     private static readonly TimeSpan CompletedRetention = TimeSpan.FromSeconds(10);
     private static readonly TimeSpan ThrottleInterval = TimeSpan.FromMilliseconds(500);
     private int _throttlePending;
@@ -54,6 +57,7 @@ internal class CallLibrary : ICallLibrary
         };
 
         _calls.TryAdd(e.CallKey, info);
+        _inFlightCalls.TryAdd(e.CallKey, info);
         _recentCalls.Enqueue(e.CallKey);
 
         while (_recentCalls.Count > _options.Monitor.LastCallsToKeep)
@@ -87,6 +91,7 @@ internal class CallLibrary : ICallLibrary
             if (e.Final)
             {
                 _completedAt.TryAdd(e.CallKey, DateTime.UtcNow);
+                _inFlightCalls.TryRemove(e.CallKey, out _);
             }
         }
 
@@ -120,8 +125,18 @@ internal class CallLibrary : ICallLibrary
             }
         }
 
-        // Return ongoing + recently completed
-        return _calls.Values.Where(x => !x.Final || _completedAt.ContainsKey(x.Key));
+        // In-flight calls come from their own store (never evicted while running, so a flood can't hide the
+        // stuck ones), plus the short tail of recently completed calls from the capped recent ring.
+        var result = new Dictionary<Guid, CallInfo>();
+        foreach (var call in _inFlightCalls.Values)
+        {
+            result[call.Key] = call;
+        }
+        foreach (var key in _completedAt.Keys)
+        {
+            if (_calls.TryGetValue(key, out var call)) result[key] = call;
+        }
+        return result.Values;
     }
 
     public CallInfo GetCall(Guid key)

--- a/Tharga.MongoDB/Configuration/MonitorOptions.cs
+++ b/Tharga.MongoDB/Configuration/MonitorOptions.cs
@@ -56,6 +56,13 @@ public record MonitorOptions
     public TimeSpan QueueMetricInterval { get; set; } = TimeSpan.FromSeconds(1);
 
     /// <summary>
+    /// The maximum number of connections a cluster allows (e.g. an Atlas cluster's connection limit, 3000 on
+    /// many tiers). When set, the central monitor shows total open connections across all sources as a
+    /// fraction of this limit. When null, only the totals are shown. Configured on the monitor/server.
+    /// </summary>
+    public int? ClusterConnectionLimit { get; set; }
+
+    /// <summary>
     /// Enable MongoDB driver command monitoring. When enabled, driver-level command durations
     /// are captured and surfaced in call step data, allowing operators to distinguish slow
     /// server execution from thread pool starvation. Default is false.

--- a/Tharga.MongoDB/Configuration/MonitorOptions.cs
+++ b/Tharga.MongoDB/Configuration/MonitorOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace Tharga.MongoDB.Configuration;
+﻿using System;
+
+namespace Tharga.MongoDB.Configuration;
 
 public record MonitorOptions
 {
@@ -39,6 +41,19 @@ public record MonitorOptions
     /// When null or empty, no forwarding is configured.
     /// </summary>
     public string SendTo { get; set; }
+
+    /// <summary>
+    /// When forwarding to a central monitor (<see cref="SendTo"/>), whether to forward every completed call.
+    /// This can be a large, continuous stream proportional to database activity, so it is <b>off by default</b>.
+    /// Collection metadata and (viewer-gated) queue metrics are forwarded regardless of this setting.
+    /// </summary>
+    public bool ForwardCompletedCalls { get; set; } = false;
+
+    /// <summary>
+    /// How often the agent forwards a queue-state snapshot to the central monitor (only while someone is
+    /// watching live). Smaller is smoother on the live graph; larger is less chatter. Default is 1 second.
+    /// </summary>
+    public TimeSpan QueueMetricInterval { get; set; } = TimeSpan.FromSeconds(1);
 
     /// <summary>
     /// Enable MongoDB driver command monitoring. When enabled, driver-level command durations

--- a/Tharga.MongoDB/ConnectionPoolMonitor.cs
+++ b/Tharga.MongoDB/ConnectionPoolMonitor.cs
@@ -1,0 +1,51 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Tharga.MongoDB;
+
+internal sealed class ConnectionPoolMonitor : IConnectionPoolMonitor
+{
+    private readonly ConcurrentDictionary<string, Counters> _pools = new();
+
+    public void OnConnectionCreated(string serverKey)
+    {
+        var c = _pools.GetOrAdd(serverKey, _ => new Counters());
+        Interlocked.Increment(ref c.Open);
+    }
+
+    public void OnConnectionClosed(string serverKey)
+    {
+        var c = _pools.GetOrAdd(serverKey, _ => new Counters());
+        // Guard against a close observed before its create (event ordering) going negative.
+        if (Interlocked.Decrement(ref c.Open) < 0)
+            Interlocked.Exchange(ref c.Open, 0);
+    }
+
+    public void SetMaxPoolSize(string serverKey, int maxPoolSize)
+    {
+        var c = _pools.GetOrAdd(serverKey, _ => new Counters());
+        Interlocked.Exchange(ref c.MaxPoolSize, maxPoolSize);
+    }
+
+    public IReadOnlyList<ConnectionPoolCount> GetSnapshot()
+    {
+        var list = new List<ConnectionPoolCount>(_pools.Count);
+        foreach (var (serverKey, c) in _pools)
+        {
+            list.Add(new ConnectionPoolCount
+            {
+                ServerKey = serverKey,
+                OpenConnections = Volatile.Read(ref c.Open),
+                MaxPoolSize = Volatile.Read(ref c.MaxPoolSize),
+            });
+        }
+        return list;
+    }
+
+    private sealed class Counters
+    {
+        public int Open;
+        public int MaxPoolSize;
+    }
+}

--- a/Tharga.MongoDB/DatabaseMonitor.cs
+++ b/Tharga.MongoDB/DatabaseMonitor.cs
@@ -36,6 +36,7 @@ internal class DatabaseMonitor : IDatabaseMonitor
     private readonly System.Collections.Concurrent.ConcurrentDictionary<string, System.Collections.Concurrent.ConcurrentDictionary<string, bool>> _collectionSources = new();
     private readonly System.Collections.Concurrent.ConcurrentDictionary<string, string> _sourceToConnectionId = new();
     private readonly System.Collections.Concurrent.ConcurrentDictionary<string, RemoteQueueState> _remoteQueueStates = new();
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, IReadOnlyList<PoolMetricDto>> _remotePoolStates = new();
 
     public event EventHandler<CollectionInfoChangedEventArgs> CollectionInfoChangedEvent;
     public event EventHandler<CollectionDroppedEventArgs> CollectionDroppedEvent;
@@ -1017,6 +1018,8 @@ internal class DatabaseMonitor : IDatabaseMonitor
 
     public void IngestQueueMetric(string sourceName, int queueCount, int executingCount, double? waitTimeMs)
     {
+        // Legacy aggregate-per-source form. Keep the aggregate (drives GetMonitorClientDetail) and
+        // store it as a single synthetic pool so it still surfaces a line in GetPerPoolQueueState.
         _remoteQueueStates[sourceName] = new RemoteQueueState
         {
             QueueCount = queueCount,
@@ -1024,29 +1027,90 @@ internal class DatabaseMonitor : IDatabaseMonitor
             LastWaitTimeMs = waitTimeMs ?? 0,
             Timestamp = DateTime.UtcNow,
         };
+        _remotePoolStates[sourceName] = new[]
+        {
+            new PoolMetricDto
+            {
+                ServerKey = string.Empty,
+                ConfigurationNames = Array.Empty<string>(),
+                QueueCount = queueCount,
+                ExecutingCount = executingCount,
+                WaitTimeMs = waitTimeMs,
+            }
+        };
     }
 
-    public IReadOnlyDictionary<string, ConnectionPoolStateDto> GetPerSourceQueueState()
+    public void IngestQueueMetric(string sourceName, IReadOnlyList<PoolMetricDto> pools)
+    {
+        pools ??= Array.Empty<PoolMetricDto>();
+        _remotePoolStates[sourceName] = pools;
+        // Maintain the aggregate per-source view for GetMonitorClientDetail.
+        _remoteQueueStates[sourceName] = new RemoteQueueState
+        {
+            QueueCount = pools.Sum(p => p.QueueCount),
+            ExecutingCount = pools.Sum(p => p.ExecutingCount),
+            LastWaitTimeMs = pools.Count == 0 ? 0 : pools.Max(p => p.WaitTimeMs ?? 0),
+            Timestamp = DateTime.UtcNow,
+        };
+    }
+
+    public IReadOnlyDictionary<string, ConnectionPoolStateDto> GetPerPoolQueueState()
     {
         var result = new Dictionary<string, ConnectionPoolStateDto>();
 
-        // Local
         var localSource = _mongoDbServiceFactory.SourceName;
-        result[localSource] = GetConnectionPoolState();
+        var localPools = _queueMonitor.GetPerPoolState(); // reads + resets per-pool wait, so call once
 
-        // Remote
-        foreach (var (source, state) in _remoteQueueStates)
+        // Suffix labels with the source when more than one source actually contributes pools, to keep lines distinct.
+        var contributingSources = new HashSet<string>();
+        if (localPools.Count > 0) contributingSources.Add(localSource);
+        foreach (var (source, pools) in _remotePoolStates)
+            if (pools.Count > 0) contributingSources.Add(source);
+        var multiSource = contributingSources.Count > 1;
+
+        // Local — one entry per physical pool.
+        foreach (var pool in localPools)
         {
-            result[source] = new ConnectionPoolStateDto
+            var key = $"{localSource}::{pool.ServerKey}";
+            result[key] = new ConnectionPoolStateDto
             {
-                QueueCount = state.QueueCount,
-                ExecutingCount = state.ExecutingCount,
-                LastWaitTimeMs = state.LastWaitTimeMs,
+                QueueCount = pool.QueueCount,
+                ExecutingCount = pool.ExecutingCount,
+                LastWaitTimeMs = pool.LastWaitTimeMs,
                 RecentMetrics = [],
+                ConfigurationNames = pool.ConfigurationNames,
+                Label = BuildPoolLabel(pool.ConfigurationNames, pool.ServerKey, localSource, multiSource),
             };
         }
 
+        // Remote — one entry per reported pool.
+        foreach (var (source, pools) in _remotePoolStates)
+        {
+            foreach (var pool in pools)
+            {
+                var key = $"{source}::{pool.ServerKey}";
+                result[key] = new ConnectionPoolStateDto
+                {
+                    QueueCount = pool.QueueCount,
+                    ExecutingCount = pool.ExecutingCount,
+                    LastWaitTimeMs = pool.WaitTimeMs ?? 0,
+                    RecentMetrics = [],
+                    ConfigurationNames = pool.ConfigurationNames,
+                    Label = BuildPoolLabel(pool.ConfigurationNames, pool.ServerKey, source, multiSource),
+                };
+            }
+        }
+
         return result;
+    }
+
+    private static string BuildPoolLabel(IReadOnlyCollection<string> configurationNames, string serverKey, string source, bool multiSource)
+    {
+        var baseLabel = configurationNames is { Count: > 0 }
+            ? string.Join(", ", configurationNames.OrderBy(x => x, StringComparer.Ordinal))
+            : string.IsNullOrEmpty(serverKey) ? source : serverKey;
+
+        return multiSource ? $"{baseLabel} @ {source}" : baseLabel;
     }
 
     private record RemoteQueueState

--- a/Tharga.MongoDB/DatabaseMonitor.cs
+++ b/Tharga.MongoDB/DatabaseMonitor.cs
@@ -27,6 +27,7 @@ internal class DatabaseMonitor : IDatabaseMonitor
     private readonly DatabaseOptions _options;
     private readonly ICollectionCache _cache;
     private readonly IQueueMonitor _queueMonitor;
+    private readonly IConnectionPoolMonitor _connectionPoolMonitor;
     private Dictionary<(string, string), StatColInfo> _staticLookup;
     private Dictionary<string, DynColInfo> _dynamicLookup;
     private readonly SemaphoreSlim _lookupLock = new(1, 1);
@@ -43,7 +44,7 @@ internal class DatabaseMonitor : IDatabaseMonitor
     public event EventHandler<CollectionDroppedEventArgs> CollectionDroppedEvent;
     public event EventHandler MonitorClientsChanged;
 
-    public DatabaseMonitor(IMongoDbServiceFactory mongoDbServiceFactory, IMongoDbInstance mongoDbInstance, IServiceProvider serviceProvider, IRepositoryConfiguration repositoryConfiguration, ICollectionProvider collectionProvider, ICallLibrary callLibrary, ICollectionCache cache, IQueueMonitor queueMonitor, IOptions<DatabaseOptions> options, ILogger<DatabaseMonitor> logger)
+    public DatabaseMonitor(IMongoDbServiceFactory mongoDbServiceFactory, IMongoDbInstance mongoDbInstance, IServiceProvider serviceProvider, IRepositoryConfiguration repositoryConfiguration, ICollectionProvider collectionProvider, ICallLibrary callLibrary, ICollectionCache cache, IQueueMonitor queueMonitor, IConnectionPoolMonitor connectionPoolMonitor, IOptions<DatabaseOptions> options, ILogger<DatabaseMonitor> logger)
     {
         _mongoDbServiceFactory = mongoDbServiceFactory;
         _mongoDbInstance = mongoDbInstance;
@@ -53,6 +54,7 @@ internal class DatabaseMonitor : IDatabaseMonitor
         _callLibrary = callLibrary;
         _cache = cache;
         _queueMonitor = queueMonitor;
+        _connectionPoolMonitor = connectionPoolMonitor;
         _logger = logger;
         _options = options.Value;
     }
@@ -1120,6 +1122,66 @@ internal class DatabaseMonitor : IDatabaseMonitor
     }
 
     public IReadOnlyList<InFlightCallInfo> GetInFlightCalls() => _queueMonitor.GetInFlightCalls();
+
+    public IReadOnlyList<ClusterConnectionSummary> GetClusterConnectionSummary()
+    {
+        // Aggregate actual open connections + capacity per cluster (serverKey) across every source:
+        // this process's own pools plus all reporting agents.
+        var byCluster = new Dictionary<string, ClusterAccumulator>();
+
+        ClusterAccumulator Get(string serverKey)
+        {
+            if (!byCluster.TryGetValue(serverKey, out var acc))
+                byCluster[serverKey] = acc = new ClusterAccumulator();
+            return acc;
+        }
+
+        // Local — config-name labels come from the limiter's per-pool view (may be empty if no calls yet).
+        var localSource = _mongoDbServiceFactory.SourceName;
+        var localConfigByServer = _queueMonitor.GetPerPoolState()
+            .ToDictionary(p => p.ServerKey, p => p.ConfigurationNames);
+        foreach (var pool in _connectionPoolMonitor.GetSnapshot())
+        {
+            var acc = Get(pool.ServerKey);
+            acc.Open += pool.OpenConnections;
+            acc.Max += pool.MaxPoolSize;
+            acc.Sources.Add(localSource);
+            if (localConfigByServer.TryGetValue(pool.ServerKey, out var names))
+                foreach (var n in names) acc.ConfigurationNames.Add(n);
+        }
+
+        // Remote — each agent's reported per-pool connection counts.
+        foreach (var (source, pools) in _remotePoolStates)
+        {
+            foreach (var pool in pools)
+            {
+                var acc = Get(pool.ServerKey);
+                acc.Open += pool.OpenConnections;
+                acc.Max += pool.MaxPoolSize;
+                acc.Sources.Add(source);
+                foreach (var n in pool.ConfigurationNames) acc.ConfigurationNames.Add(n);
+            }
+        }
+
+        var limit = _options.Monitor.ClusterConnectionLimit;
+        return byCluster.Select(kvp => new ClusterConnectionSummary
+        {
+            ServerKey = kvp.Key,
+            ConfigurationNames = kvp.Value.ConfigurationNames.OrderBy(x => x, StringComparer.Ordinal).ToArray(),
+            SourceCount = kvp.Value.Sources.Count,
+            OpenConnections = kvp.Value.Open,
+            MaxConnections = kvp.Value.Max,
+            Limit = limit,
+        }).ToArray();
+    }
+
+    private sealed class ClusterAccumulator
+    {
+        public int Open;
+        public int Max;
+        public readonly HashSet<string> Sources = new();
+        public readonly HashSet<string> ConfigurationNames = new();
+    }
 
     private static string BuildPoolLabel(IReadOnlyCollection<string> configurationNames, string serverKey, string source, bool multiSource)
     {

--- a/Tharga.MongoDB/DatabaseMonitor.cs
+++ b/Tharga.MongoDB/DatabaseMonitor.cs
@@ -37,6 +37,7 @@ internal class DatabaseMonitor : IDatabaseMonitor
     private readonly System.Collections.Concurrent.ConcurrentDictionary<string, string> _sourceToConnectionId = new();
     private readonly System.Collections.Concurrent.ConcurrentDictionary<string, RemoteQueueState> _remoteQueueStates = new();
     private readonly System.Collections.Concurrent.ConcurrentDictionary<string, IReadOnlyList<PoolMetricDto>> _remotePoolStates = new();
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, MonitorClientStatus> _clientStatus = new();
 
     public event EventHandler<CollectionInfoChangedEventArgs> CollectionInfoChangedEvent;
     public event EventHandler<CollectionDroppedEventArgs> CollectionDroppedEvent;
@@ -860,7 +861,20 @@ internal class DatabaseMonitor : IDatabaseMonitor
 
     public IEnumerable<MonitorClientDto> GetMonitorClients()
     {
-        return _monitorClients.Values;
+        return _monitorClients.Values.Select(WithStatus);
+    }
+
+    public void IngestClientStatus(string sourceName, MonitorClientStatus status)
+    {
+        if (string.IsNullOrEmpty(sourceName) || status == null) return;
+        _clientStatus[sourceName] = status;
+    }
+
+    private MonitorClientDto WithStatus(MonitorClientDto client)
+    {
+        if (!string.IsNullOrEmpty(client.SourceName) && _clientStatus.TryGetValue(client.SourceName, out var status))
+            return client with { Status = status };
+        return client;
     }
 
     public IReadOnlyList<CollectionInfo> GetCollectionsWithFailedIndices()
@@ -887,6 +901,7 @@ internal class DatabaseMonitor : IDatabaseMonitor
 
         var client = _monitorClients.Values.FirstOrDefault(x => x.SourceName == sourceName);
         if (client == null) return null;
+        client = WithStatus(client);
 
         var collectionKeys = _collectionSources
             .Where(kvp => kvp.Value.ContainsKey(sourceName))

--- a/Tharga.MongoDB/DatabaseMonitor.cs
+++ b/Tharga.MongoDB/DatabaseMonitor.cs
@@ -1104,6 +1104,8 @@ internal class DatabaseMonitor : IDatabaseMonitor
         return result;
     }
 
+    public IReadOnlyList<InFlightCallInfo> GetInFlightCalls() => _queueMonitor.GetInFlightCalls();
+
     private static string BuildPoolLabel(IReadOnlyCollection<string> configurationNames, string serverKey, string source, bool multiSource)
     {
         var baseLabel = configurationNames is { Count: > 0 }

--- a/Tharga.MongoDB/DatabaseNullMonitor.cs
+++ b/Tharga.MongoDB/DatabaseNullMonitor.cs
@@ -106,6 +106,8 @@ internal class DatabaseNullMonitor : IDatabaseMonitor
 
     public void IngestClientConnected(MonitorClientDto client) { }
 
+    public void IngestClientStatus(string sourceName, MonitorClientStatus status) { }
+
     public void IngestClientDisconnected(string connectionId) { }
 
     public void IngestCollectionInfo(RemoteCollectionInfoDto collectionInfo, string connectionId = null) { }

--- a/Tharga.MongoDB/DatabaseNullMonitor.cs
+++ b/Tharga.MongoDB/DatabaseNullMonitor.cs
@@ -122,6 +122,8 @@ internal class DatabaseNullMonitor : IDatabaseMonitor
 
     public IReadOnlyDictionary<string, ConnectionPoolStateDto> GetPerPoolQueueState() => new Dictionary<string, ConnectionPoolStateDto>();
 
+    public IReadOnlyList<InFlightCallInfo> GetInFlightCalls() => Array.Empty<InFlightCallInfo>();
+
     public void ResetCalls() { }
 
     public Task ResetAsync() => Task.CompletedTask;

--- a/Tharga.MongoDB/DatabaseNullMonitor.cs
+++ b/Tharga.MongoDB/DatabaseNullMonitor.cs
@@ -118,7 +118,9 @@ internal class DatabaseNullMonitor : IDatabaseMonitor
 
     public void IngestQueueMetric(string sourceName, int queueCount, int executingCount, double? waitTimeMs) { }
 
-    public IReadOnlyDictionary<string, ConnectionPoolStateDto> GetPerSourceQueueState() => new Dictionary<string, ConnectionPoolStateDto>();
+    public void IngestQueueMetric(string sourceName, IReadOnlyList<PoolMetricDto> pools) { }
+
+    public IReadOnlyDictionary<string, ConnectionPoolStateDto> GetPerPoolQueueState() => new Dictionary<string, ConnectionPoolStateDto>();
 
     public void ResetCalls() { }
 

--- a/Tharga.MongoDB/DatabaseNullMonitor.cs
+++ b/Tharga.MongoDB/DatabaseNullMonitor.cs
@@ -126,6 +126,8 @@ internal class DatabaseNullMonitor : IDatabaseMonitor
 
     public IReadOnlyList<InFlightCallInfo> GetInFlightCalls() => Array.Empty<InFlightCallInfo>();
 
+    public IReadOnlyList<ClusterConnectionSummary> GetClusterConnectionSummary() => Array.Empty<ClusterConnectionSummary>();
+
     public void ResetCalls() { }
 
     public Task ResetAsync() => Task.CompletedTask;

--- a/Tharga.MongoDB/Disk/DiskRepositoryCollectionBase.cs
+++ b/Tharga.MongoDB/Disk/DiskRepositoryCollectionBase.cs
@@ -142,7 +142,7 @@ public abstract class DiskRepositoryCollectionBase<TEntity, TKey> : RepositoryCo
                 if (operation == Operation.Delete && session == null) await DropEmptyAsync(collection);
 
                 return response;
-            }, _mongoDbService.GetServerKey(), _mongoDbService.GetConfigurationName(), _mongoDbService.GetMaxConnectionPoolSize(), cancellationToken);
+            }, _mongoDbService.GetServerKey(), _mongoDbService.GetMaxConnectionPoolSize(), BuildCallContext(callKey, functionName, operation, filter), cancellationToken);
 
             count = response.Result.Count;
             return response.Result.Data;
@@ -208,6 +208,37 @@ public abstract class DiskRepositoryCollectionBase<TEntity, TKey> : RepositoryCo
         {
             Timestamp = Stopwatch.GetTimestamp(),
             Step = nameof(FireCallStartEvent)
+        };
+    }
+
+    // Metadata handed to the limiter so it can report what is queued vs executing. The filter renders lazily
+    // (only when in-flight calls are inspected, e.g. via MCP) using the default serializer registry, so it is
+    // available while the call is still queued — without touching the collection.
+    private ExecuteCallContext BuildCallContext(Guid callKey, string functionName, Operation operation, FilterDefinition<TEntity> filter)
+    {
+        return new ExecuteCallContext
+        {
+            CallKey = callKey,
+            ConfigurationName = ConfigurationName ?? Constants.DefaultConfigurationName,
+            DatabaseName = DatabaseName,
+            CollectionName = CollectionName,
+            FunctionName = functionName,
+            Operation = operation,
+            FilterProvider = BuildQueuedFilterProvider(filter),
+        };
+    }
+
+    private static Func<string> BuildQueuedFilterProvider(FilterDefinition<TEntity> filter)
+    {
+        if (filter == null) return null;
+        return () =>
+        {
+            try
+            {
+                var serializer = BsonSerializer.LookupSerializer<TEntity>();
+                return filter.Render(new RenderArgs<TEntity>(serializer, BsonSerializer.SerializerRegistry)).ToJson();
+            }
+            catch { return null; }
         };
     }
 
@@ -1083,7 +1114,7 @@ public abstract class DiskRepositoryCollectionBase<TEntity, TKey> : RepositoryCo
         {
             try
             {
-                var setup = await OpenCursorWithinLimiterAsync(queryFactory, filterForObservability, steps, cancellationToken);
+                var setup = await OpenCursorWithinLimiterAsync(queryFactory, filterForObservability, steps, callKey, functionName, cancellationToken);
                 cursor = setup.Cursor;
                 collection = setup.Collection;
                 filterJsonProvider = setup.FilterJsonProvider;
@@ -1101,7 +1132,7 @@ public abstract class DiskRepositoryCollectionBase<TEntity, TKey> : RepositoryCo
                 bool hasMore;
                 try
                 {
-                    hasMore = await MoveNextWithinLimiterAsync(cursor, cancellationToken);
+                    hasMore = await MoveNextWithinLimiterAsync(cursor, callKey, functionName, cancellationToken);
                 }
                 catch (Exception e)
                 {
@@ -1157,6 +1188,8 @@ public abstract class DiskRepositoryCollectionBase<TEntity, TKey> : RepositoryCo
         Func<IMongoCollection<TEntity>, CancellationToken, Task<IAsyncCursor<T>>> queryFactory,
         FilterDefinition<TEntity> filterForObservability,
         List<StepResponse> steps,
+        Guid callKey,
+        string functionName,
         CancellationToken cancellationToken)
     {
         Func<string> filterJsonProvider = null;
@@ -1214,14 +1247,14 @@ public abstract class DiskRepositoryCollectionBase<TEntity, TKey> : RepositoryCo
             steps.Add(new StepResponse { Timestamp = openEndTimestamp, Step = "OpenCursor", Message = openMessage });
 
             return (cur, c);
-        }, _mongoDbService.GetServerKey(), _mongoDbService.GetConfigurationName(), _mongoDbService.GetMaxConnectionPoolSize(), cancellationToken);
+        }, _mongoDbService.GetServerKey(), _mongoDbService.GetMaxConnectionPoolSize(), BuildCallContext(callKey, functionName, Operation.Read, filterForObservability), cancellationToken);
 
         return (response.Result.cur, response.Result.c, filterJsonProvider, explainProvider);
     }
 
-    private async Task<bool> MoveNextWithinLimiterAsync<T>(IAsyncCursor<T> cursor, CancellationToken cancellationToken)
+    private async Task<bool> MoveNextWithinLimiterAsync<T>(IAsyncCursor<T> cursor, Guid callKey, string functionName, CancellationToken cancellationToken)
     {
-        var response = await _databaseExecutor.ExecuteAsync(ct => cursor.MoveNextAsync(ct), _mongoDbService.GetServerKey(), _mongoDbService.GetConfigurationName(), _mongoDbService.GetMaxConnectionPoolSize(), cancellationToken);
+        var response = await _databaseExecutor.ExecuteAsync(ct => cursor.MoveNextAsync(ct), _mongoDbService.GetServerKey(), _mongoDbService.GetMaxConnectionPoolSize(), BuildCallContext(callKey, functionName, Operation.Read, null), cancellationToken);
         return response.Result;
     }
 

--- a/Tharga.MongoDB/Disk/DiskRepositoryCollectionBase.cs
+++ b/Tharga.MongoDB/Disk/DiskRepositoryCollectionBase.cs
@@ -142,7 +142,7 @@ public abstract class DiskRepositoryCollectionBase<TEntity, TKey> : RepositoryCo
                 if (operation == Operation.Delete && session == null) await DropEmptyAsync(collection);
 
                 return response;
-            }, _mongoDbService.GetServerKey(), _mongoDbService.GetMaxConnectionPoolSize(), cancellationToken);
+            }, _mongoDbService.GetServerKey(), _mongoDbService.GetConfigurationName(), _mongoDbService.GetMaxConnectionPoolSize(), cancellationToken);
 
             count = response.Result.Count;
             return response.Result.Data;
@@ -1214,14 +1214,14 @@ public abstract class DiskRepositoryCollectionBase<TEntity, TKey> : RepositoryCo
             steps.Add(new StepResponse { Timestamp = openEndTimestamp, Step = "OpenCursor", Message = openMessage });
 
             return (cur, c);
-        }, _mongoDbService.GetServerKey(), _mongoDbService.GetMaxConnectionPoolSize(), cancellationToken);
+        }, _mongoDbService.GetServerKey(), _mongoDbService.GetConfigurationName(), _mongoDbService.GetMaxConnectionPoolSize(), cancellationToken);
 
         return (response.Result.cur, response.Result.c, filterJsonProvider, explainProvider);
     }
 
     private async Task<bool> MoveNextWithinLimiterAsync<T>(IAsyncCursor<T> cursor, CancellationToken cancellationToken)
     {
-        var response = await _databaseExecutor.ExecuteAsync(ct => cursor.MoveNextAsync(ct), _mongoDbService.GetServerKey(), _mongoDbService.GetMaxConnectionPoolSize(), cancellationToken);
+        var response = await _databaseExecutor.ExecuteAsync(ct => cursor.MoveNextAsync(ct), _mongoDbService.GetServerKey(), _mongoDbService.GetConfigurationName(), _mongoDbService.GetMaxConnectionPoolSize(), cancellationToken);
         return response.Result;
     }
 

--- a/Tharga.MongoDB/ExecuteLimiter.cs
+++ b/Tharga.MongoDB/ExecuteLimiter.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Tharga.MongoDB.Disk;
 
 namespace Tharga.MongoDB;
 
@@ -22,6 +23,9 @@ internal class ExecuteLimiter : IExecuteLimiter, IQueueMonitor
     private readonly ConcurrentDictionary<string, bool> _warnedServerKeys = new();
     private readonly ConcurrentQueue<QueueMetricEventArgs> _metrics = new();
 
+    // Calls currently held by the limiter (queued or executing), for on-demand diagnostics.
+    private readonly ConcurrentDictionary<Guid, TrackedCall> _inFlight = new();
+
     // Atomic state for polling
     private int _totalQueueCount;
     private int _totalExecutingCount;
@@ -36,7 +40,7 @@ internal class ExecuteLimiter : IExecuteLimiter, IQueueMonitor
         _maxConcurrentOverride = options.Value.MaxConcurrent;
     }
 
-    public async Task<(T Result, ExecuteInfo Info)> ExecuteAsync<T>(Func<CancellationToken, Task<T>> action, string serverKey, string configurationName, int maxConnectionPoolSize, CancellationToken cancellationToken)
+    public async Task<(T Result, ExecuteInfo Info)> ExecuteAsync<T>(Func<CancellationToken, Task<T>> action, string serverKey, int maxConnectionPoolSize, ExecuteCallContext context, CancellationToken cancellationToken)
     {
         if (!_enabled)
         {
@@ -56,9 +60,10 @@ internal class ExecuteLimiter : IExecuteLimiter, IQueueMonitor
         }
 
         var state = _states.GetOrAdd(serverKey, _ => new PerPoolState(maxConcurrent));
-        state.TagConfiguration(configurationName);
+        state.TagConfiguration(context?.ConfigurationName);
 
         var queuedAt = Stopwatch.GetTimestamp();
+        var tracked = TrackInFlight(serverKey, context);
 
         // Mark as queued (waiting to acquire a slot)
         var queuedCount = state.IncrementQueued();
@@ -87,6 +92,7 @@ internal class ExecuteLimiter : IExecuteLimiter, IQueueMonitor
             Interlocked.Decrement(ref _totalQueueCount);
 
             // Now executing
+            tracked?.MarkExecuting();
             var executingCount = state.IncrementExecuting();
             Interlocked.Increment(ref _totalExecutingCount);
             LogCount("ExecuteConcurrent", executingCount);
@@ -141,6 +147,10 @@ internal class ExecuteLimiter : IExecuteLimiter, IQueueMonitor
 
             throw;
         }
+        finally
+        {
+            UntrackInFlight(tracked);
+        }
     }
 
     public IReadOnlyList<QueueMetricEventArgs> GetRecentMetrics()
@@ -173,6 +183,49 @@ internal class ExecuteLimiter : IExecuteLimiter, IQueueMonitor
             });
         }
         return result;
+    }
+
+    public IReadOnlyList<InFlightCallInfo> GetInFlightCalls()
+    {
+        var result = new List<InFlightCallInfo>(_inFlight.Count);
+        foreach (var (_, call) in _inFlight)
+        {
+            result.Add(new InFlightCallInfo
+            {
+                CallKey = call.CallKey,
+                ServerKey = call.ServerKey,
+                ConfigurationName = call.ConfigurationName,
+                DatabaseName = call.DatabaseName,
+                CollectionName = call.CollectionName,
+                FunctionName = call.FunctionName,
+                Operation = call.Operation,
+                IsExecuting = call.IsExecuting,
+                EnqueuedUtc = call.EnqueuedUtc,
+                Filter = RenderFilter(call.FilterProvider), // rendered here (diagnostics path), never on the hot path
+            });
+        }
+        return result;
+    }
+
+    private TrackedCall TrackInFlight(string serverKey, ExecuteCallContext context)
+    {
+        if (context == null || context.CallKey == Guid.Empty) return null;
+
+        var tracked = new TrackedCall(serverKey, context);
+        _inFlight[context.CallKey] = tracked;
+        return tracked;
+    }
+
+    private void UntrackInFlight(TrackedCall tracked)
+    {
+        if (tracked != null) _inFlight.TryRemove(tracked.CallKey, out _);
+    }
+
+    private static string RenderFilter(Func<string> provider)
+    {
+        if (provider == null) return null;
+        try { return provider(); }
+        catch { return null; }
     }
 
     private void RecordMetric(int queueCount, int executingCount, TimeSpan? waitTime)
@@ -250,5 +303,36 @@ internal class ExecuteLimiter : IExecuteLimiter, IQueueMonitor
         }
 
         public double GetAndResetWait() => Interlocked.Exchange(ref _lastWaitTimeMs, 0);
+    }
+
+    private sealed class TrackedCall
+    {
+        private int _executing;
+
+        public TrackedCall(string serverKey, ExecuteCallContext context)
+        {
+            ServerKey = serverKey;
+            CallKey = context.CallKey;
+            ConfigurationName = context.ConfigurationName;
+            DatabaseName = context.DatabaseName;
+            CollectionName = context.CollectionName;
+            FunctionName = context.FunctionName;
+            Operation = context.Operation;
+            FilterProvider = context.FilterProvider;
+            EnqueuedUtc = DateTime.UtcNow;
+        }
+
+        public Guid CallKey { get; }
+        public string ServerKey { get; }
+        public string ConfigurationName { get; }
+        public string DatabaseName { get; }
+        public string CollectionName { get; }
+        public string FunctionName { get; }
+        public Operation Operation { get; }
+        public Func<string> FilterProvider { get; }
+        public DateTime EnqueuedUtc { get; }
+
+        public bool IsExecuting => Volatile.Read(ref _executing) == 1;
+        public void MarkExecuting() => Interlocked.Exchange(ref _executing, 1);
     }
 }

--- a/Tharga.MongoDB/ExecuteLimiter.cs
+++ b/Tharga.MongoDB/ExecuteLimiter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -35,7 +36,7 @@ internal class ExecuteLimiter : IExecuteLimiter, IQueueMonitor
         _maxConcurrentOverride = options.Value.MaxConcurrent;
     }
 
-    public async Task<(T Result, ExecuteInfo Info)> ExecuteAsync<T>(Func<CancellationToken, Task<T>> action, string serverKey, int maxConnectionPoolSize, CancellationToken cancellationToken)
+    public async Task<(T Result, ExecuteInfo Info)> ExecuteAsync<T>(Func<CancellationToken, Task<T>> action, string serverKey, string configurationName, int maxConnectionPoolSize, CancellationToken cancellationToken)
     {
         if (!_enabled)
         {
@@ -55,6 +56,7 @@ internal class ExecuteLimiter : IExecuteLimiter, IQueueMonitor
         }
 
         var state = _states.GetOrAdd(serverKey, _ => new PerPoolState(maxConcurrent));
+        state.TagConfiguration(configurationName);
 
         var queuedAt = Stopwatch.GetTimestamp();
 
@@ -104,6 +106,7 @@ internal class ExecuteLimiter : IExecuteLimiter, IQueueMonitor
                 if (Interlocked.CompareExchange(ref _lastWaitTimeMs, waitMs, current) == current) break;
                 spin.SpinOnce();
             }
+            state.RecordWait(waitMs);
 
             RecordMetric(state.GetQueued(), executingCount, queueElapsed);
 
@@ -155,6 +158,23 @@ internal class ExecuteLimiter : IExecuteLimiter, IQueueMonitor
         );
     }
 
+    public IReadOnlyList<PoolQueueState> GetPerPoolState()
+    {
+        var result = new List<PoolQueueState>(_states.Count);
+        foreach (var (serverKey, state) in _states)
+        {
+            result.Add(new PoolQueueState
+            {
+                ServerKey = serverKey,
+                ConfigurationNames = state.GetConfigurations(),
+                QueueCount = state.GetQueued(),
+                ExecutingCount = state.GetExecuting(),
+                LastWaitTimeMs = state.GetAndResetWait(),
+            });
+        }
+        return result;
+    }
+
     private void RecordMetric(int queueCount, int executingCount, TimeSpan? waitTime)
     {
         var metric = new QueueMetricEventArgs
@@ -191,6 +211,8 @@ internal class ExecuteLimiter : IExecuteLimiter, IQueueMonitor
 
         private int _queued;
         private int _executing;
+        private double _lastWaitTimeMs;
+        private readonly ConcurrentDictionary<string, bool> _configurationNames = new();
 
         public PerPoolState(int maxConcurrent)
         {
@@ -204,5 +226,29 @@ internal class ExecuteLimiter : IExecuteLimiter, IQueueMonitor
         public int IncrementExecuting() => Interlocked.Increment(ref _executing);
         public int DecrementExecuting() => Interlocked.Decrement(ref _executing);
         public int GetExecuting() => Volatile.Read(ref _executing);
+
+        public void TagConfiguration(string configurationName)
+        {
+            if (!string.IsNullOrEmpty(configurationName))
+                _configurationNames.TryAdd(configurationName, true);
+        }
+
+        public IReadOnlyCollection<string> GetConfigurations() => _configurationNames.Keys.ToArray();
+
+        // Track the wait-time high-water mark since the last read (take the max, reset on read),
+        // mirroring the global _lastWaitTimeMs semantics.
+        public void RecordWait(double waitMs)
+        {
+            SpinWait spin = default;
+            while (true)
+            {
+                var current = Volatile.Read(ref _lastWaitTimeMs);
+                if (waitMs <= current) break;
+                if (Interlocked.CompareExchange(ref _lastWaitTimeMs, waitMs, current) == current) break;
+                spin.SpinOnce();
+            }
+        }
+
+        public double GetAndResetWait() => Interlocked.Exchange(ref _lastWaitTimeMs, 0);
     }
 }

--- a/Tharga.MongoDB/IConnectionPoolMonitor.cs
+++ b/Tharga.MongoDB/IConnectionPoolMonitor.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+
+namespace Tharga.MongoDB;
+
+/// <summary>
+/// Tracks the actual MongoDB driver connection pool size per cluster (server-key) for this process —
+/// the real open-connection count that counts toward a cluster's connection limit (e.g. Atlas max connections).
+/// Fed by driver connection-pool events; far more accurate than the limiter's in-use count, which ignores
+/// idle-but-open pooled connections.
+/// </summary>
+public interface IConnectionPoolMonitor
+{
+    void OnConnectionCreated(string serverKey);
+    void OnConnectionClosed(string serverKey);
+    void SetMaxPoolSize(string serverKey, int maxPoolSize);
+    IReadOnlyList<ConnectionPoolCount> GetSnapshot();
+}
+
+/// <summary>Open-connection count and configured ceiling for one cluster pool in this process.</summary>
+public record ConnectionPoolCount
+{
+    public required string ServerKey { get; init; }
+    public required int OpenConnections { get; init; }
+    public required int MaxPoolSize { get; init; }
+}

--- a/Tharga.MongoDB/IDatabaseMonitor.cs
+++ b/Tharga.MongoDB/IDatabaseMonitor.cs
@@ -140,6 +140,11 @@ public interface IDatabaseMonitor
     void IngestClientConnected(MonitorClientDto client);
 
     /// <summary>
+    /// Record an agent's self-reported configuration (call forwarding, queue interval, …), correlated by source name.
+    /// </summary>
+    void IngestClientStatus(string sourceName, MonitorClientStatus status);
+
+    /// <summary>
     /// Mark a monitoring agent as disconnected.
     /// </summary>
     void IngestClientDisconnected(string connectionId);

--- a/Tharga.MongoDB/IDatabaseMonitor.cs
+++ b/Tharga.MongoDB/IDatabaseMonitor.cs
@@ -194,4 +194,10 @@ public interface IDatabaseMonitor
     /// Remote agents are not aggregated here; query each agent's own monitor for its in-flight calls.
     /// </summary>
     IReadOnlyList<InFlightCallInfo> GetInFlightCalls();
+
+    /// <summary>
+    /// Per-cluster open-connection totals (and capacity) aggregated across this server and all connected
+    /// agents, for comparing against a cluster's connection limit (e.g. Atlas max connections).
+    /// </summary>
+    IReadOnlyList<ClusterConnectionSummary> GetClusterConnectionSummary();
 }

--- a/Tharga.MongoDB/IDatabaseMonitor.cs
+++ b/Tharga.MongoDB/IDatabaseMonitor.cs
@@ -183,4 +183,10 @@ public interface IDatabaseMonitor
     /// (the configuration name(s) routing through that pool).
     /// </summary>
     IReadOnlyDictionary<string, ConnectionPoolStateDto> GetPerPoolQueueState();
+
+    /// <summary>
+    /// The calls the local limiter is currently holding (queued or executing) — for diagnosing a flood.
+    /// Remote agents are not aggregated here; query each agent's own monitor for its in-flight calls.
+    /// </summary>
+    IReadOnlyList<InFlightCallInfo> GetInFlightCalls();
 }

--- a/Tharga.MongoDB/IDatabaseMonitor.cs
+++ b/Tharga.MongoDB/IDatabaseMonitor.cs
@@ -167,12 +167,20 @@ public interface IDatabaseMonitor
     IReadOnlyDictionary<string, int> GetSubscriptions();
 
     /// <summary>
-    /// Ingest a queue metric snapshot from a remote agent.
+    /// Ingest a queue metric snapshot from a remote agent (legacy, aggregate-per-source form).
+    /// Stored as a single synthetic pool so pre-per-pool agents still surface a line.
     /// </summary>
     void IngestQueueMetric(string sourceName, int queueCount, int executingCount, double? waitTimeMs);
 
     /// <summary>
-    /// Get per-source queue state for all known sources (local + remote).
+    /// Ingest a per-pool queue metric snapshot from a remote agent.
     /// </summary>
-    IReadOnlyDictionary<string, ConnectionPoolStateDto> GetPerSourceQueueState();
+    void IngestQueueMetric(string sourceName, IReadOnlyList<PoolMetricDto> pools);
+
+    /// <summary>
+    /// Get per-connection-pool queue state for all known sources (local + remote). Keyed by a unique
+    /// <c>"{source}::{serverKey}"</c> key; each value carries a display <see cref="ConnectionPoolStateDto.Label"/>
+    /// (the configuration name(s) routing through that pool).
+    /// </summary>
+    IReadOnlyDictionary<string, ConnectionPoolStateDto> GetPerPoolQueueState();
 }

--- a/Tharga.MongoDB/IExecuteLimiter.cs
+++ b/Tharga.MongoDB/IExecuteLimiter.cs
@@ -1,10 +1,28 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Tharga.MongoDB.Disk;
 
 namespace Tharga.MongoDB;
 
 internal interface IExecuteLimiter
 {
-    Task<(T Result, ExecuteInfo Info)> ExecuteAsync<T>(Func<CancellationToken, Task<T>> action, string serverKey, string configurationName, int maxConnectionPoolSize, CancellationToken cancellationToken = default);
+    Task<(T Result, ExecuteInfo Info)> ExecuteAsync<T>(Func<CancellationToken, Task<T>> action, string serverKey, int maxConnectionPoolSize, ExecuteCallContext context, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Lightweight metadata about a call entering the limiter, so the limiter can report what is actually
+/// queued vs executing (per-pool) for diagnostics. Carries a <see cref="FilterProvider"/> that renders the
+/// query filter lazily — it is only invoked when someone inspects the in-flight calls (e.g. via MCP), never
+/// on the execution hot path.
+/// </summary>
+internal sealed class ExecuteCallContext
+{
+    public Guid CallKey { get; init; }
+    public string ConfigurationName { get; init; }
+    public string DatabaseName { get; init; }
+    public string CollectionName { get; init; }
+    public string FunctionName { get; init; }
+    public Operation Operation { get; init; }
+    public Func<string> FilterProvider { get; init; }
 }

--- a/Tharga.MongoDB/IExecuteLimiter.cs
+++ b/Tharga.MongoDB/IExecuteLimiter.cs
@@ -6,5 +6,5 @@ namespace Tharga.MongoDB;
 
 internal interface IExecuteLimiter
 {
-    Task<(T Result, ExecuteInfo Info)> ExecuteAsync<T>(Func<CancellationToken, Task<T>> action, string serverKey, int maxConnectionPoolSize, CancellationToken cancellationToken = default);
+    Task<(T Result, ExecuteInfo Info)> ExecuteAsync<T>(Func<CancellationToken, Task<T>> action, string serverKey, string configurationName, int maxConnectionPoolSize, CancellationToken cancellationToken = default);
 }

--- a/Tharga.MongoDB/IQueueMonitor.cs
+++ b/Tharga.MongoDB/IQueueMonitor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Tharga.MongoDB.Disk;
 
 namespace Tharga.MongoDB;
 
@@ -14,6 +15,36 @@ public interface IQueueMonitor
     /// carrying the configuration name(s) that have used it. Reading resets the per-pool wait-time high-water mark.
     /// </summary>
     IReadOnlyList<PoolQueueState> GetPerPoolState();
+
+    /// <summary>
+    /// The calls currently in the limiter — both queued (waiting for a pool slot) and executing. Intended for
+    /// on-demand diagnostics (e.g. via MCP): the query filter, if any, is rendered while building this list, not
+    /// on the execution path. Empty when the limiter is disabled.
+    /// </summary>
+    IReadOnlyList<InFlightCallInfo> GetInFlightCalls();
+}
+
+/// <summary>
+/// A single call currently held by the limiter — either queued (waiting for a connection-pool slot) or executing.
+/// </summary>
+public record InFlightCallInfo
+{
+    public required Guid CallKey { get; init; }
+    public required string ServerKey { get; init; }
+    public string ConfigurationName { get; init; }
+    public string DatabaseName { get; init; }
+    public string CollectionName { get; init; }
+    public string FunctionName { get; init; }
+    public Operation Operation { get; init; }
+
+    /// <summary>True once the call has acquired a pool slot and is running; false while still queued.</summary>
+    public required bool IsExecuting { get; init; }
+
+    /// <summary>When the call entered the limiter (UTC).</summary>
+    public required DateTime EnqueuedUtc { get; init; }
+
+    /// <summary>The rendered query filter, if one was supplied and could be rendered; otherwise null.</summary>
+    public string Filter { get; init; }
 }
 
 /// <summary>

--- a/Tharga.MongoDB/IQueueMonitor.cs
+++ b/Tharga.MongoDB/IQueueMonitor.cs
@@ -8,4 +8,24 @@ public interface IQueueMonitor
     event EventHandler<QueueMetricEventArgs> QueueMetricEvent;
     IReadOnlyList<QueueMetricEventArgs> GetRecentMetrics();
     (int QueueCount, int ExecutingCount, double LastWaitTimeMs) GetCurrentState();
+
+    /// <summary>
+    /// Per-connection-pool queue state. Each entry is one physical pool (keyed by <see cref="PoolQueueState.ServerKey"/>),
+    /// carrying the configuration name(s) that have used it. Reading resets the per-pool wait-time high-water mark.
+    /// </summary>
+    IReadOnlyList<PoolQueueState> GetPerPoolState();
+}
+
+/// <summary>
+/// A snapshot of one connection pool's queue state. The pool is the real unit of concurrency contention
+/// (one <c>MongoClient</c>/pool per server-key); <see cref="ConfigurationNames"/> are the named configurations
+/// that route through it.
+/// </summary>
+public record PoolQueueState
+{
+    public required string ServerKey { get; init; }
+    public required IReadOnlyCollection<string> ConfigurationNames { get; init; }
+    public required int QueueCount { get; init; }
+    public required int ExecutingCount { get; init; }
+    public required double LastWaitTimeMs { get; init; }
 }

--- a/Tharga.MongoDB/Internals/MongoDbClientProvider.cs
+++ b/Tharga.MongoDB/Internals/MongoDbClientProvider.cs
@@ -12,10 +12,12 @@ internal class MongoDbClientProvider : IMongoDbClientProvider
 {
     private readonly ConcurrentDictionary<string, Lazy<MongoClient>> _cache = new();
     private readonly CommandMonitorService _commandMonitor;
+    private readonly IConnectionPoolMonitor _connectionPoolMonitor;
 
-    public MongoDbClientProvider(CommandMonitorService commandMonitor = null)
+    public MongoDbClientProvider(CommandMonitorService commandMonitor = null, IConnectionPoolMonitor connectionPoolMonitor = null)
     {
         _commandMonitor = commandMonitor;
+        _connectionPoolMonitor = connectionPoolMonitor;
     }
 
     public MongoClient GetClient(MongoUrl mongoUrl)
@@ -30,12 +32,24 @@ internal class MongoDbClientProvider : IMongoDbClientProvider
                     ? TimeSpan.FromSeconds(5)
                     : TimeSpan.FromSeconds(10);
 
-                if (_commandMonitor != null)
+                _connectionPoolMonitor?.SetMaxPoolSize(key, settings.MaxConnectionPoolSize);
+
+                if (_commandMonitor != null || _connectionPoolMonitor != null)
                 {
                     settings.ClusterConfigurator = cb =>
                     {
-                        cb.Subscribe<CommandSucceededEvent>(e => _commandMonitor.OnCommandSucceeded(e));
-                        cb.Subscribe<CommandFailedEvent>(e => _commandMonitor.OnCommandFailed(e));
+                        if (_commandMonitor != null)
+                        {
+                            cb.Subscribe<CommandSucceededEvent>(e => _commandMonitor.OnCommandSucceeded(e));
+                            cb.Subscribe<CommandFailedEvent>(e => _commandMonitor.OnCommandFailed(e));
+                        }
+
+                        if (_connectionPoolMonitor != null)
+                        {
+                            // Count actual open pooled connections for this cluster (CMAP create/close events).
+                            cb.Subscribe<ConnectionCreatedEvent>(_ => _connectionPoolMonitor.OnConnectionCreated(key));
+                            cb.Subscribe<ConnectionClosedEvent>(_ => _connectionPoolMonitor.OnConnectionClosed(key));
+                        }
                     };
                 }
 

--- a/Tharga.MongoDB/MongoDbRegistrationExtensions.cs
+++ b/Tharga.MongoDB/MongoDbRegistrationExtensions.cs
@@ -73,16 +73,19 @@ public static class MongoDbRegistrationExtensions
         services.AddHttpClient(Atlas.AtlasTokenService.HttpClientName);
         services.AddSingleton<Atlas.IAtlasTokenService, Atlas.AtlasTokenService>();
         services.AddTransient<IMongoDbFirewallService, MongoDbFirewallService>();
+        services.AddSingleton<ConnectionPoolMonitor>();
+        services.AddSingleton<IConnectionPoolMonitor>(sp => sp.GetRequiredService<ConnectionPoolMonitor>());
         if (o.Monitor?.EnableCommandMonitoring == true)
         {
             services.AddSingleton<CommandMonitorService>();
             services.AddSingleton<ICommandMonitorService>(sp => sp.GetRequiredService<CommandMonitorService>());
             services.AddSingleton<IMongoDbClientProvider>(sp =>
-                new MongoDbClientProvider(sp.GetRequiredService<CommandMonitorService>()));
+                new MongoDbClientProvider(sp.GetRequiredService<CommandMonitorService>(), sp.GetRequiredService<IConnectionPoolMonitor>()));
         }
         else
         {
-            services.AddSingleton<IMongoDbClientProvider>(new MongoDbClientProvider());
+            services.AddSingleton<IMongoDbClientProvider>(sp =>
+                new MongoDbClientProvider(connectionPoolMonitor: sp.GetRequiredService<IConnectionPoolMonitor>()));
         }
         services.AddSingleton<IMongoDbFirewallStateService, MongoDbFirewallStateService>();
         services.AddHttpClient(Atlas.Quilt4NetFirewallProxyClient.HttpClientName);

--- a/Tharga.MongoDB/MonitorClientDto.cs
+++ b/Tharga.MongoDB/MonitorClientDto.cs
@@ -24,4 +24,28 @@ public record MonitorClientDto
     /// supply a name.
     /// </summary>
     public string AuthKeyName { get; init; }
+
+    /// <summary>
+    /// The agent's reported monitor configuration (call forwarding, queue interval, …). <c>null</c> until the
+    /// agent reports it, or for agents on a version that predates status reporting.
+    /// </summary>
+    public MonitorClientStatus Status { get; init; }
+}
+
+/// <summary>
+/// The forwarding-related configuration an agent reports about itself, surfaced on the Clients page.
+/// </summary>
+public record MonitorClientStatus
+{
+    /// <summary>Whether the agent forwards every completed call (off by default — can be a large stream).</summary>
+    public required bool ForwardCompletedCalls { get; init; }
+
+    /// <summary>How often the agent forwards a queue-state snapshot, in milliseconds.</summary>
+    public required int QueueMetricIntervalMs { get; init; }
+
+    /// <summary>Where the agent persists its monitor state (e.g. Database / Memory).</summary>
+    public string StorageMode { get; init; }
+
+    /// <summary>Whether the agent captures MongoDB driver command durations.</summary>
+    public bool EnableCommandMonitoring { get; init; }
 }

--- a/Tharga.MongoDB/MonitorDto.cs
+++ b/Tharga.MongoDB/MonitorDto.cs
@@ -106,6 +106,35 @@ public record PoolMetricDto
     public required int QueueCount { get; init; }
     public required int ExecutingCount { get; init; }
     public double? WaitTimeMs { get; init; }
+
+    /// <summary>Actual open driver connections for this pool (counts toward the cluster connection limit).</summary>
+    public int OpenConnections { get; init; }
+
+    /// <summary>Configured max pool size for this pool (capacity ceiling).</summary>
+    public int MaxPoolSize { get; init; }
+}
+
+/// <summary>
+/// Aggregated connection usage for one cluster (server-key) across all reporting sources (the central
+/// server plus every connected agent). Lets you see total open connections versus a configured limit
+/// (e.g. an Atlas cluster's max connections).
+/// </summary>
+public record ClusterConnectionSummary
+{
+    public required string ServerKey { get; init; }
+    public required IReadOnlyCollection<string> ConfigurationNames { get; init; }
+
+    /// <summary>Number of distinct sources (processes) contributing connections to this cluster.</summary>
+    public required int SourceCount { get; init; }
+
+    /// <summary>Total actual open connections across all sources right now.</summary>
+    public required int OpenConnections { get; init; }
+
+    /// <summary>Total capacity (sum of each source's configured max pool size) — the most connections this fleet could open.</summary>
+    public required int MaxConnections { get; init; }
+
+    /// <summary>Configured connection limit for the cluster (e.g. Atlas max), or null when not configured.</summary>
+    public int? Limit { get; init; }
 }
 
 /// <summary>

--- a/Tharga.MongoDB/MonitorDto.cs
+++ b/Tharga.MongoDB/MonitorDto.cs
@@ -77,7 +77,9 @@ public record SlowCallWithIndexInfoDto
 }
 
 /// <summary>
-/// Aggregate connection pool state.
+/// Connection pool state. When produced per pool (see <see cref="IDatabaseMonitor.GetPerPoolQueueState"/>)
+/// <see cref="Label"/> / <see cref="ConfigurationNames"/> describe which configuration(s) route through the pool;
+/// for the aggregate process-wide state they are left null.
 /// </summary>
 public record ConnectionPoolStateDto
 {
@@ -85,6 +87,25 @@ public record ConnectionPoolStateDto
     public required int ExecutingCount { get; init; }
     public required double LastWaitTimeMs { get; init; }
     public required IReadOnlyList<QueueMetricDto> RecentMetrics { get; init; }
+
+    /// <summary>Display label for the pool — the configuration name(s) routing through it (source-suffixed when ambiguous).</summary>
+    public string Label { get; init; }
+
+    /// <summary>The configuration name(s) that have used this pool.</summary>
+    public IReadOnlyCollection<string> ConfigurationNames { get; init; }
+}
+
+/// <summary>
+/// Per-pool queue snapshot used both for remote-agent ingest and over the wire
+/// (<c>MonitorQueueMetricMessage.Pools</c>).
+/// </summary>
+public record PoolMetricDto
+{
+    public required string ServerKey { get; init; }
+    public required IReadOnlyCollection<string> ConfigurationNames { get; init; }
+    public required int QueueCount { get; init; }
+    public required int ExecutingCount { get; init; }
+    public double? WaitTimeMs { get; init; }
 }
 
 /// <summary>

--- a/docs/articles/mcp-integration.md
+++ b/docs/articles/mcp-integration.md
@@ -42,7 +42,7 @@ Anything above the configured level is filtered out of `tools/list` and `resourc
 |---|---|---|
 | `mongodb://collections` | Metadata | Collections with stats, indexes, clean status |
 | `mongodb://clients` | Metadata | Connected remote monitoring agents |
-| `mongodb://monitoring` | DataRead | Recent + slow calls, summaries, error summary, connection-pool state (calls embed filter values, hence the gating) |
+| `mongodb://monitoring` | DataRead | Recent + slow calls, summaries, error summary, connection-pool state, and `inFlightCalls` — what the limiter is holding right now (queued vs executing), grouped by collection / function / filter, for diagnosing a flood (calls embed filter values, hence the gating) |
 
 ## Tools
 

--- a/docs/articles/monitoring.md
+++ b/docs/articles/monitoring.md
@@ -17,12 +17,21 @@ Configure via `appsettings.json`:
     "Enabled": true,
     "StorageMode": "Database",
     "LastCallsToKeep": 1000,
-    "SlowCallsToKeep": 200
+    "SlowCallsToKeep": 200,
+    "ForwardCompletedCalls": false,
+    "QueueMetricInterval": "00:00:01",
+    "ClusterConnectionLimit": 3000
   }
 }
 ```
 
 Or by code via `services.AddMongoDB(o => o.Monitor = new MonitorOptions { ... })`.
+
+| Option | Where | Default | Purpose |
+|---|---|---|---|
+| `ForwardCompletedCalls` | Agent | `false` | Forward every completed call to the central monitor. Off by default — it is a large, continuous stream proportional to database activity. See [Centralised monitoring](#centralised-monitoring). |
+| `QueueMetricInterval` | Agent | `00:00:01` (1s) | How often a queue/connection snapshot is forwarded while someone is watching live. Larger = less chatter, coarser live graph. |
+| `ClusterConnectionLimit` | Server | `null` | A cluster's connection limit (e.g. an Atlas tier's max, often 3000). When set, the queue view shows total open connections as a fraction of it. See [Connection-pool usage](#connection-pool-queue-and-in-flight-calls). |
 
 ## Source identification
 
@@ -36,6 +45,34 @@ Enable driver-level command timing to see how much of "Action" time is real Mong
 - **Action**: `Driver: find 12.34ms | Other: 3.21ms`
 
 Useful for distinguishing slow database from slow serialization or application contention.
+
+## Connection pool, queue and in-flight calls
+
+Database operations pass through a per-pool concurrency limiter (one pool per cluster, keyed by the set of
+server hosts). The Blazor queue view surfaces this **per pool**, not as a single process-wide figure:
+
+- **Queue / Exec counters and the Queue-Depth / Wait-Time graphs** are drawn one line per pool, labelled by the
+  configuration name(s) routing through that pool. Configurations on separate clusters get their own lines;
+  configurations sharing a cluster collapse into one line (they share one connection pool). When agents are
+  connected, their pools appear as additional lines (source-suffixed), so local + remote are shown together.
+
+- **Connection-pool usage vs a limit.** The monitor counts the *actual* open MongoDB driver connections per
+  cluster (from the driver's connection-pool events) — this is what counts toward a cluster's connection limit,
+  unlike `Exec`, which is in-use operations only and ignores idle-but-open pooled connections. The queue view
+  shows, per cluster across **all sources (this server + every agent)**, the total open connections and the
+  total capacity (sum of each pool's `maxPoolSize`). Set `Monitor.ClusterConnectionLimit` (on the server) to your
+  cluster's limit (e.g. an Atlas tier's 3000) to see `open / limit` with a bar that warns as you approach it.
+  Read it via `IDatabaseMonitor.GetClusterConnectionSummary()`.
+
+  > Only monitored processes are counted — other clients (Compass, un-instrumented services) and the driver's
+  > per-process SDAM heartbeat connections are not. Treat the figure as a close lower bound on the cluster total.
+
+- **Inspecting the queue (in-flight calls).** When a flood stacks up behind the limiter, you can see exactly
+  *what* is queued vs executing — grouped by collection, function and (rendered on demand) filter — via the
+  [MCP monitoring resource](mcp-integration.md) and `IDatabaseMonitor.GetInFlightCalls()`. The Blazor *Ongoing*
+  call view shows in-flight calls too; these are tracked separately from the capped recent-call ring so a flood
+  no longer evicts the longest-queued calls from view. (In-flight detail is per-process: query an agent's own
+  MCP for its queued calls; the central server receives only the per-pool counts from agents.)
 
 ## Centralised monitoring
 
@@ -58,7 +95,7 @@ var app = builder.Build();
 app.UseMongoDbMonitorServer();
 ```
 
-Agents push call events fire-and-forget over [Tharga.Communication](https://www.nuget.org/packages/Tharga.Communication) (SignalR-backed). The server ingests them into its local `IDatabaseMonitor` so the [Blazor admin UI](https://www.nuget.org/packages/Tharga.MongoDB.Blazor) renders local + remote data side by side. When the server is unavailable or not configured, the agent has zero overhead.
+Agents push monitoring data fire-and-forget over [Tharga.Communication](https://www.nuget.org/packages/Tharga.Communication) (SignalR-backed). The server ingests it into its local `IDatabaseMonitor` so the [Blazor admin UI](https://www.nuget.org/packages/Tharga.MongoDB.Blazor) renders local + remote data side by side. When the server is unavailable or not configured, the agent has zero overhead. By default agents forward collection metadata and (while watched) per-pool queue/connection snapshots; forwarding of every completed call is opt-in via `Monitor.ForwardCompletedCalls` — see [What agents forward](#what-agents-forward-and-when).
 
 ## API key rotation
 
@@ -68,9 +105,15 @@ Configure both `primaryApiKey` and `secondaryApiKey` on the server during a rota
 
 When the server dashboard displays collections from remote agents, actions like *touch*, *drop index*, *restore index*, *clean* are automatically delegated to the agent that owns the collection. No extra configuration — if `Monitor.Client` and `Monitor.Server` are installed, it works out of the box.
 
-## Live subscriptions
+## What agents forward, and when
 
-Live data (queue depth, ongoing calls) is only forwarded when someone is actively viewing the relevant tab. Blazor components subscribe on mount and unsubscribe on dispose. Collection metadata and completed calls are always forwarded.
+| Data | When forwarded |
+|---|---|
+| Collection metadata (counts, sizes, indexes, clean status) | Always — a burst at connect, then on change. Small. |
+| Queue / connection per-pool snapshots | Only while someone is viewing the live queue tab (gated on an active subscription), at `QueueMetricInterval`. |
+| Completed calls | Only when `Monitor.ForwardCompletedCalls = true` (off by default). This is the large stream — leave it off unless you need per-call history on the central server. With it off, the agent's *Last/Slow calls* lists on the server stay empty (its queue/connection metrics and collection metadata still flow). |
+
+Blazor components subscribe to the live data on mount and unsubscribe on dispose, so queue/connection snapshots stop when no one is looking. Each agent reports its own forwarding configuration (call forwarding on/off, queue interval, storage mode) on connect; the **Clients** page shows it per agent (a *Call forwarding* badge, with the full set in the client detail dialog).
 
 ## Reset
 


### PR DESCRIPTION
## Summary

Make the MongoDB monitor's queue/connection picture accurate and actionable **per connection pool**, and let a central monitor see the whole fleet's connection usage against a cluster limit (e.g. Atlas max connections). Also makes the large completed-call forwarding stream opt-in.

Motivation: on a central manager the queue/exec figure was a single process-wide aggregate (summed across pools, so it could read >100 with no explanation), there was no way to see what was actually stuck in the limiter queue during a flood, and nothing showed how close the fleet was to a cluster's connection limit.

## What's in it

**Per-pool queue metrics** — Queue/Exec counters and the Queue-Depth / Wait-Time graphs are now one line per connection pool (per cluster, labelled by the configuration name(s) routing through it), aggregated across the local process and all connected agents. `ExecuteLimiter` exposes `IQueueMonitor.GetPerPoolState()`; `GetPerSourceQueueState` → `GetPerPoolQueueState` keyed per `{source}::{serverKey}`.

**In-flight (queued vs executing) call inspection** — A lightweight `ExecuteCallContext` is threaded into the limiter so it can report exactly what is queued vs executing (with collection / function / lazily-rendered filter), surfaced via `IDatabaseMonitor.GetInFlightCalls()` and the MCP `mongodb://monitoring` resource (`inFlightCalls`, grouped). The query filter renders only when inspected, never on the hot path. Also fixes the Blazor **Ongoing** view: in-flight calls are tracked separately from the capped recent-call ring, so a flood no longer evicts the longest-queued calls from view (this was why Ongoing looked far shorter than the queue count).

**Opt-in completed-call forwarding + configurable interval** — `Monitor.ForwardCompletedCalls` (default **off**) gates forwarding of every completed call (a large, continuous stream); when off the forwarder doesn't even subscribe to call events. `Monitor.QueueMetricInterval` (default 1s; was a hardcoded 500ms) controls the snapshot cadence. Agents report their config on connect; the **Clients** page shows it (a *Call forwarding* badge + a Configuration card).

**Per-cluster connection totals vs limit** — `ConnectionPoolMonitor` counts actual open driver connections per cluster from the driver's CMAP `ConnectionCreated`/`ConnectionClosed` events (the limiter's `Exec` is in-use only and ignores idle-but-open pooled connections). `IDatabaseMonitor.GetClusterConnectionSummary()` aggregates open connections + capacity per cluster across the server and every agent; set `Monitor.ClusterConnectionLimit` to show `open / limit` with a warning bar in the queue view.

## Notes / caveats

- **Behaviour change:** completed calls no longer reach the central server unless `ForwardCompletedCalls` is enabled (per-agent Last/Slow call lists stay empty otherwise). Collection metadata and (viewer-gated) queue/connection snapshots still flow.
- The wire change to `MonitorQueueMetricMessage` is additive (a `Pools` list alongside the retained aggregate scalars), so it's backward/forward compatible across client/server versions.
- Connection counts include monitored processes only (not Compass / un-instrumented clients / SDAM heartbeats) — a close lower bound on the cluster total. Counts populate while the live view is watched.

## Tests

Build clean (0 warnings). 42 targeted tests pass, including new coverage for per-pool split + config labelling, shared-cluster collapse, remote round-trip, in-flight queued-vs-executing tracking, ongoing-not-evicted-under-overflow, connection counting (incl. negative guard), and local/remote per-cluster aggregation.

Docs updated: `docs/articles/monitoring.md`, `docs/articles/mcp-integration.md`, root `README.md`, and the Blazor / Monitor.Client / Monitor.Server READMEs.
