### PR TITLE
fix: DeleteOneAsync reported itself as UpdateOneAsync

### DIFF
--- a/Tharga.MongoDB.Tests/Interception/LockableInterceptionCoverageTests.cs
+++ b/Tharga.MongoDB.Tests/Interception/LockableInterceptionCoverageTests.cs
@@ -98,12 +98,10 @@ public class LockableInterceptionCoverageTests : LockableTestBase
         var scope = await sut.PickForDeleteAsync(entity.Id);
         await scope.CommitAsync();
 
-        // Asserted on OperationType, not on the name. DeleteOneAsync(FilterDefinition, ...) labels
-        // itself nameof(UpdateOneAsync) — a pre-existing copy-paste bug in the package that predates
-        // this feature and also mislabels the monitor. It passes Operation.Delete correctly, so the
-        // classification an interceptor should key on is right; only the display string is wrong.
-        // Recorded as a follow-up rather than fixed here, because correcting it changes what the
-        // monitor shows for every delete.
+        // Asserted on OperationType rather than the operation name, which is what the docs tell
+        // consumers to key on: the name is a diagnostic label, and a lockable call reports whichever
+        // disk operation actually runs. Operation-name correctness is covered separately by
+        // OperationLabellingTests.
         interceptor.Calls.Should().Contain(x => x.OperationType == Operation.Delete,
             "the delete commit removes the document");
     }

