### PR TITLE
chore(deps): tier 3 cascade — consume tiers 0-2, MongoDB.Driver 3.11.0

### DIFF
--- a/Sample/ConsoleSample/ConsoleSample.csproj
+++ b/Sample/ConsoleSample/ConsoleSample.csproj
@@ -14,8 +14,8 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
-    <PackageReference Include="Tharga.Console" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
+    <PackageReference Include="Tharga.Console" Version="4.2.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Tharga.MongoDB\Tharga.MongoDB.csproj" />

--- a/Sample/SimpleConsoleDemo/SimpleConsoleDemo.csproj
+++ b/Sample/SimpleConsoleDemo/SimpleConsoleDemo.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sample/Tharga.TemplateBlazor.Web.Client/Tharga.TemplateBlazor.Web.Client.csproj
+++ b/Sample/Tharga.TemplateBlazor.Web.Client/Tharga.TemplateBlazor.Web.Client.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sample/Tharga.TemplateBlazor.Web/Tharga.TemplateBlazor.Web.csproj
+++ b/Sample/Tharga.TemplateBlazor.Web/Tharga.TemplateBlazor.Web.csproj
@@ -11,7 +11,7 @@
     <ProjectReference Include="..\Tharga.TemplateBlazor.Web.Client\Tharga.TemplateBlazor.Web.Client.csproj" />
     <ProjectReference Include="..\..\Tharga.MongoDB.Monitor.Server\Tharga.MongoDB.Monitor.Server.csproj" />
     <ProjectReference Include="..\..\Tharga.MongoDB.Mcp\Tharga.MongoDB.Mcp.csproj" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.11" />
   </ItemGroup>
 
 </Project>

--- a/Tharga.MongoDB.Blazor/Tharga.MongoDB.Blazor.csproj
+++ b/Tharga.MongoDB.Blazor/Tharga.MongoDB.Blazor.csproj
@@ -36,7 +36,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Tharga.Blazor" Version="2.2.3" />
+    <PackageReference Include="Tharga.Blazor" Version="2.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tharga.MongoDB\Tharga.MongoDB.csproj" />

--- a/Tharga.MongoDB.Mcp/Tharga.MongoDB.Mcp.csproj
+++ b/Tharga.MongoDB.Mcp/Tharga.MongoDB.Mcp.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Tharga.Mcp" Version="1.0.0" />
+    <PackageReference Include="Tharga.Mcp" Version="1.1.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tharga.MongoDB.Monitor.Client/Tharga.MongoDB.Monitor.Client.csproj
+++ b/Tharga.MongoDB.Monitor.Client/Tharga.MongoDB.Monitor.Client.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Tharga.Communication" Version="1.0.0" />
+    <PackageReference Include="Tharga.Communication" Version="1.0.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tharga.MongoDB.Monitor.Server/Tharga.MongoDB.Monitor.Server.csproj
+++ b/Tharga.MongoDB.Monitor.Server/Tharga.MongoDB.Monitor.Server.csproj
@@ -42,7 +42,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Tharga.Communication" Version="1.0.0" />
+    <PackageReference Include="Tharga.Communication" Version="1.0.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tharga.MongoDB.Tests/Tharga.MongoDB.Tests.csproj
+++ b/Tharga.MongoDB.Tests/Tharga.MongoDB.Tests.csproj
@@ -11,10 +11,10 @@
 		<PackageReference Include="AutoBogus" Version="2.13.1" />
 		<PackageReference Include="FluentAssertions" Version="8.10.0" />
 		<PackageReference Include="JetBrains.Annotations" Version="2026.2.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
-		<PackageReference Include="Moq.AutoMock" Version="4.0.2" />
-		<PackageReference Include="Tharga.Test.Toolkit" Version="1.14.12" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+		<PackageReference Include="Moq.AutoMock" Version="4.0.3" />
+		<PackageReference Include="Tharga.Test.Toolkit" Version="1.14.14" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tharga.MongoDB/Tharga.MongoDB.csproj
+++ b/Tharga.MongoDB/Tharga.MongoDB.csproj
@@ -42,23 +42,23 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
     <!-- Enables the opt-in AddMongoDb() health-check helper (needs IHealthChecksBuilder). Small, framework-shared; its transitive deps (Logging.Abstractions, Options, Hosting.Abstractions) are already present. -->
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Features" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.10" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301">
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Features" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.11" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MongoDB.Driver" Version="3.10.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.11.0" />
     <!-- Floors transitive SharpCompress 0.30.1 (from MongoDB.Driver) above CVE-2026-44788 / GHSA-6c8g-7p36-r338 (zip-slip; affected <= 0.47.4). Do not drop until MongoDB.Driver itself ships SharpCompress >= 1.0.0. -->
     <PackageReference Include="SharpCompress" Version="1.0.0" />
     <!-- Floors transitive Snappier 1.0.0 (from MongoDB.Driver) above CVE / GHSA-pggp-6c3x-2xmx (infinite-loop on malformed framed Snappy; affected <= 1.3.0). Do not drop until MongoDB.Driver itself ships Snappier >= 1.3.1. -->
     <PackageReference Include="Snappier" Version="1.3.1" />
