### PR TITLE
chore: cascade nuget sweep (tier 3) + release retry guard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,11 +211,29 @@ jobs:
           if [ -n "${{ steps.version.outputs.previous_tag }}" ]; then
             NOTES_FLAG="--notes-start-tag ${{ steps.version.outputs.previous_tag }}"
           fi
-          gh release create "${{ steps.version.outputs.version }}" \
-            --title "v${{ steps.version.outputs.version }}" \
-            --generate-notes \
-            $NOTES_FLAG \
-            ./artifacts/*.nupkg
+          # The package is already on nuget.org by this point, so a transient GitHub API failure here
+          # leaves a published package with no tag. The next build then recomputes the SAME version,
+          # pushes a duplicate that --skip-duplicate swallows silently, and the version after it never
+          # ships. Observed three times on 2026-08-17 during a GitHub incident (HTTP 503/504).
+          # Retry, and treat an already-created release as success so a re-run is safe.
+          for attempt in 1 2 3 4 5; do
+            if gh release create "${{ steps.version.outputs.version }}" \
+                 --title "v${{ steps.version.outputs.version }}" \
+                 --generate-notes \
+                 $NOTES_FLAG \
+                 ./artifacts/*.nupkg; then
+              echo "Release ${{ steps.version.outputs.version }} created."
+              exit 0
+            fi
+            if gh release view "${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+              echo "Release ${{ steps.version.outputs.version }} already exists - an earlier attempt succeeded."
+              exit 0
+            fi
+            echo "Attempt $attempt failed; retrying in 20s..."
+            sleep 20
+          done
+          echo "::error::Could not create the GitHub release for ${{ steps.version.outputs.version }} after 5 attempts. The package is most likely already on nuget.org, so the tag must be created by hand or the next release will silently republish this version: git tag ${{ steps.version.outputs.version }} <sha> && git push origin ${{ steps.version.outputs.version }}"
+          exit 1
 
       - name: Comment released version on merged PR
         if: always()
@@ -296,11 +314,26 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "${{ steps.version.outputs.version }}" \
-            --title "v${{ steps.version.outputs.version }} (pre-release)" \
-            --notes "Pre-release from \`${{ github.head_ref }}\` branch." \
-            --prerelease \
-            ./artifacts/*.nupkg
+          # Same reasoning as the release job: the pre-release package is pushed before this runs, so a
+          # transient API failure would leave it published with no tag to match.
+          for attempt in 1 2 3 4 5; do
+            if gh release create "${{ steps.version.outputs.version }}" \
+                 --title "v${{ steps.version.outputs.version }} (pre-release)" \
+                 --notes "Pre-release from \`${{ github.head_ref }}\` branch." \
+                 --prerelease \
+                 ./artifacts/*.nupkg; then
+              echo "Pre-release ${{ steps.version.outputs.version }} created."
+              exit 0
+            fi
+            if gh release view "${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+              echo "Pre-release ${{ steps.version.outputs.version }} already exists - an earlier attempt succeeded."
+              exit 0
+            fi
+            echo "Attempt $attempt failed; retrying in 20s..."
+            sleep 20
+          done
+          echo "::error::Could not create the GitHub pre-release for ${{ steps.version.outputs.version }} after 5 attempts."
+          exit 1
 
   docs:
     needs: release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  MAJOR_MINOR: '2.14'
+  MAJOR_MINOR: '2.15'
 
 permissions:
   contents: write

--- a/Sample/ConsoleSample/ConsoleSample.csproj
+++ b/Sample/ConsoleSample/ConsoleSample.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
-    <PackageReference Include="Tharga.Console" Version="4.2.1" />
+    <PackageReference Include="Tharga.Console" Version="4.2.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Tharga.MongoDB\Tharga.MongoDB.csproj" />

--- a/Tharga.MongoDB.Blazor/Tharga.MongoDB.Blazor.csproj
+++ b/Tharga.MongoDB.Blazor/Tharga.MongoDB.Blazor.csproj
@@ -36,7 +36,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Tharga.Blazor" Version="2.3.0" />
+    <PackageReference Include="Tharga.Blazor" Version="2.3.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tharga.MongoDB\Tharga.MongoDB.csproj" />

--- a/Tharga.MongoDB.Mcp/Tharga.MongoDB.Mcp.csproj
+++ b/Tharga.MongoDB.Mcp/Tharga.MongoDB.Mcp.csproj
@@ -41,8 +41,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Tharga.Mcp" Version="1.1.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301">
+    <PackageReference Include="Tharga.Mcp" Version="2.0.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tharga.MongoDB.Monitor.Client/Tharga.MongoDB.Monitor.Client.csproj
+++ b/Tharga.MongoDB.Monitor.Client/Tharga.MongoDB.Monitor.Client.csproj
@@ -41,8 +41,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Tharga.Communication" Version="1.0.1" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301">
+    <PackageReference Include="Tharga.Communication" Version="1.1.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tharga.MongoDB.Monitor.Server/Tharga.MongoDB.Monitor.Server.csproj
+++ b/Tharga.MongoDB.Monitor.Server/Tharga.MongoDB.Monitor.Server.csproj
@@ -42,8 +42,8 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Tharga.Communication" Version="1.0.1" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301">
+    <PackageReference Include="Tharga.Communication" Version="1.1.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tharga.MongoDB.Tests/AtlasMongoDbToolProviderTests.cs
+++ b/Tharga.MongoDB.Tests/AtlasMongoDbToolProviderTests.cs
@@ -24,7 +24,6 @@ public class AtlasMongoDbToolProviderTests
     {
         _contextMock = new Mock<IMcpContext>();
         _contextMock.Setup(c => c.Scope).Returns(McpScope.System);
-        _contextMock.Setup(c => c.IsDeveloper).Returns(true);
     }
 
     private static MongoDbApiAccess Access => new()

--- a/Tharga.MongoDB.Tests/McpProviderTests.cs
+++ b/Tharga.MongoDB.Tests/McpProviderTests.cs
@@ -23,7 +23,6 @@ public class McpProviderTests
         _monitorMock = new Mock<IDatabaseMonitor>();
         _contextMock = new Mock<IMcpContext>();
         _contextMock.Setup(c => c.Scope).Returns(McpScope.System);
-        _contextMock.Setup(c => c.IsDeveloper).Returns(true);
     }
 
     private MongoDbToolProvider CreateToolProvider(DataAccessLevel level = DataAccessLevel.DataReadWrite, ILiveMonitoringSubscription liveSubscription = null)

--- a/Tharga.MongoDB.Tests/Tharga.MongoDB.Tests.csproj
+++ b/Tharga.MongoDB.Tests/Tharga.MongoDB.Tests.csproj
@@ -14,7 +14,7 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
 		<PackageReference Include="Moq.AutoMock" Version="4.0.3" />
-		<PackageReference Include="Tharga.Test.Toolkit" Version="1.14.14" />
+		<PackageReference Include="Tharga.Test.Toolkit" Version="1.14.15" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tharga.MongoDB/Tharga.MongoDB.csproj
+++ b/Tharga.MongoDB/Tharga.MongoDB.csproj
@@ -58,7 +58,7 @@
     <PackageReference Include="SharpCompress" Version="1.0.0" />
     <!-- Floors transitive Snappier 1.0.0 (from MongoDB.Driver) above CVE / GHSA-pggp-6c3x-2xmx (infinite-loop on malformed framed Snappy; affected <= 1.3.0). Do not drop until MongoDB.Driver itself ships Snappier >= 1.3.1. -->
     <PackageReference Include="Snappier" Version="1.3.1" />
-    <PackageReference Include="Tharga.Runtime" Version="1.0.1" />
+    <PackageReference Include="Tharga.Runtime" Version="1.0.2" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Cascade sweep tier 3. Internal bumps to the versions published earlier in this sweep, plus external SourceLink 10.0.400 in the three siblings that still lagged.

Mcp 2.0.0 drops `IMcpContext.IsDeveloper`; no production code here read it (the providers gate on `Scope`), so only two dead Moq setups needed removing.

Also adds the release retry guard: the package is on nuget.org before `gh release create` runs, so a transient API failure strands a published version with no tag and the next build silently republishes it.

6 Lockable/Transactions tests fail - pre-existing, they need a live replica set, already filed as a backlog item.

Supersedes #144, which only carried the SourceLink bumps.