--- a/Tharga.MongoDB.Tests/OperationLabellingTests.cs
+++ b/Tharga.MongoDB.Tests/OperationLabellingTests.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MongoDB.Driver;
+using Tharga.MongoDB.Disk;
+using Tharga.MongoDB.Tests.Support;
+using Xunit;
+
+namespace Tharga.MongoDB.Tests;
+
+/// <summary>
+/// The function name every operation reports to the monitor, the call history and the MCP call
+/// surfaces. It is a display and grouping key — `DatabaseMonitor` aggregates call statistics by it —
+/// so an operation reporting another operation's name silently merges two different things in every
+/// one of those views.
+/// </summary>
+[Collection("Sequential")]
+[CollectionDefinition("Sequential", DisableParallelization = true)]
+public class OperationLabellingTests : MongoDbTestBase
+{
+    private DiskTestRepositoryCollection Collection => new(MongoDbServiceFactory, DatabaseContext);
+
+    private List<(string FunctionName, Operation Operation)> RecordCalls()
+    {
+        var calls = new List<(string, Operation)>();
+        MongoDbServiceFactory.CallStartEvent += (_, e) => calls.Add((e.FunctionName, e.Operation));
+        return calls;
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task DeleteOneAsync_ReportsItsOwnName()
+    {
+        // Regression: this overload reported nameof(UpdateOneAsync), so every delete showed up in the
+        // monitor as an update. The Operation enum was always correct — only the label was wrong.
+        var sut = Collection;
+        await sut.AddAsync(TestEntityFactory.CreateTestEntity());
+        var calls = RecordCalls();
+
+        await sut.DeleteOneAsync(x => true);
+
+        calls.Should().Contain(x => x.FunctionName == nameof(DiskTestRepositoryCollection.DeleteOneAsync));
+        calls.Should().NotContain(x => x.FunctionName == nameof(DiskTestRepositoryCollection.UpdateOneAsync));
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task DeleteOneAsync_ById_ReportsItsOwnName()
+    {
+        var sut = Collection;
+        var entity = TestEntityFactory.CreateTestEntity();
+        await sut.AddAsync(entity);
+        var calls = RecordCalls();
+
+        await sut.DeleteOneAsync(entity.Id);
+
+        calls.Should().Contain(x => x.FunctionName == nameof(DiskTestRepositoryCollection.DeleteOneAsync));
+        calls.Should().NotContain(x => x.FunctionName == nameof(DiskTestRepositoryCollection.UpdateOneAsync));
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task DeleteOneAsync_ReportsTheDeleteOperation()
+    {
+        var sut = Collection;
+        await sut.AddAsync(TestEntityFactory.CreateTestEntity());
+        var calls = RecordCalls();
+
+        await sut.DeleteOneAsync(x => true);
+
+        calls.Should().Contain(x => x.Operation == Operation.Delete);
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task UpdateOneAsync_StillReportsUpdate()
+    {
+        // The other user of nameof(UpdateOneAsync) is the genuine one — guards against the fix
+        // being applied to the wrong call site.
+        var sut = Collection;
+        var entity = TestEntityFactory.CreateTestEntity();
+        await sut.AddAsync(entity);
+        var calls = RecordCalls();
+
+        await sut.UpdateOneAsync(entity.Id, Builders<TestEntity>.Update.Set(x => x.Value, "changed"));
+
+        calls.Should().Contain(x => x.FunctionName == nameof(DiskTestRepositoryCollection.UpdateOneAsync) && x.Operation == Operation.Update);
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task DeleteManyAsync_ReportsItsOwnName()
+    {
+        var sut = Collection;
+        await sut.AddAsync(TestEntityFactory.CreateTestEntity());
+        var calls = RecordCalls();
+
+        await sut.DeleteManyAsync(x => true);
+
+        calls.Should().Contain(x => x.FunctionName == nameof(DiskTestRepositoryCollection.DeleteManyAsync) && x.Operation == Operation.Delete);
+    }
+}

--- a/Tharga.MongoDB/Disk/DiskRepositoryCollectionBase.cs
+++ b/Tharga.MongoDB/Disk/DiskRepositoryCollectionBase.cs
@@ -1120,7 +1120,7 @@ public abstract class DiskRepositoryCollectionBase<TEntity, TKey> : RepositoryCo
     {
         if (filter == null) throw new ArgumentNullException(nameof(filter));
 
-        return await ExecuteAsync(nameof(UpdateOneAsync), async (collection, sess, ct) =>
+        return await ExecuteAsync(nameof(DeleteOneAsync), async (collection, sess, ct) =>
         {
             var sort = options?.Sort;
             var findFluent = collection.FindMaybe(sess, filter).Sort(sort).Limit(2);


### PR DESCRIPTION
`DeleteOneAsync(FilterDefinition<TEntity>, …)` passed `nameof(UpdateOneAsync)` as its function name, so every delete has been reported as an update. The other two `DeleteOneAsync` overloads delegate to this one, so all three were affected.

`Operation.Delete` was always passed correctly, so nothing was misclassified — only the label was wrong. Found during the lockable coverage audit for #137 and deliberately deferred out of that PR, since it changes what the monitor shows for every delete.

## Impact

The function name is a display and grouping key. No production code switches on the string, but `DatabaseMonitor` aggregates call statistics by it — so deletes have been silently merged into `UpdateOneAsync` in those stats, and will now aggregate separately. It also surfaces in the call history, the Blazor admin call views and the MCP call surfaces.

Historical `_monitor` data still holds deletes recorded as `UpdateOneAsync`, so aggregated history will show a split at the upgrade boundary. Nothing needs migrating.

## Tests

`OperationLabellingTests`, five tests covering the delete overloads by filter and by id, the reported `Operation` enum, `DeleteManyAsync`, and one that pins the *legitimate* `nameof(UpdateOneAsync)` call site still reporting `UpdateOneAsync` — a guard against the fix being applied to the wrong one.

Verified non-vacuous: reverting the one-word change makes `DeleteOneAsync_ReportsItsOwnName` and `DeleteOneAsync_ById_ReportsItsOwnName` fail, and they pass again once restored.

Also refreshes a comment in `LockableInterceptionCoverageTests` that documented this bug as outstanding.

## Verification

Build clean (0 warnings). 692 passed / 8 skipped, rebased onto master after #137. The 5 failures are the pre-existing environmental `TransactionsTests` that need a replica set.

## Related

A second instance of the same shape exists and is **not** fixed here: `TryAddAsync` passes `nameof(AddAsync)`. Both are single-document inserts under `Operation.Create`, so nothing is misclassified — two similar operations are merely conflated under one label. That reads as plausibly deliberate grouping rather than a slip, so it is filed as a follow-up rather than swept in.