-    <PackageReference Include="Tharga.Runtime" Version="1.0.0" />
+    <PackageReference Include="Tharga.Runtime" Version="1.0.1" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
**Tier 3** of the cascade update — the tier with the widest fan-out, since everything at tier 4 sits on this.

## Internal — consuming tiers 0-2

| Package | From | To |
|---|---|---|
| `Tharga.Runtime` | 1.0.0 | **1.0.1** |
| `Tharga.Communication` | 1.0.0 | **1.0.1** (Monitor.Client + Monitor.Server) |
| `Tharga.Mcp` | 1.0.0 | **1.1.0** |
| `Tharga.Blazor` | 2.2.3 | **2.3.0** |
| `Tharga.Test.Toolkit` | 1.14.12 | **1.14.14** |
| `Tharga.Console` | 4.2.0 | **4.2.1** (ConsoleSample) |

All verified by an actual `dotnet restore`, not just a flatcontainer listing.

Two of these carry more than a patch: **`Tharga.Mcp` 1.1.0** brings MCP SDK `ModelContextProtocol` 2.2.0 (stateless HTTP transport by default), and **`Tharga.Blazor` 2.3.0** brings **Radzen.Blazor 11.x**, a major. Both are deliberate and both are why those packages shipped as minors.

## External

**Library** (`Tharga.MongoDB`)
- `MongoDB.Driver` 3.10.0 → **3.11.0**
- `Microsoft.Extensions.Configuration.Binder`, `.DependencyInjection.Abstractions`, `.Diagnostics.HealthChecks`, `.Features`, `.Hosting.Abstractions`, `.Http` — 10.0.10 → 10.0.11
- `Microsoft.SourceLink.GitHub` 10.0.301 → 10.0.400

**The two CVE floors were deliberately left alone.** `SharpCompress` 1.0.0 and `Snappier` 1.3.1 are pinned above transitive versions carrying GHSA-6c8g-7p36-r338 (zip-slip) and GHSA-pggp-6c3x-2xmx (infinite loop on malformed framed Snappy). Their comments say not to drop them until `MongoDB.Driver` itself ships those floors, and the driver bump does not change that instruction — so both stay exactly as they were. `System.Linq.Async` 7.0.1 is current.

**Test tooling and samples** (do not ship): `Microsoft.NET.Test.Sdk` 18.9.0, `Mvc.Testing` 10.0.11, `Moq.AutoMock` 4.0.3, `Microsoft.Extensions.Hosting` 10.0.11, `Components.WebAssembly` + `.Server` 10.0.11.

## Verification — read this, the suite is not green

`dotnet build -c Release --no-incremental` — **0 warnings, 0 errors**.

`dotnet test -c Release` — **714 passed, 8 skipped, 6 failed** of 728.

**The failures are pre-existing and environmental, and I verified that rather than assuming it.** Method: stashed the dependency changes, rebuilt at master, and ran the same filtered set. Result was *identical* — same five failures, same 26 passed / 31 total. So `MongoDB.Driver` 3.11.0 introduces no regression here.

The failures are two separate pre-existing problems:

1. **Five deterministic:** all of `Lockable.TransactionsTests`, every one throwing `System.NotSupportedException: Standalone servers do not support transactions.` These need a **replica-set** MongoDB; a standalone local instance cannot run transactions at all. Nothing to do with this change.

2. **A flaky lock-expiry pair:** `Lockable.PickTests.PickEntityWithExpiredLock` and `Lockable.GetLockedTests.GetLockedExpired` swap in and out between runs — three consecutive full runs gave 5, 5, then 6 failures. The message names the cause: `LockException : Entity … is locked by 'first actor' for **-00:00:00.0008418**` — a *negative* remaining lock time, so the lock had expired by 0.8 ms and the check still treated it as held. Filed as a new Important/Easy backlog item; not fixed here, since this is a dependency PR.

If CI is green on this PR, that is the stronger signal — it says the failures are specific to a standalone local MongoDB.

## Untouched

`Tharga.MongoDB.Tests/IngestThroughputTests.cs` is an untracked EP-4320 exploratory benchmark in the working tree and is **not part of this PR**. It compiles into local test runs but was never staged.

No source changes, no public API change, no `MAJOR_MINOR` bump (stays 2.14).
