### PR TITLE
chore: drop the consumer-project reference

### DIFF
--- a/.claude/mission.md
+++ b/.claude/mission.md
@@ -11,4 +11,3 @@ MongoDB repository library with monitoring, Blazor UI, and Communication integra
 - **Plan directory**: `$DOC_ROOT/Tharga/plans/Toolkit/MongoDB`
 - **Backlog**: `$DOC_ROOT/Tharga/Toolkit/MongoDB.md`
 - **Incoming requests**: `$DOC_ROOT/Tharga/Requests.md` — check for pending requests for this project on startup
-- **Eplicta requests**: `$DEV_ROOT/Eplicta/plan/requests.md` — check for requests from Eplicta on startup


### PR DESCRIPTION
Documentation-only cleanup of `.claude/mission.md`. No code, no packages, no CI logic.

Part of an ecosystem-wide pass across every Tharga project; the rules behind it now live in
`shared-instructions.md` → *Feature Requests (cross-project)* → **External consumers**.

## Two changes

**1. The requests path was a literal machine path.**

```diff
- **Incoming requests**: `c:\Users\danie\SynologyDrive\Documents\Notes\Tharga\Requests.md`
+ **Incoming requests**: `$DOC_ROOT/Tharga/Requests.md`
```

A hard-coded path resolves on exactly one machine and silently finds nothing everywhere else — and "silently finds nothing" is indistinguishable from "there was nothing pending". That failure mode is the reason this matters more than tidiness.

**2. Removed the reference to a consuming product's checkout.**

```diff
- **Eplicta requests**: `$DEV_ROOT/Eplicta/plan/requests.md` — check for requests from Eplicta on startup
```

A Tharga project should not know about a specific consuming product at all. Two problems with the line:

- It made this project's **startup depend on a checkout it has no claim to** — unresolvable on any machine that does not happen to have that product cloned at that exact path.
- It was a second inbound channel that only one consumer had, so their asks arrived by a route nobody else could use.

**The boundary now runs one way.** A consuming product raises a **GitHub issue on this repository** — that is the whole inbound channel. Outbound is a comment on that issue and nothing further: no follow-up entry, no adoption tracker, no writing into their files. Whoever asked tracks their own adoption; they have the issue and the release notes to do it from.

Nothing is lost by removing it: open GitHub issues are already a mandatory request source on every startup, independent of what `mission.md` lists.

## Note on merging

Merging this triggers the full CI pipeline, including `release`, because no repo filters by path — so it will publish a new patch version whose package content is identical to the current one. That is the only cost, and it is why this PR is left for you to merge rather than merged automatically.
