### PR TITLE
chore(deps): finish the SourceLink 10.0.400 bump across all packable projects

### DIFF
--- a/Tharga.MongoDB.Mcp/Tharga.MongoDB.Mcp.csproj
+++ b/Tharga.MongoDB.Mcp/Tharga.MongoDB.Mcp.csproj
@@ -42,7 +42,7 @@
 
   <ItemGroup>
     <PackageReference Include="Tharga.Mcp" Version="1.1.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tharga.MongoDB.Monitor.Client/Tharga.MongoDB.Monitor.Client.csproj
+++ b/Tharga.MongoDB.Monitor.Client/Tharga.MongoDB.Monitor.Client.csproj
@@ -42,7 +42,7 @@
 
   <ItemGroup>
     <PackageReference Include="Tharga.Communication" Version="1.0.1" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tharga.MongoDB.Monitor.Server/Tharga.MongoDB.Monitor.Server.csproj
+++ b/Tharga.MongoDB.Monitor.Server/Tharga.MongoDB.Monitor.Server.csproj
@@ -43,7 +43,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Tharga.Communication" Version="1.0.1" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Follow-up to [#143](https://github.com/Tharga/MongoDB/pull/143). That PR bumped `Microsoft.SourceLink.GitHub` 10.0.301 → 10.0.400 in `Tharga.MongoDB` but **missed the same reference in three sibling packages**:

- `Tharga.MongoDB.Mcp`
- `Tharga.MongoDB.Monitor.Client`
- `Tharga.MongoDB.Monitor.Server`

All three were left at 10.0.301. This brings them in line, so every packable project in the repo now stamps SourceLink identically.

## How it was missed

The tier 3 bump list came from the cross-repo External Package Status report, which aggregates **per sub-repo** and lists each package once:

```
| 3 | MongoDB | ... Microsoft.SourceLink.GitHub 10.0.301 → 10.0.400 ... |
```

That single row was four separate `PackageReference` entries in four `.csproj` files. The report says *which* packages are behind, not *how many projects* hold them, so one row read as one edit. Caught by re-running the report after the cascade and noticing MongoDB was the only repo with anything left in the library table.

## Impact

Low, and build-time only. SourceLink carries `PrivateAssets=all`, so it never reaches consumers and no published dependency graph changes. The practical effect is that source-stepping metadata for `Tharga.MongoDB.Mcp` and the two Monitor packages was being generated by an older SourceLink than the core package.

## Verification

`dotnet build -c Release --no-incremental` — **0 warnings, 0 errors**.

No test run: SourceLink is build-only, so the build is the meaningful check. (The repo's suite also carries known pre-existing failures — five `TransactionsTests` needing a replica-set MongoDB, plus a flaky lock-expiry pair — documented in #143 and the backlog.)

No source changes, no public API change, no `MAJOR_MINOR` bump.
