### PR TITLE
Per-configuration MaxPoolSize override + pool-size-aware client cache (closes #126, #128)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1258,16 +1258,16 @@ Cursors are sort-bound: passing one issued for `sortBy: x => x.Name` to a call s
 
 ## Execute Limiter
 The built-in execute limiter queues database operations to prevent exhausting the MongoDB connection pool.
-By default it is enabled and automatically sizes itself to `MaxConnectionPoolSize` from the MongoDB driver — no configuration needed.
+It is always sized to the connection's `MaxConnectionPoolSize` (the driver default is 100) — no configuration needed.
+Set `MaxPoolSize` in the connection string, or use [`MaxPoolSizeOverride`](#per-configuration-pool-size) to control it per configuration.
 
-Operations sharing the same connection pool (i.e. the same set of servers) share a single queue, regardless of how many configuration names point to that cluster.
+Operations sharing the same connection pool — the same set of servers **and** the same `MaxConnectionPoolSize` — share a single queue, regardless of how many configuration names point to that cluster. Configurations on the same cluster with **different** pool sizes get their own `MongoClient` and their own queue.
 
 ### Configuration by `appsettings.json`
 ```json
 "MongoDB": {
   "Limiter": {
-    "Enabled": true,
-    "MaxConcurrent": 50
+    "Enabled": true
   }
 }
 ```
@@ -1278,18 +1278,36 @@ builder.AddMongoDB(o =>
 {
     o.Limiter = new ExecuteLimiterOptions
     {
-        Enabled = true,
-        MaxConcurrent = 50
+        Enabled = true
     };
 });
 ```
 
 | Setting | Default | Description |
 |---|---|---|
-| `Enabled` | `true` | Enable or disable the limiter. |
-| `MaxConcurrent` | `null` (auto) | Maximum concurrent operations per connection pool. When `null`, auto-detected from `MaxConnectionPoolSize`. Capped at the pool size even if set higher — a warning is logged in that case. |
+| `Enabled` | `true` | Enable or disable the limiter. When disabled, operations run without any concurrency restriction. The concurrency limit is always derived from `MaxConnectionPoolSize`. |
 
 The monitor surfaces the limiter **per pool** (one per cluster): queue/exec and depth/wait graphs per pool, what is queued vs executing right now (`GetInFlightCalls()` / the MCP `inFlightCalls` resource), and actual open connections per cluster vs a configured limit (`GetClusterConnectionSummary()` + `Monitor.ClusterConnectionLimit`). See the [monitoring docs](https://github.com/Tharga/MongoDB/blob/master/docs/articles/monitoring.md).
+
+### Per-configuration pool size
+`MaxConnectionPoolSize` is part of the `MongoClient` cache key, so two configurations pointing at the same cluster with different `MaxPoolSize` values each get their own client with the correct pool size — they no longer silently share whichever client was created first.
+
+To set the pool size per configuration name without separate connection strings, provide `MaxPoolSizeOverride`. It is applied to the connection URL **before** the `MongoClient` is created, so both the driver and the execute limiter see the same value:
+
+```csharp
+builder.AddMongoDB(o =>
+{
+    o.DefaultConfigurationName = "Aggregator";
+    o.MaxPoolSizeOverride = (serviceProvider, configName, connectionStringPoolSize) => configName switch
+    {
+        "Aggregator"  => Task.FromResult(500),
+        "Integration" => Task.FromResult(50),
+        _             => Task.FromResult(connectionStringPoolSize) // pass through if unknown
+    };
+});
+```
+
+The delegate receives the service provider, the configuration name, and the `MaxPoolSize` already present in the connection string (or the driver default of 100 if absent). It is `async` and invoked once per configuration when the URL is built — never on the execution hot path.
 
 ---
 

--- a/Sample/HostSample/Program.cs
+++ b/Sample/HostSample/Program.cs
@@ -11,7 +11,6 @@ builder.AddMongoDB(o =>
 {
     o.AssureIndex = AssureIndexMode.BySchema;
     o.DefaultConfigurationName = "NoDefault";
-    o.Limiter.MaxConcurrent = 1;
     o.Monitor.SlowCallsToKeep = 1;
 });
 

--- a/Tharga.MongoDB.Tests/ConfigurationTests.cs
+++ b/Tharga.MongoDB.Tests/ConfigurationTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
@@ -29,7 +30,7 @@ public class ConfigurationTests
         var connectionStringBuilder = new MongoUrlBuilder(hostEnvironmentMock.Object);
         var mongoUrlBuilderLoaderMock = new Mock<IMongoUrlBuilderLoader>(MockBehavior.Strict);
         mongoUrlBuilderLoaderMock.Setup(x => x.GetConnectionStringBuilder(It.IsAny<DatabaseContext>()))
-            .Returns((DatabaseContext _) => (connectionStringBuilder, () => "mongodb://localhost:27017/Tharga{environment}{part}"));
+            .Returns((DatabaseContext _) => (connectionStringBuilder, () => "mongodb://localhost:27017/Tharga{environment}{part}", new Func<global::MongoDB.Driver.MongoUrl, global::MongoDB.Driver.MongoUrl>(u => u)));
         var repositoryConfiguration = new Mock<IRepositoryConfiguration>(MockBehavior.Strict);
         var databaseContext = Mock.Of<DatabaseContext>(x => x.DatabasePart == part);
         var databaseOptions = Mock.Of<DatabaseOptions>(x => x.DefaultConfigurationName == "Default");

--- a/Tharga.MongoDB.Tests/ExecuteLimiterLoggingTests.cs
+++ b/Tharga.MongoDB.Tests/ExecuteLimiterLoggingTests.cs
@@ -26,7 +26,7 @@ public class ExecuteLimiterLoggingTests
     private static ExecuteLimiter CreateLimiter(ILogger<ExecuteLimiter> logger)
     {
         var options = Mock.Of<IOptions<ExecuteLimiterOptions>>(x =>
-            x.Value == new ExecuteLimiterOptions { Enabled = true, MaxConcurrent = 1 });
+            x.Value == new ExecuteLimiterOptions { Enabled = true });
         return new ExecuteLimiter(options, logger);
     }
 
@@ -47,14 +47,14 @@ public class ExecuteLimiterLoggingTests
         var logger = new Mock<ILogger<ExecuteLimiter>>();
         var limiter = CreateLimiter(logger.Object);
 
-        // Block the single concurrency slot so the next two operations pile up in the queue,
-        // driving queuedCount past the > 1 threshold that emits the "Queued ..." message.
+        // Pool size of 1 -> a single concurrency slot. Block it so the next two operations pile up in the
+        // queue, driving queuedCount past the > 1 threshold that emits the "Queued ..." message.
         var gate = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var blocking = limiter.ExecuteAsync(async _ => { await gate.Task; return 0; }, ServerKey, 100, Ctx(), CancellationToken.None);
+        var blocking = limiter.ExecuteAsync(async _ => { await gate.Task; return 0; }, ServerKey, 1, Ctx(), CancellationToken.None);
         await SpinUntil(() => limiter.GetCurrentState().ExecutingCount == 1);
 
-        var waiterA = limiter.ExecuteAsync(_ => Task.FromResult(1), ServerKey, 100, Ctx(), CancellationToken.None);
-        var waiterB = limiter.ExecuteAsync(_ => Task.FromResult(2), ServerKey, 100, Ctx(), CancellationToken.None);
+        var waiterA = limiter.ExecuteAsync(_ => Task.FromResult(1), ServerKey, 1, Ctx(), CancellationToken.None);
+        var waiterB = limiter.ExecuteAsync(_ => Task.FromResult(2), ServerKey, 1, Ctx(), CancellationToken.None);
         await SpinUntil(() => limiter.GetCurrentState().QueueCount >= 2);
 
         gate.SetResult(0);

--- a/Tharga.MongoDB.Tests/FetchCollectionLockTests.cs
+++ b/Tharga.MongoDB.Tests/FetchCollectionLockTests.cs
@@ -51,7 +51,7 @@ public class FetchCollectionLockTests : IDisposable
         });
         mocker.Use(mongoDbClientProvider);
 
-        var executeLimiter = new ExecuteLimiter(Mock.Of<IOptions<ExecuteLimiterOptions>>(x => x.Value == new ExecuteLimiterOptions { MaxConcurrent = 20 }), null);
+        var executeLimiter = new ExecuteLimiter(Mock.Of<IOptions<ExecuteLimiterOptions>>(x => x.Value == new ExecuteLimiterOptions()), null);
         mocker.Use((IExecuteLimiter)executeLimiter);
 
         // Use a real CollectionPool so the double-check pattern works correctly

--- a/Tharga.MongoDB.Tests/InFlightCallTests.cs
+++ b/Tharga.MongoDB.Tests/InFlightCallTests.cs
@@ -16,9 +16,9 @@ public class InFlightCallTests
 {
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
 
-    private static ExecuteLimiter CreateLimiter(int maxConcurrent) =>
+    private static ExecuteLimiter CreateLimiter() =>
         new(Mock.Of<IOptions<ExecuteLimiterOptions>>(x =>
-                x.Value == new ExecuteLimiterOptions { Enabled = true, MaxConcurrent = maxConcurrent }),
+                x.Value == new ExecuteLimiterOptions { Enabled = true }),
             NullLogger<ExecuteLimiter>.Instance);
 
     private static ExecuteCallContext Ctx(string function, Operation operation, string filterJson = null) => new()
@@ -35,17 +35,18 @@ public class InFlightCallTests
     [Fact]
     public async Task GetInFlightCalls_DistinguishesQueuedFromExecuting_WithMetadataAndRenderedFilter()
     {
-        var limiter = CreateLimiter(maxConcurrent: 1);
+        var limiter = CreateLimiter();
         var gate = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
 
+        // Pool size of 1 -> a single concurrency slot, so the second call must queue behind the first.
         // Occupy the only slot; this one is executing.
         var executing = limiter.ExecuteAsync(async _ => { await gate.Task; return 0; },
-            "srv", 100, Ctx("GetManyAsync", Operation.Read, "{ \"x\" : 1 }"), CancellationToken.None);
+            "srv", 1, Ctx("GetManyAsync", Operation.Read, "{ \"x\" : 1 }"), CancellationToken.None);
         await SpinUntil(() => limiter.GetInFlightCalls().Any(c => c.IsExecuting));
 
         // This one cannot acquire the slot; it stays queued.
         var queued = limiter.ExecuteAsync(_ => Task.FromResult(1),
-            "srv", 100, Ctx("UpdateOneAsync", Operation.Update), CancellationToken.None);
+            "srv", 1, Ctx("UpdateOneAsync", Operation.Update), CancellationToken.None);
         await SpinUntil(() => limiter.GetInFlightCalls().Count(c => !c.IsExecuting) == 1);
 
         var inFlight = limiter.GetInFlightCalls();

--- a/Tharga.MongoDB.Tests/Lockable/Base/LockableTestBase.cs
+++ b/Tharga.MongoDB.Tests/Lockable/Base/LockableTestBase.cs
@@ -38,7 +38,7 @@ public abstract class LockableTestBase : IDisposable
         });
         mocker.Use(mongoDbClientProvider);
 
-        var executeLimiter = new ExecuteLimiter(Mock.Of<IOptions<ExecuteLimiterOptions>>(x => x.Value == new ExecuteLimiterOptions { MaxConcurrent = 20 }), null);
+        var executeLimiter = new ExecuteLimiter(Mock.Of<IOptions<ExecuteLimiterOptions>>(x => x.Value == new ExecuteLimiterOptions()), null);
         mocker.Use((IExecuteLimiter)executeLimiter);
 
         var collectionPool = new Mock<ICollectionPool>(MockBehavior.Loose);

--- a/Tharga.MongoDB.Tests/MaxPoolSizeOverrideTests.cs
+++ b/Tharga.MongoDB.Tests/MaxPoolSizeOverrideTests.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Driver;
+using Moq;
+using Tharga.MongoDB.Configuration;
+using Tharga.MongoDB.Internals;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests;
+
+public class MaxPoolSizeOverrideTests
+{
+    // --- Cache key (fixes #126) ---
+
+    [Fact]
+    public void GetServerKey_SameHost_DifferentMaxPoolSize_ProducesDifferentKeys()
+    {
+        var low = MongoDbClientProvider.GetServerKey(new MongoUrl("mongodb://localhost:27017/Db?maxPoolSize=100"));
+        var high = MongoDbClientProvider.GetServerKey(new MongoUrl("mongodb://localhost:27017/Db?maxPoolSize=300"));
+
+        low.Should().NotBe(high);
+    }
+
+    [Fact]
+    public void GetServerKey_SameHost_SameMaxPoolSize_ProducesSameKey()
+    {
+        // Different database, same cluster + same pool size -> still one shared client.
+        var a = MongoDbClientProvider.GetServerKey(new MongoUrl("mongodb://localhost:27017/Aggregator?maxPoolSize=200"));
+        var b = MongoDbClientProvider.GetServerKey(new MongoUrl("mongodb://localhost:27017/Integration?maxPoolSize=200"));
+
+        a.Should().Be(b);
+    }
+
+    // --- Override delegate (#128) ---
+
+    private static MongoUrlBuilderLoader CreateLoader(DatabaseOptions options, IServiceProvider provider = null)
+        => new(provider ?? Mock.Of<IServiceProvider>(), options);
+
+    private static Func<MongoUrl, MongoUrl> GetApplicator(DatabaseOptions options, IServiceProvider provider = null)
+        => CreateLoader(options, provider).GetConnectionStringBuilder(null).ApplyPoolSizeOverride;
+
+    [Fact]
+    public void Override_Upserts_MaxConnectionPoolSize_FromConnectionStringValue()
+    {
+        var options = new DatabaseOptions
+        {
+            DefaultConfigurationName = "Aggregator",
+            MaxPoolSizeOverride = (_, name, _) => Task.FromResult(name == "Aggregator" ? 500 : 50),
+        };
+
+        var result = GetApplicator(options)(new MongoUrl("mongodb://localhost:27017/Db?maxPoolSize=100"));
+
+        result.MaxConnectionPoolSize.Should().Be(500);
+    }
+
+    [Fact]
+    public void Override_ReceivesDriverDefault_WhenConnectionStringHasNoMaxPoolSize()
+    {
+        var seen = 0;
+        var options = new DatabaseOptions
+        {
+            DefaultConfigurationName = "Aggregator",
+            MaxPoolSizeOverride = (_, _, current) => { seen = current; return Task.FromResult(current); },
+        };
+
+        GetApplicator(options)(new MongoUrl("mongodb://localhost:27017/Db"));
+
+        seen.Should().Be(100); // MongoDB driver default
+    }
+
+    [Fact]
+    public void Override_PassesServiceProviderAndConfigurationName()
+    {
+        var provider = Mock.Of<IServiceProvider>();
+        IServiceProvider seenProvider = null;
+        string seenName = null;
+        var options = new DatabaseOptions
+        {
+            DefaultConfigurationName = "Integration",
+            MaxPoolSizeOverride = (sp, name, current) => { seenProvider = sp; seenName = name; return Task.FromResult(current); },
+        };
+
+        GetApplicator(options, provider)(new MongoUrl("mongodb://localhost:27017/Db?maxPoolSize=100"));
+
+        seenProvider.Should().BeSameAs(provider);
+        seenName.Should().Be("Integration");
+    }
+
+    [Fact]
+    public void NoOverride_LeavesUrlUnchanged()
+    {
+        var options = new DatabaseOptions { DefaultConfigurationName = "Aggregator" };
+        var url = new MongoUrl("mongodb://localhost:27017/Db?maxPoolSize=100");
+
+        var result = GetApplicator(options)(url);
+
+        result.Should().BeSameAs(url);
+    }
+
+    [Fact]
+    public void Override_ReturningSameValue_LeavesUrlUnchanged()
+    {
+        var options = new DatabaseOptions
+        {
+            DefaultConfigurationName = "Aggregator",
+            MaxPoolSizeOverride = (_, _, current) => Task.FromResult(current),
+        };
+        var url = new MongoUrl("mongodb://localhost:27017/Db?maxPoolSize=150");
+
+        var result = GetApplicator(options)(url);
+
+        result.Should().BeSameAs(url);
+    }
+}

--- a/Tharga.MongoDB.Tests/RegistrationOptionsTests.cs
+++ b/Tharga.MongoDB.Tests/RegistrationOptionsTests.cs
@@ -95,56 +95,6 @@ public class RegistrationOptionsTests
         result.Enabled.Should().BeFalse();
     }
 
-    [Fact]
-    public void Limiter_NoConfiguration_DefaultsToNull()
-    {
-        var provider = Register(BuildConfig());
-
-        var result = provider.GetRequiredService<IOptions<ExecuteLimiterOptions>>().Value;
-
-        result.MaxConcurrent.Should().BeNull();
-    }
-
-    [Fact]
-    public void Limiter_CodeConfigured_UsesCodeValue()
-    {
-        var provider = Register(BuildConfig(), o => o.Limiter.MaxConcurrent = 5);
-
-        var result = provider.GetRequiredService<IOptions<ExecuteLimiterOptions>>().Value;
-
-        result.MaxConcurrent.Should().Be(5);
-    }
-
-    [Fact]
-    public void Limiter_AppSettingsConfigured_UsesAppSettingsValue()
-    {
-        var config = BuildConfig(new Dictionary<string, string>
-        {
-            { "MongoDB:Limiter:MaxConcurrent", "10" }
-        });
-
-        var provider = Register(config);
-
-        var result = provider.GetRequiredService<IOptions<ExecuteLimiterOptions>>().Value;
-
-        result.MaxConcurrent.Should().Be(10);
-    }
-
-    [Fact]
-    public void Limiter_BothCodeAndAppSettings_CodeWins()
-    {
-        var config = BuildConfig(new Dictionary<string, string>
-        {
-            { "MongoDB:Limiter:MaxConcurrent", "10" }
-        });
-
-        var provider = Register(config, o => o.Limiter.MaxConcurrent = 5);
-
-        var result = provider.GetRequiredService<IOptions<ExecuteLimiterOptions>>().Value;
-
-        result.MaxConcurrent.Should().Be(5);
-    }
-
     // --- Monitor ---
 
     [Fact]

--- a/Tharga.MongoDB.Tests/Support/MongoDbTestBase.cs
+++ b/Tharga.MongoDB.Tests/Support/MongoDbTestBase.cs
@@ -47,7 +47,7 @@ public abstract class MongoDbTestBase : IDisposable
         });
         mocker.Use(mongoDbClientProvider);
 
-        var executeLimiter = new ExecuteLimiter(Mock.Of<IOptions<ExecuteLimiterOptions>>(x => x.Value == new ExecuteLimiterOptions { MaxConcurrent = 20 }), null);
+        var executeLimiter = new ExecuteLimiter(Mock.Of<IOptions<ExecuteLimiterOptions>>(x => x.Value == new ExecuteLimiterOptions()), null);
         mocker.Use((IExecuteLimiter)executeLimiter);
 
         var collectionPool = new Mock<ICollectionPool>(MockBehavior.Loose);

--- a/Tharga.MongoDB/Configuration/DatabaseOptions.cs
+++ b/Tharga.MongoDB/Configuration/DatabaseOptions.cs
@@ -26,6 +26,27 @@ public record DatabaseOptions
     public Func<ConfigurationName, IServiceProvider, Task<ConnectionString>> ConnectionStringLoader { get; set; }
 
     /// <summary>
+    /// Optional override for <c>MaxPoolSize</c>, applied per configuration name to the connection URL
+    /// <b>before</b> the <c>MongoClient</c> is created — so both the MongoDB driver and the execute
+    /// limiter see the same value, and configurations on the same cluster with different pool sizes
+    /// get their own <c>MongoClient</c> (the effective pool size is part of the client cache key).
+    /// <para>
+    /// Parameters: the service provider, the configuration name (e.g. <c>"Aggregator"</c>), and the
+    /// <c>MaxPoolSize</c> already present in the connection string (or the driver default of 100 if
+    /// absent). Return the pool size to use.
+    /// </para>
+    /// <code>
+    /// o.MaxPoolSizeOverride = (sp, name, csPoolSize) => name switch
+    /// {
+    ///     "Aggregator"  => Task.FromResult(500),
+    ///     "Integration" => Task.FromResult(50),
+    ///     _             => Task.FromResult(csPoolSize) // pass through if unknown
+    /// };
+    /// </code>
+    /// </summary>
+    public Func<IServiceProvider, string, int, Task<int>> MaxPoolSizeOverride { get; set; }
+
+    /// <summary>
     /// If true, all classes inheriting from IRepository will be registered. This value is default true.
     /// Use IServiceCollection to register repositories manually.
     /// </summary>

--- a/Tharga.MongoDB/ExecuteLimiter.cs
+++ b/Tharga.MongoDB/ExecuteLimiter.cs
@@ -17,10 +17,8 @@ internal class ExecuteLimiter : IExecuteLimiter, IQueueMonitor
     private const int MaxMetricEntries = 500;
 
     private readonly bool _enabled;
-    private readonly int? _maxConcurrentOverride;
 
     private readonly ConcurrentDictionary<string, PerPoolState> _states = new();
-    private readonly ConcurrentDictionary<string, bool> _warnedServerKeys = new();
     private readonly ConcurrentQueue<QueueMetricEventArgs> _metrics = new();
 
     // Calls currently held by the limiter (queued or executing), for on-demand diagnostics.
@@ -37,7 +35,6 @@ internal class ExecuteLimiter : IExecuteLimiter, IQueueMonitor
     {
         _logger = logger;
         _enabled = options.Value.Enabled;
-        _maxConcurrentOverride = options.Value.MaxConcurrent;
     }
 
     public async Task<(T Result, ExecuteInfo Info)> ExecuteAsync<T>(Func<CancellationToken, Task<T>> action, string serverKey, int maxConnectionPoolSize, ExecuteCallContext context, CancellationToken cancellationToken)
@@ -48,16 +45,7 @@ internal class ExecuteLimiter : IExecuteLimiter, IQueueMonitor
             return (result, new ExecuteInfo { QueueElapsed = TimeSpan.Zero, ConcurrentCount = 0, QueueCount = 0 });
         }
 
-        var maxConcurrent = _maxConcurrentOverride.HasValue
-            ? Math.Min(_maxConcurrentOverride.Value, maxConnectionPoolSize)
-            : maxConnectionPoolSize;
-
-        if (_maxConcurrentOverride.HasValue && _maxConcurrentOverride.Value > maxConnectionPoolSize
-            && _warnedServerKeys.TryAdd(serverKey, true))
-        {
-            _logger?.LogWarning("Configured MaxConcurrent ({configured}) exceeds MaxConnectionPoolSize ({poolSize}) for {serverKey}. Capping at {poolSize}.",
-                _maxConcurrentOverride.Value, maxConnectionPoolSize, serverKey, maxConnectionPoolSize);
-        }
+        var maxConcurrent = maxConnectionPoolSize;
 
         var state = _states.GetOrAdd(serverKey, _ => new PerPoolState(maxConcurrent));
         state.TagConfiguration(context?.ConfigurationName);

--- a/Tharga.MongoDB/ExecuteLimiterOptions.cs
+++ b/Tharga.MongoDB/ExecuteLimiterOptions.cs
@@ -8,11 +8,4 @@ public record ExecuteLimiterOptions
     /// By default, the limiter is enabled.
     /// </summary>
     public bool Enabled { get; set; } = true;
-
-    /// <summary>
-    /// Maximum number of concurrent database operations allowed per connection pool.
-    /// Excess operations are queued until a slot becomes available.
-    /// When null (default), the limit is auto-detected from <c>MaxConnectionPoolSize</c>.
-    /// </summary>
-    public int? MaxConcurrent { get; set; }
 }

--- a/Tharga.MongoDB/Internals/IMongoUrlBuilderLoader.cs
+++ b/Tharga.MongoDB/Internals/IMongoUrlBuilderLoader.cs
@@ -1,8 +1,9 @@
 ﻿using System;
+using MongoDB.Driver;
 
 namespace Tharga.MongoDB.Internals;
 
 internal interface IMongoUrlBuilderLoader
 {
-    (IMongoUrlBuilder Builder, Func<string> ConnectionStringLoader) GetConnectionStringBuilder(DatabaseContext databaseContext);
+    (IMongoUrlBuilder Builder, Func<string> ConnectionStringLoader, Func<MongoUrl, MongoUrl> ApplyPoolSizeOverride) GetConnectionStringBuilder(DatabaseContext databaseContext);
 }

--- a/Tharga.MongoDB/Internals/MongoDbClientProvider.cs
+++ b/Tharga.MongoDB/Internals/MongoDbClientProvider.cs
@@ -62,6 +62,10 @@ internal class MongoDbClientProvider : IMongoDbClientProvider
 
     internal static string GetServerKey(MongoUrl url)
     {
-        return string.Join(",", url.Servers.Select(s => s.ToString()).OrderBy(x => x));
+        // MaxConnectionPoolSize is part of the key so two configurations pointing at the same cluster
+        // with different pool sizes get their own MongoClient (and their own ExecuteLimiter pool, which
+        // shares this key) instead of silently sharing whichever client was created first.
+        var servers = string.Join(",", url.Servers.Select(s => s.ToString()).OrderBy(x => x));
+        return $"{servers}|pool={url.MaxConnectionPoolSize}";
     }
 }

--- a/Tharga.MongoDB/Internals/MongoUrlBuilderLoader.cs
+++ b/Tharga.MongoDB/Internals/MongoUrlBuilderLoader.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
+using MongoDB.Driver;
 using Tharga.MongoDB.Configuration;
 
 namespace Tharga.MongoDB.Internals;
@@ -16,7 +17,7 @@ internal class MongoUrlBuilderLoader : IMongoUrlBuilderLoader
         _databaseOptions = databaseOptions;
     }
 
-    public (IMongoUrlBuilder Builder, Func<string> ConnectionStringLoader) GetConnectionStringBuilder(DatabaseContext databaseContext)
+    public (IMongoUrlBuilder Builder, Func<string> ConnectionStringLoader, Func<MongoUrl, MongoUrl> ApplyPoolSizeOverride) GetConnectionStringBuilder(DatabaseContext databaseContext)
     {
         var builder = new Lazy<IMongoUrlBuilder>(() =>
         {
@@ -24,7 +25,28 @@ internal class MongoUrlBuilderLoader : IMongoUrlBuilderLoader
             return new MongoUrlBuilder(hostEnvironment);
         });
 
-        return ((IMongoUrlBuilder)_serviceProvider.GetService(typeof(IMongoUrlBuilder)) ?? builder.Value, () => GetConnectionString(databaseContext, _databaseOptions, _serviceProvider));
+        return (
+            (IMongoUrlBuilder)_serviceProvider.GetService(typeof(IMongoUrlBuilder)) ?? builder.Value,
+            () => GetConnectionString(databaseContext, _databaseOptions, _serviceProvider),
+            url => ApplyMaxPoolSizeOverride(url, databaseContext));
+    }
+
+    // Applies DatabaseOptions.MaxPoolSizeOverride to the built URL so the overridden MaxPoolSize feeds both
+    // the MongoClient settings and the client cache key (MongoDbClientProvider.GetServerKey). Runs once per
+    // URL construction (not on the hot path); sync-over-async mirrors the ConnectionStringLoader call above.
+    private MongoUrl ApplyMaxPoolSizeOverride(MongoUrl url, DatabaseContext databaseContext)
+    {
+        var ovr = _databaseOptions.MaxPoolSizeOverride;
+        if (ovr == null || url == null) return url;
+
+        var configurationName = databaseContext?.ConfigurationName?.Value.NullIfEmpty() ?? _databaseOptions.DefaultConfigurationName;
+        if (configurationName == null) return url;
+
+        var current = url.MaxConnectionPoolSize;
+        var resolved = ovr(_serviceProvider, configurationName, current).GetAwaiter().GetResult();
+        if (resolved == current) return url;
+
+        return new global::MongoDB.Driver.MongoUrlBuilder(url.ToString()) { MaxConnectionPoolSize = resolved }.ToMongoUrl();
     }
 
     private string GetConnectionString(DatabaseContext databaseContext, DatabaseOptions databaseOptions, IServiceProvider provider)

--- a/Tharga.MongoDB/Internals/RepositoryConfigurationInternal.cs
+++ b/Tharga.MongoDB/Internals/RepositoryConfigurationInternal.cs
@@ -47,7 +47,7 @@ internal class RepositoryConfigurationInternal : IRepositoryConfigurationInterna
 
             var server = mongoUrl.ToString().TrimEnd(mongoUrl.DatabaseName);
             mongoUrl = new MongoUrl($"{server}{databaseName}");
-            return mongoUrl;
+            return result.ApplyPoolSizeOverride(mongoUrl);
         }
         else
         {
@@ -58,6 +58,7 @@ internal class RepositoryConfigurationInternal : IRepositoryConfigurationInterna
             var result = _mongoUrlBuilderLoader.GetConnectionStringBuilder(_databaseContext.Value);
 
             mongoUrl = result.Builder.Build(result.ConnectionStringLoader(), _databaseContext.Value?.DatabasePart);
+            mongoUrl = result.ApplyPoolSizeOverride(mongoUrl);
 
             _databaseUrlCache.TryAdd(key, mongoUrl);
             return mongoUrl;

--- a/Tharga.MongoDB/MongoDbRegistrationExtensions.cs
+++ b/Tharga.MongoDB/MongoDbRegistrationExtensions.cs
@@ -51,7 +51,6 @@ public static class MongoDbRegistrationExtensions
             Limiter = new ExecuteLimiterOptions
             {
                 Enabled = c?.Limiter?.Enabled ?? lo.Enabled,
-                MaxConcurrent = c?.Limiter?.MaxConcurrent ?? lo.MaxConcurrent,
             }
         };
         options?.Invoke(o);

--- a/docs/articles/monitoring.md
+++ b/docs/articles/monitoring.md
@@ -48,13 +48,16 @@ Useful for distinguishing slow database from slow serialization or application c
 
 ## Connection pool, queue and in-flight calls
 
-Database operations pass through a per-pool concurrency limiter (one pool per cluster, keyed by the set of
-server hosts). The Blazor queue view surfaces this **per pool**, not as a single process-wide figure:
+Database operations pass through a per-pool concurrency limiter (one pool per `MongoClient`, keyed by the set of
+server hosts **and** the pool's `MaxConnectionPoolSize`). The Blazor queue view surfaces this **per pool**, not as
+a single process-wide figure:
 
 - **Queue / Exec counters and the Queue-Depth / Wait-Time graphs** are drawn one line per pool, labelled by the
   configuration name(s) routing through that pool. Configurations on separate clusters get their own lines;
-  configurations sharing a cluster collapse into one line (they share one connection pool). When agents are
-  connected, their pools appear as additional lines (source-suffixed), so local + remote are shown together.
+  configurations sharing a cluster *and* the same `MaxPoolSize` collapse into one line (they share one connection
+  pool), while configurations on the same cluster with different pool sizes get their own client and their own
+  line. When agents are connected, their pools appear as additional lines (source-suffixed), so local + remote are
+  shown together.
 
 - **Connection-pool usage vs a limit.** The monitor counts the *actual* open MongoDB driver connections per
   cluster (from the driver's connection-pool events) — this is what counts toward a cluster's connection limit,


### PR DESCRIPTION
## Summary

One feature resolving both #126 (bug) and #128 (feature request).

`MongoDbClientProvider` cached `MongoClient` instances keyed by server host only, so multiple configurations pointing at the same cluster shared one client — the first to create it won, and every other configuration's `MaxPoolSize` was silently discarded. `ExecuteLimiter`, keyed by the same server key and capped by the shared client's pool size, inherited the same problem.

## Changes

- **`DatabaseOptions.MaxPoolSizeOverride`** (`Func<IServiceProvider, string, int, Task<int>>`) — `(provider, configurationName, connectionStringPoolSize) → effectivePoolSize`. Applied to the `MongoUrl` **before** the `MongoClient` is created, so the driver and the limiter see the same value. Async + `IServiceProvider` per the discussion on #128.
- **Pool-size-aware cache key** — `MongoDbClientProvider.GetServerKey` now appends `|pool={MaxConnectionPoolSize}`. Configurations on one cluster with different pool sizes get their own client and their own limiter pool. This fixes #126 on its own, even for plain connection strings that differ only in `MaxPoolSize`.
- **BREAKING — `ExecuteLimiterOptions.MaxConcurrent` removed.** The limiter now always derives its concurrency from `MaxConnectionPoolSize`. Set `MaxPoolSize` in the connection string or via `MaxPoolSizeOverride` instead.

## Breaking change / versioning

Removing `MaxConcurrent` is a public API break on `ExecuteLimiterOptions` — worth a minor/major bump. Any code setting `o.Limiter.MaxConcurrent` will no longer compile; the equivalent is now the connection string's `MaxPoolSize` (or `MaxPoolSizeOverride`).

## Tests

- New `MaxPoolSizeOverrideTests` (7): server-key split by pool size, override upsert, driver-default-100 passthrough, provider/name passed through, no-override and same-value identity.
- Tests that used `MaxConcurrent` to force a small pool now pass `maxConnectionPoolSize: 1` to `ExecuteAsync` directly (that argument already sizes the semaphore).
- Full non-Database suite green (317 passing; one pre-existing flaky timing test, `RevalidationQueueTests.HighPriorityKeys_DrainBeforeLow`, unrelated to this change — passes in isolation).

## Docs

README Execute Limiter section rewritten (`MaxConcurrent` removed, `MaxPoolSizeOverride` + cache-key behaviour documented); `docs/articles/monitoring.md` pool-key note updated.

Closes #126
Closes #128
