### PR TITLE
fix: TryAddAsync reported itself as AddAsync

### DIFF
--- a/Tharga.MongoDB.Tests/OperationLabellingTests.cs
+++ b/Tharga.MongoDB.Tests/OperationLabellingTests.cs
@@ -89,6 +89,35 @@ public class OperationLabellingTests : MongoDbTestBase
 
     [Fact]
     [Trait("Category", "Database")]
+    public async Task TryAddAsync_ReportsItsOwnName()
+    {
+        // Reported nameof(AddAsync). Both insert one document under Operation.Create, so nothing was
+        // misclassified — but they differ in a way monitoring cares about: AddAsync throws on a
+        // duplicate, TryAddAsync returns false. Conflating them hid rejected inserts inside the
+        // successful-add statistics.
+        var sut = Collection;
+        var calls = RecordCalls();
+
+        await sut.TryAddAsync(TestEntityFactory.CreateTestEntity());
+
+        calls.Should().Contain(x => x.FunctionName == nameof(DiskTestRepositoryCollection.TryAddAsync) && x.Operation == Operation.Create);
+        calls.Should().NotContain(x => x.FunctionName == nameof(DiskTestRepositoryCollection.AddAsync));
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
+    public async Task AddAsync_StillReportsAdd()
+    {
+        var sut = Collection;
+        var calls = RecordCalls();
+
+        await sut.AddAsync(TestEntityFactory.CreateTestEntity());
+
+        calls.Should().Contain(x => x.FunctionName == nameof(DiskTestRepositoryCollection.AddAsync) && x.Operation == Operation.Create);
+    }
+
+    [Fact]
+    [Trait("Category", "Database")]
     public async Task DeleteManyAsync_ReportsItsOwnName()
     {
         var sut = Collection;

--- a/Tharga.MongoDB/Disk/DiskRepositoryCollectionBase.cs
+++ b/Tharga.MongoDB/Disk/DiskRepositoryCollectionBase.cs
@@ -919,7 +919,7 @@ public abstract class DiskRepositoryCollectionBase<TEntity, TKey> : RepositoryCo
 
     public override async Task<bool> TryAddAsync(TEntity entity, IClientSessionHandle session = null)
     {
-        return await ExecuteAsync(nameof(AddAsync), async (collection, sess, ct) =>
+        return await ExecuteAsync(nameof(TryAddAsync), async (collection, sess, ct) =>
         {
             try
             {


### PR DESCRIPTION
`TryAddAsync` passed `nameof(AddAsync)` as its function name, so it reported as `AddAsync` in the monitor, call history and MCP call surfaces. Sibling of the `DeleteOneAsync` mislabel fixed in #138, and noted there as deferred pending a judgement call.

## Why this is a slip, not deliberate grouping

It was worth checking, because unlike the delete case nothing here is *misclassified* — both are single-document inserts under `Operation.Create`.

Three things point at a copy-paste slip:

- Every other operation in the file self-labels with its own name. The only other apparent deviation, `ReplaceOneWithCheckAsync`, does label itself — it just happens to be the private method the public `ReplaceOneAsync` overloads delegate to.
- The two methods differ in a way monitoring cares about: `AddAsync` throws on a duplicate key, `TryAddAsync` swallows `MongoWriteException` and returns `false`. Conflating them hides rejected inserts inside the successful-add statistics.
- `DatabaseMonitor` aggregates call statistics by function name, so the two were being summed into one row with no way to separate them.

## Impact

Same shape as #138: the function name is a display and grouping key, and no production code switches on the string. `TryAddAsync` calls will now aggregate separately from `AddAsync`. Historical `_monitor` data still holds them merged, so aggregated history shows a split at the upgrade boundary. Nothing needs migrating.

## Tests

Two added to `OperationLabellingTests`: one asserting `TryAddAsync` reports its own name and `Operation.Create`, and one pinning that `AddAsync` still reports `AddAsync` — the same guard pattern used in #138 against fixing the wrong call site.

Verified non-vacuous: reverting the one-word change makes `TryAddAsync_ReportsItsOwnName` fail, and it passes again once restored.

## Verification

Build clean (0 warnings). 694 passed / 8 skipped. The 5 failures are the pre-existing environmental `TransactionsTests` that need a replica set.

With this, every `ExecuteAsync(nameof(...))` call site in `DiskRepositoryCollectionBase` reports its own enclosing method.
